### PR TITLE
Wall mount touchups

### DIFF
--- a/code/datums/elements/wall_mount.dm
+++ b/code/datums/elements/wall_mount.dm
@@ -38,6 +38,6 @@
 		if(SOUTH)
 			real_target.plane = WALL_PLANE
 		if(EAST)
-			real_target.plane = WALL_PLANE
+			real_target.plane = OVER_FRILL_PLANE
 		if(WEST)
-			real_target.plane = WALL_PLANE
+			real_target.plane = OVER_FRILL_PLANE

--- a/code/game/objects/items/devices/radio/intercom.dm
+++ b/code/game/objects/items/devices/radio/intercom.dm
@@ -18,6 +18,7 @@
 	var/area/current_area = get_area(src)
 	if(!current_area)
 		return
+	AddElement(/datum/element/wall_mount)
 	RegisterSignal(current_area, COMSIG_AREA_POWER_CHANGE, .proc/AreaPowerCheck)
 	AddElement(/datum/element/wall_mount)
 


### PR DESCRIPTION
I'm doin two things here.
First is simple, intercoms needed the wallmount element and didn't have it.

Second is less so.

There's this annoying behavior with say, signs where they don't render "over" you when you walk under them, because they're on the wall plane, which is below the game plane.

I'm giving a shot to moving them to the over frill plane, which fixes that, and also issues where things mounted on the side of a wall overlap with the frill overlay poorly

Potentially addresses #74 #41 and #26