### PR TITLE
Elementizes plastic flap hitbox behavior into the Render over, Keep hitbox element! Applies to directional windows

### DIFF
--- a/code/datums/elements/ranged_attacks.dm
+++ b/code/datums/elements/ranged_attacks.dm
@@ -9,7 +9,7 @@
 /datum/element/ranged_attacks/Attach(atom/movable/target, casingtype, projectilesound, projectiletype)
 	. = ..()
 	if(!isbasicmob(target))
-		return COMPONENT_INCOMPATIBLE
+		return ELEMENT_INCOMPATIBLE
 
 	src.casingtype = casingtype
 	src.projectilesound = projectilesound

--- a/code/datums/elements/ranged_attacks.dm
+++ b/code/datums/elements/ranged_attacks.dm
@@ -9,7 +9,7 @@
 /datum/element/ranged_attacks/Attach(atom/movable/target, casingtype, projectilesound, projectiletype)
 	. = ..()
 	if(!isbasicmob(target))
-		return ELEMENT_INCOMPATIBLE
+		return COMPONENT_INCOMPATIBLE
 
 	src.casingtype = casingtype
 	src.projectilesound = projectilesound

--- a/code/datums/elements/render_over_keep_hitbox.dm
+++ b/code/datums/elements/render_over_keep_hitbox.dm
@@ -13,32 +13,35 @@
 	var/obj/structure/obj_target = target
 
 	RegisterSignal(obj_target, COMSIG_MOVABLE_Z_CHANGED, .proc/on_changed_z_level)
+	RegisterSignal(obj_target, COMSIG_ATOM_UPDATE_OVERLAYS, .proc/on_update_overlays)
 	obj_target.alpha = 0
-	gen_overlay(obj_target)
+	obj_target.update_overlays()
 
 /datum/element/render_over_keep_hitbox/Detach(obj/structure/target, ...)
-	UnregisterSignal(target, COMSIG_MOVABLE_Z_CHANGED)
+	UnregisterSignal(target, list(COMSIG_MOVABLE_Z_CHANGED, COMSIG_ATOM_UPDATE_OVERLAYS))
 	target.alpha = initial(target.alpha)
-	SSvis_overlays.remove_vis_overlay(target.managed_vis_overlays)
+	target.update_overlays()
 	return ..()
 
 /datum/element/render_over_keep_hitbox/proc/on_changed_z_level(obj/structure/target, turf/old_turf, turf/new_turf, same_z_layer)
 	SIGNAL_HANDLER
-	
+
 	if(same_z_layer)
 		return
-	SSvis_overlays.remove_vis_overlay(target.managed_vis_overlays)
-	gen_overlay(target)
+	target.update_overlays()
 
-/datum/element/render_over_keep_hitbox/proc/gen_overlay(obj/structure/target)
+/datum/element/render_over_keep_hitbox/proc/on_update_overlays(obj/structure/target, list/overlays)
+	SIGNAL_HANDLER
+
 	var/turf/our_turf = get_turf(target)
 	//you see mobs under it, but you hit them like they are above it
-	SSvis_overlays.add_vis_overlay(
-		target,
+
+	overlays += mutable_appearance(
 		target.icon,
 		target.icon_state,
 		ABOVE_MOB_LAYER,
+		null,
 		MUTATE_PLANE(GAME_PLANE, our_turf),
-		target.dir,
-		add_appearance_flags = RESET_ALPHA
+		initial(target.alpha),
+		RESET_ALPHA,
 	)

--- a/code/datums/elements/render_over_keep_hitbox.dm
+++ b/code/datums/elements/render_over_keep_hitbox.dm
@@ -8,7 +8,7 @@
 
 /datum/element/render_over_keep_hitbox/Attach(datum/target)
 	. = ..()
-	if(!istype(target, /obj/structure))
+	if(!isstructure(target))
 		return ELEMENT_INCOMPATIBLE
 	var/obj/structure/obj_target = target
 
@@ -20,14 +20,15 @@
 	UnregisterSignal(target, COMSIG_MOVABLE_Z_CHANGED)
 	target.alpha = initial(target.alpha)
 	SSvis_overlays.remove_vis_overlay(target.managed_vis_overlays)
-	. = ..()
+	return ..()
 
 /datum/element/render_over_keep_hitbox/proc/on_changed_z_level(obj/structure/target, turf/old_turf, turf/new_turf, same_z_layer)
+	SIGNAL_HANDLER
+	
 	if(same_z_layer)
 		return
 	SSvis_overlays.remove_vis_overlay(target.managed_vis_overlays)
 	gen_overlay(target)
-	return
 
 /datum/element/render_over_keep_hitbox/proc/gen_overlay(obj/structure/target)
 	var/turf/our_turf = get_turf(target)

--- a/code/datums/elements/render_over_keep_hitbox.dm
+++ b/code/datums/elements/render_over_keep_hitbox.dm
@@ -13,35 +13,32 @@
 	var/obj/structure/obj_target = target
 
 	RegisterSignal(obj_target, COMSIG_MOVABLE_Z_CHANGED, .proc/on_changed_z_level)
-	RegisterSignal(obj_target, COMSIG_ATOM_UPDATE_OVERLAYS, .proc/on_update_overlays)
 	obj_target.alpha = 0
-	obj_target.update_overlays()
+	gen_overlay(obj_target)
 
 /datum/element/render_over_keep_hitbox/Detach(obj/structure/target, ...)
-	UnregisterSignal(target, list(COMSIG_MOVABLE_Z_CHANGED, COMSIG_ATOM_UPDATE_OVERLAYS))
+	UnregisterSignal(target, COMSIG_MOVABLE_Z_CHANGED)
 	target.alpha = initial(target.alpha)
-	target.update_overlays()
+	SSvis_overlays.remove_vis_overlay(target.managed_vis_overlays)
 	return ..()
 
 /datum/element/render_over_keep_hitbox/proc/on_changed_z_level(obj/structure/target, turf/old_turf, turf/new_turf, same_z_layer)
 	SIGNAL_HANDLER
-
+	
 	if(same_z_layer)
 		return
-	target.update_overlays()
+	SSvis_overlays.remove_vis_overlay(target.managed_vis_overlays)
+	gen_overlay(target)
 
-/datum/element/render_over_keep_hitbox/proc/on_update_overlays(obj/structure/target, list/overlays)
-	SIGNAL_HANDLER
-
+/datum/element/render_over_keep_hitbox/proc/gen_overlay(obj/structure/target)
 	var/turf/our_turf = get_turf(target)
 	//you see mobs under it, but you hit them like they are above it
-
-	overlays += mutable_appearance(
+	SSvis_overlays.add_vis_overlay(
+		target,
 		target.icon,
 		target.icon_state,
 		ABOVE_MOB_LAYER,
-		null,
 		MUTATE_PLANE(GAME_PLANE, our_turf),
-		initial(target.alpha),
-		RESET_ALPHA,
+		target.dir,
+		add_appearance_flags = RESET_ALPHA
 	)

--- a/code/datums/elements/render_over_keep_hitbox.dm
+++ b/code/datums/elements/render_over_keep_hitbox.dm
@@ -1,0 +1,43 @@
+/**
+ * # Render over, Keep hitbox element!
+ *
+ * Non bespoke element (1 in existence) that makes structures render over mobs, but still allow you to attack the mob's hitbox!
+ * Used in plastic flaps, and directional windows!
+ */
+/datum/element/render_over_keep_hitbox
+
+/datum/element/render_over_keep_hitbox/Attach(datum/target)
+	. = ..()
+	if(!istype(target, /obj/structure))
+		return ELEMENT_INCOMPATIBLE
+	var/obj/structure/obj_target = target
+
+	RegisterSignal(obj_target, COMSIG_MOVABLE_Z_CHANGED, .proc/on_changed_z_level)
+	obj_target.alpha = 0
+	gen_overlay(obj_target)
+
+/datum/element/render_over_keep_hitbox/Detach(obj/structure/target, ...)
+	UnregisterSignal(target, COMSIG_MOVABLE_Z_CHANGED)
+	target.alpha = initial(target.alpha)
+	SSvis_overlays.remove_vis_overlay(target.managed_vis_overlays)
+	. = ..()
+
+/datum/element/render_over_keep_hitbox/proc/on_changed_z_level(obj/structure/target, turf/old_turf, turf/new_turf, same_z_layer)
+	if(same_z_layer)
+		return
+	SSvis_overlays.remove_vis_overlay(target.managed_vis_overlays)
+	gen_overlay(target)
+	return
+
+/datum/element/render_over_keep_hitbox/proc/gen_overlay(obj/structure/target)
+	var/turf/our_turf = get_turf(target)
+	//you see mobs under it, but you hit them like they are above it
+	SSvis_overlays.add_vis_overlay(
+		target,
+		target.icon,
+		target.icon_state,
+		ABOVE_MOB_LAYER,
+		MUTATE_PLANE(GAME_PLANE, our_turf),
+		target.dir,
+		add_appearance_flags = RESET_ALPHA
+	)

--- a/code/game/objects/structures/plasticflaps.dm
+++ b/code/game/objects/structures/plasticflaps.dm
@@ -14,8 +14,7 @@
 
 /obj/structure/plasticflaps/Initialize(mapload)
 	. = ..()
-	alpha = 0
-	gen_overlay()
+	AddElement(/datum/element/render_over_keep_hitbox)
 	air_update_turf(TRUE, TRUE) // wallening todo: why is this atmos logic here? should it be upstreamed?
 	if(mapload)
 		return INITIALIZE_HINT_LATELOAD
@@ -30,17 +29,6 @@
 	. = ..()
 	if (oldloc)
 		oldloc.air_update_turf(TRUE, FALSE)
-
-/obj/structure/plasticflaps/on_changed_z_level(turf/old_turf, turf/new_turf, same_z_layer, notify_contents)
-	if(same_z_layer)
-		return ..()
-	SSvis_overlays.remove_vis_overlay(managed_vis_overlays)
-	gen_overlay()
-	return ..()
-
-/obj/structure/plasticflaps/proc/gen_overlay()
-	var/turf/our_turf = get_turf(src)
-	SSvis_overlays.add_vis_overlay(src, icon, icon_state, ABOVE_MOB_LAYER, MUTATE_PLANE(GAME_PLANE, our_turf), dir, add_appearance_flags = RESET_ALPHA) //you see mobs under it, but you hit them like they are above it
 
 /obj/structure/plasticflaps/examine(mob/user)
 	. = ..()

--- a/code/game/objects/structures/windows/window.dm
+++ b/code/game/objects/structures/windows/window.dm
@@ -52,6 +52,8 @@
 		setDir()
 		update_icon_state()
 		AddElement(/datum/element/can_barricade)
+	else
+		AddElement(/datum/element/render_over_keep_hitbox)
 
 	//windows only block while reinforced and fulltile, so we'll use the proc
 	real_explosion_block = explosion_block

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -1058,6 +1058,7 @@
 #include "code\datums\elements\radiation_protected_clothing.dm"
 #include "code\datums\elements\radioactive.dm"
 #include "code\datums\elements\ranged_attacks.dm"
+#include "code\datums\elements\render_over_keep_hitbox.dm"
 #include "code\datums\elements\ridable.dm"
 #include "code\datums\elements\rust.dm"
 #include "code\datums\elements\selfknockback.dm"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Plastic flaps render over people, but you're still able to hit the person crawling under. This is exactly what directional windows need to act properly, so I've elementized the behavior and applied to both!

NOTE: Plastic flap code does pic related, and so this element brings that visual error with it. But it's still worth!
![image](https://user-images.githubusercontent.com/40974010/193427159-605d71ea-cb1e-4c3f-98f2-1e4d1e1e2e92.png)

## Why It's Good For The Game

Fixes #110 

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: Directional windows now properly render over you
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
