### PR TITLE
Brings Telescreens up to Parity with Lights

### DIFF
--- a/_maps/demo_map/PubbyStation.dmm
+++ b/_maps/demo_map/PubbyStation.dmm
@@ -6035,14 +6035,12 @@
 	c_tag = "Dormitories Fore"
 	},
 /obj/machinery/light/directional/north,
-/obj/machinery/computer/security/telescreen{
-	desc = "Used for watching the monastery.";
-	name = "Monastery Monitor";
-	network = list("monastery");
-	pixel_y = 32
-	},
 /obj/effect/turf_decal/tile/blue{
 	dir = 1
+	},
+/obj/machinery/computer/security/telescreen/directional/north{
+	name = "Monastery Monitor";
+	network = list("monastery")
 	},
 /turf/open/floor/iron,
 /area/station/commons/dorms)
@@ -7824,11 +7822,9 @@
 /area/station/command/heads_quarters/hop)
 "aBC" = (
 /obj/structure/closet/secure_closet/hop,
-/obj/machinery/computer/security/telescreen{
-	desc = "Used for watching the monastery.";
+/obj/machinery/computer/security/telescreen/directional/north{
 	name = "Monastery Monitor";
-	network = list("monastery");
-	pixel_y = 32
+	network = list("monastery")
 	},
 /turf/open/floor/wood,
 /area/station/command/heads_quarters/hop)
@@ -18291,17 +18287,13 @@
 /turf/open/floor/iron/white,
 /area/station/medical/pharmacy)
 "buk" = (
-/obj/machinery/computer/security/telescreen{
-	desc = "Used for monitoring medbay to ensure patient safety.";
-	dir = 1;
-	name = "Medbay Monitor";
-	network = list("medbay");
-	pixel_y = -30
-	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 1
 	},
 /obj/effect/turf_decal/tile/red/half/contrasted,
+/obj/machinery/computer/security/telescreen/cmo/directional/south{
+	name = "Medbay Telescreen"
+	},
 /turf/open/floor/iron,
 /area/station/security/checkpoint/medical)
 "bul" = (
@@ -19729,15 +19721,12 @@
 /area/station/hallway/secondary/entry)
 "bzB" = (
 /obj/effect/turf_decal/stripes/line,
-/obj/machinery/computer/security/telescreen{
-	desc = "Used for watching the monastery.";
-	dir = 8;
-	name = "Monastery Monitor";
-	network = list("monastery");
-	pixel_x = 28
-	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 1
+	},
+/obj/machinery/computer/security/telescreen/directional/east{
+	network = list("monastery");
+	name = "Monastery Monitor"
 	},
 /turf/open/floor/iron/dark,
 /area/station/hallway/secondary/entry)
@@ -21817,14 +21806,6 @@
 /turf/open/floor/engine,
 /area/station/science/ordnance/burnchamber)
 "bIN" = (
-/obj/machinery/computer/security/telescreen{
-	desc = "Used for watching the test chamber.";
-	dir = 4;
-	layer = 4;
-	name = "Test Chamber Telescreen";
-	network = list("ordnance");
-	pixel_x = -32
-	},
 /obj/structure/table,
 /obj/item/computer_hardware/hard_drive/portable,
 /obj/item/computer_hardware/hard_drive/portable,
@@ -21836,6 +21817,7 @@
 /obj/item/computer_hardware/hard_drive/portable,
 /obj/item/computer_hardware/hard_drive/portable,
 /obj/effect/turf_decal/tile/purple/half/contrasted,
+/obj/machinery/computer/security/telescreen/ordnance/directional/west,
 /turf/open/floor/iron,
 /area/station/science/ordnance/testlab)
 "bIP" = (
@@ -24692,16 +24674,10 @@
 	layer = 2.9
 	},
 /obj/structure/cable,
-/obj/machinery/computer/security/telescreen{
-	desc = "Used for watching the engine containment area.";
-	dir = 4;
-	name = "Engine Monitor";
-	network = list("engine");
-	pixel_x = -32
-	},
 /obj/effect/turf_decal/tile/red/half/contrasted{
 	dir = 8
 	},
+/obj/machinery/computer/security/telescreen/engine/directional/west,
 /turf/open/floor/iron,
 /area/station/security/checkpoint/engineering)
 "bUW" = (
@@ -26639,17 +26615,14 @@
 /turf/open/floor/plating,
 /area/station/engineering/transit_tube)
 "ceU" = (
-/obj/machinery/computer/security/telescreen{
-	desc = "Used for watching telecomms.";
-	layer = 4;
-	name = "Telecomms Telescreen";
-	network = list("tcomms");
-	pixel_y = 28
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
 /obj/structure/cable,
+/obj/machinery/computer/security/telescreen/directional/north{
+	network = list("tcomms");
+	name = "Telecomms Telescreen"
+	},
 /turf/open/floor/iron/dark,
 /area/station/engineering/transit_tube)
 "ceV" = (
@@ -35201,17 +35174,11 @@
 /turf/open/floor/iron/dark,
 /area/station/engineering/engine_smes)
 "hnV" = (
-/obj/machinery/computer/security/telescreen{
-	desc = "Used for watching the turbine vent.";
-	dir = 4;
-	name = "turbine vent monitor";
-	network = list("turbine");
-	pixel_x = -29
-	},
 /obj/structure/closet/radiation,
 /obj/effect/turf_decal/tile/yellow/half/contrasted{
 	dir = 8
 	},
+/obj/machinery/computer/security/telescreen/turbine/directional/west,
 /turf/open/floor/iron/dark,
 /area/station/maintenance/disposal/incinerator)
 "hnY" = (
@@ -41647,13 +41614,17 @@
 /turf/open/floor/plating,
 /area/station/maintenance/department/engine)
 "nIm" = (
-/obj/machinery/computer/security/telescreen{
-	dir = 8;
-	name = "Test Chamber Monitor";
-	network = list("xeno");
-	pixel_y = 2
-	},
 /obj/structure/table/reinforced,
+/obj/machinery/button/door{
+	id = "misclab";
+	name = "Test Chamber Blast Doors";
+	pixel_y = -2;
+	req_access = list("xenobiology")
+	},
+/obj/machinery/button/ignition{
+	id = "xenoigniter";
+	pixel_y = 7
+	},
 /turf/open/floor/iron,
 /area/station/science/xenobiology)
 "nIt" = (
@@ -42770,18 +42741,8 @@
 /turf/open/floor/plating,
 /area/station/engineering/supermatter)
 "oEW" = (
-/obj/machinery/button/door{
-	id = "misclab";
-	name = "Test Chamber Blast Doors";
-	pixel_y = -2;
-	req_access = list("xenobiology")
-	},
 /obj/structure/table/reinforced,
 /obj/structure/window/reinforced,
-/obj/machinery/button/ignition{
-	id = "xenoigniter";
-	pixel_y = 7
-	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/general/visible,
 /turf/open/floor/iron,
 /area/station/science/xenobiology)
@@ -44018,7 +43979,10 @@
 /area/station/service/library/artgallery)
 "pIW" = (
 /obj/structure/closet/l3closet/scientist,
-/obj/structure/sign/warning/no_smoking/directional/north,
+/obj/machinery/computer/security/telescreen/directional/north{
+	name = "Test Chamber Monitor";
+	network = list("xeno")
+	},
 /turf/open/floor/iron/dark,
 /area/station/science/xenobiology)
 "pJc" = (
@@ -44405,6 +44369,13 @@
 /obj/machinery/door/firedoor,
 /turf/open/floor/iron,
 /area/station/hallway/primary/central/aft)
+"qbQ" = (
+/obj/machinery/power/shieldwallgen/xenobiologyaccess,
+/obj/structure/sign/warning/electric_shock/directional/east,
+/obj/structure/cable,
+/obj/structure/sign/warning/no_smoking/directional/north,
+/turf/open/floor/plating,
+/area/station/science/xenobiology)
 "qbZ" = (
 /obj/structure/rack,
 /obj/item/clothing/mask/gas,
@@ -49190,13 +49161,7 @@
 "uco" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/structure/cable,
-/obj/machinery/computer/security/telescreen{
-	desc = "Used for watching the engine containment area.";
-	dir = 1;
-	name = "Engine Monitor";
-	network = list("engine");
-	pixel_y = -32
-	},
+/obj/machinery/computer/security/telescreen/engine/directional/south,
 /turf/open/floor/iron,
 /area/station/engineering/main)
 "ucA" = (
@@ -105671,7 +105636,7 @@ xEI
 bbP
 aaa
 bkF
-dmT
+qbQ
 ltk
 nEb
 pWm

--- a/code/game/machinery/computer/camera.dm
+++ b/code/game/machinery/computer/camera.dm
@@ -253,6 +253,10 @@
 	circuit = null
 	light_power = 0
 
+/obj/machinery/computer/security/telescreen/Initialize(mapload)
+	. = ..()
+	AddElement(/datum/element/wall_mount)
+
 /obj/machinery/computer/security/telescreen/update_icon_state()
 	if(machine_stat & BROKEN)
 		icon_state += "b"
@@ -260,11 +264,13 @@
 		icon_state = initial(icon_state)
 	return ..()
 
+INVERT_MAPPING_DIRECTIONAL_HELPERS(/obj/machinery/computer/security/telescreen, 0)
+
 /obj/machinery/computer/security/telescreen/entertainment
 	name = "entertainment monitor"
 	desc = "Damn, they better have the /tg/ channel on these things."
 	icon = 'icons/obj/status_display.dmi'
-	icon_state = "entertainment_blank"
+	icon_state = "entertainment_blank" // wallening todo - Should this be merged back into telescreens or keep using status display icons? Icon needs updating regardless.
 	network = list()
 	density = FALSE
 	circuit = null
@@ -272,7 +278,7 @@
 	var/icon_state_off = "entertainment_blank"
 	var/icon_state_on = "entertainment"
 
-INVERT_MAPPING_DIRECTIONAL_HELPERS(/obj/machinery/computer/security/telescreen/entertainment, 32)
+INVERT_MAPPING_DIRECTIONAL_HELPERS(/obj/machinery/computer/security/telescreen/entertainment, 32) // Wallening todo: Depending on the comment on icon_state, adjust offset. Keep wall_mount element in mind.
 
 /obj/machinery/computer/security/telescreen/entertainment/Initialize(mapload)
 	. = ..()
@@ -368,69 +374,97 @@ INVERT_MAPPING_DIRECTIONAL_HELPERS(/obj/machinery/computer/security/telescreen/e
 	desc = "Used for watching the AI and the RD's goons from the safety of his office."
 	network = list("rd", "aicore", "aiupload", "minisat", "xeno", "test", "toxins")
 
+INVERT_MAPPING_DIRECTIONAL_HELPERS(/obj/machinery/computer/security/telescreen/rd, 0)
+
 /obj/machinery/computer/security/telescreen/research
 	name = "research telescreen"
 	desc = "A telescreen with access to the research division's camera network."
 	network = list("rd")
+
+INVERT_MAPPING_DIRECTIONAL_HELPERS(/obj/machinery/computer/security/telescreen/research, 0)
 
 /obj/machinery/computer/security/telescreen/ce
 	name = "\improper Chief Engineer's telescreen"
 	desc = "Used for watching the engine, telecommunications and the minisat."
 	network = list("engine", "singularity", "tcomms", "minisat")
 
+INVERT_MAPPING_DIRECTIONAL_HELPERS(/obj/machinery/computer/security/telescreen/ce, 0)
+
 /obj/machinery/computer/security/telescreen/cmo
 	name = "\improper Chief Medical Officer's telescreen"
 	desc = "A telescreen with access to the medbay's camera network."
 	network = list("medbay")
+
+INVERT_MAPPING_DIRECTIONAL_HELPERS(/obj/machinery/computer/security/telescreen/cmo, 0)
 
 /obj/machinery/computer/security/telescreen/vault
 	name = "vault monitor"
 	desc = "A telescreen that connects to the vault's camera network."
 	network = list("vault")
 
+INVERT_MAPPING_DIRECTIONAL_HELPERS(/obj/machinery/computer/security/telescreen/vault, 0)
+
 /obj/machinery/computer/security/telescreen/ordnance
 	name = "bomb test site monitor"
 	desc = "A telescreen that connects to the bomb test site's camera."
 	network = list("ordnance")
+
+INVERT_MAPPING_DIRECTIONAL_HELPERS(/obj/machinery/computer/security/telescreen/ordnance, 0)
 
 /obj/machinery/computer/security/telescreen/engine
 	name = "engine monitor"
 	desc = "A telescreen that connects to the engine's camera network."
 	network = list("engine")
 
+INVERT_MAPPING_DIRECTIONAL_HELPERS(/obj/machinery/computer/security/telescreen/engine, 0)
+
 /obj/machinery/computer/security/telescreen/turbine
 	name = "turbine monitor"
 	desc = "A telescreen that connects to the turbine's camera."
 	network = list("turbine")
+
+INVERT_MAPPING_DIRECTIONAL_HELPERS(/obj/machinery/computer/security/telescreen/turbine, 0)
 
 /obj/machinery/computer/security/telescreen/interrogation
 	name = "interrogation room monitor"
 	desc = "A telescreen that connects to the interrogation room's camera."
 	network = list("interrogation")
 
+INVERT_MAPPING_DIRECTIONAL_HELPERS(/obj/machinery/computer/security/telescreen/interrogation, 0)
+
 /obj/machinery/computer/security/telescreen/prison
 	name = "prison monitor"
 	desc = "A telescreen that connects to the permabrig's camera network."
 	network = list("prison")
+
+INVERT_MAPPING_DIRECTIONAL_HELPERS(/obj/machinery/computer/security/telescreen/prison, 0)
 
 /obj/machinery/computer/security/telescreen/auxbase
 	name = "auxiliary base monitor"
 	desc = "A telescreen that connects to the auxiliary base's camera."
 	network = list("auxbase")
 
+INVERT_MAPPING_DIRECTIONAL_HELPERS(/obj/machinery/computer/security/telescreen/auxbase, 0)
+
 /obj/machinery/computer/security/telescreen/minisat
 	name = "minisat monitor"
 	desc = "A telescreen that connects to the minisat's camera network."
 	network = list("minisat")
+
+INVERT_MAPPING_DIRECTIONAL_HELPERS(/obj/machinery/computer/security/telescreen/minisat, 0)
 
 /obj/machinery/computer/security/telescreen/aiupload
 	name = "\improper AI upload monitor"
 	desc = "A telescreen that connects to the AI upload's camera network."
 	network = list("aiupload")
 
+INVERT_MAPPING_DIRECTIONAL_HELPERS(/obj/machinery/computer/security/telescreen/aiupload, 0)
+
 /obj/machinery/computer/security/telescreen/bar
 	name = "bar monitor"
 	desc = "A telescreen that connects to the bar's camera network. Perfect for checking on customers."
 	network = list("bar")
+
+INVERT_MAPPING_DIRECTIONAL_HELPERS(/obj/machinery/computer/security/telescreen/bar, 0)
 
 #undef DEFAULT_MAP_SIZE


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Telescreens now have the wallmount element and directional helpers. Converts all the telescreens on pubbystation to this.
![image](https://user-images.githubusercontent.com/50649185/197631181-65b63b7c-fd3a-484f-9665-c38066c35bbe.png)
Note that this means telescreens now suffer from #125 for mappers, but a fix for that should be able to neatly slot in here as well.
Also implements a todo notice around the entertainment monitor as it's special.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Another scuffed wallmount knocked down.
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
code: Telescreens now rely on directional helpers and properly mount onto the wall.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->

## Additional Notes
- Pepperspray's offsets are still scuffed - going to take a look at that.
- Few non-directional helper uses of safes and fire axe cabinets and blahblah around, I'll look into that too.
- The xenobio test chamber monitor was moved to a north wall, taking the place of the former no smoking sign. Said sign now is on the opposite side of the window. Table-mounted buttons and whatnot still need massive cleanup, as do keycard authenticators.
- North-facing telescreens fall under #129 .
![image](https://user-images.githubusercontent.com/50649185/197631679-f9c34797-6051-41d4-bd75-c7e87d12ea97.png)
- Camera networks really need to be converted to defines and telescreens really need a quality pass, but that's out of scope for wallening.