### PR TITLE
Pubby arrivals shuttle hotfix

### DIFF
--- a/_maps/demo_map/PubbyStation.dmm
+++ b/_maps/demo_map/PubbyStation.dmm
@@ -15229,7 +15229,7 @@
 	height = 13;
 	name = "pubby arrivals";
 	roundstart_template = /datum/map_template/shuttle/arrival/pubby;
-	shuttle_id = "arrivals_stationary";
+	shuttle_id = "arrival_stationary";
 	width = 6
 	},
 /turf/open/space/basic,


### PR DESCRIPTION
## About The Pull Request
As reported by Twaticus, the arrivals shuttle fails to function normally and spams the chat with errors. 
![spam](https://user-images.githubusercontent.com/105393050/194506749-b08bb474-bb0d-4f23-b2f1-09c8889c279f.png)
With the removal of a single letter in the docking_port, the shuttle now operates normally and without chat spam.
## Changelog
:cl:
fix: Fixed Pubby's arrival shuttle failing to operate
/:cl:
