### PR TITLE
Safes, Lightswitches, And Fire Axe Cabinets - The Paritying

### DIFF
--- a/_maps/demo_map/PubbyStation.dmm
+++ b/_maps/demo_map/PubbyStation.dmm
@@ -3065,14 +3065,7 @@
 	fax_name = "Head of Security's Office";
 	name = "Head of Security's Fax Machine"
 	},
-/turf/open/floor/iron/dark,
-/area/station/command/heads_quarters/hos)
-"akV" = (
-/obj/item/storage/secure/safe{
-	pixel_x = -22;
-	pixel_y = 32
-	},
-/obj/effect/turf_decal/tile/red/half/contrasted,
+/obj/item/storage/secure/safe/hos/directional/north,
 /turf/open/floor/iron/dark,
 /area/station/command/heads_quarters/hos)
 "akW" = (
@@ -7135,11 +7128,8 @@
 /turf/open/floor/carpet,
 /area/station/command/heads_quarters/captain)
 "azc" = (
-/obj/item/storage/secure/safe{
-	pixel_x = 35;
-	pixel_y = 5
-	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
+/obj/item/storage/secure/safe/directional/east,
 /turf/open/floor/carpet,
 /area/station/command/heads_quarters/captain)
 "azd" = (
@@ -7163,9 +7153,6 @@
 /turf/open/floor/grass,
 /area/station/medical/medbay/central)
 "azg" = (
-/obj/structure/fireaxecabinet{
-	pixel_y = -32
-	},
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 8
@@ -7173,6 +7160,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
 	},
+/obj/structure/fireaxecabinet/directional/south,
 /turf/open/floor/iron/dark,
 /area/station/command/bridge)
 "azh" = (
@@ -7184,10 +7172,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
 	},
-/obj/item/storage/secure/safe/caps_spare{
-	pixel_x = 6;
-	pixel_y = -28
-	},
+/obj/item/storage/secure/safe/caps_spare/directional/south,
 /turf/open/floor/iron/dark,
 /area/station/command/bridge)
 "azj" = (
@@ -7797,10 +7782,6 @@
 /turf/open/floor/iron/dark,
 /area/station/command/bridge)
 "aBz" = (
-/obj/item/storage/secure/safe{
-	pixel_x = -22;
-	pixel_y = 4
-	},
 /obj/structure/table/wood,
 /obj/item/paper_bin{
 	layer = 2.9
@@ -7808,6 +7789,7 @@
 /obj/item/pen{
 	layer = 4
 	},
+/obj/item/storage/secure/safe/directional/west,
 /turf/open/floor/wood,
 /area/station/command/heads_quarters/hop)
 "aBA" = (
@@ -15698,13 +15680,11 @@
 /obj/structure/table,
 /obj/item/stack/package_wrap,
 /obj/item/hand_labeler,
-/obj/item/storage/secure/safe{
-	pixel_x = -27
-	},
 /obj/item/radio/intercom/directional/south,
 /obj/effect/turf_decal/tile/brown/anticorner/contrasted{
 	dir = 8
 	},
+/obj/item/storage/secure/safe/directional/west,
 /turf/open/floor/iron,
 /area/station/commons/vacant_room/commissary)
 "biL" = (
@@ -25864,15 +25844,13 @@
 /area/space/nearstation)
 "bZT" = (
 /obj/structure/reagent_dispensers/watertank/high,
-/obj/structure/fireaxecabinet{
-	pixel_y = 32
-	},
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible{
 	dir = 4
 	},
 /obj/effect/turf_decal/tile/yellow/half/contrasted{
 	dir = 1
 	},
+/obj/structure/fireaxecabinet/directional/north,
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
 "bZU" = (
@@ -33005,9 +32983,6 @@
 /turf/open/floor/iron/white,
 /area/station/medical/chemistry)
 "fhM" = (
-/obj/item/storage/secure/safe{
-	pixel_x = -22
-	},
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 8
@@ -33015,6 +32990,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
 	},
+/obj/item/storage/secure/safe/directional/west,
 /turf/open/floor/iron/grimy,
 /area/station/security/detectives_office)
 "fih" = (
@@ -80942,7 +80918,7 @@ dAa
 abI
 ajs
 aka
-akV
+akX
 kNE
 amv
 alJ

--- a/code/game/machinery/lightswitch.dm
+++ b/code/game/machinery/lightswitch.dm
@@ -2,7 +2,7 @@
 /obj/machinery/light_switch
 	name = "light switch"
 	icon = 'icons/obj/power.dmi'
-	icon_state = "light-nopower"
+	icon_state = "light-p"
 	base_icon_state = "light"
 	desc = "Make dark."
 	power_channel = AREA_USAGE_LIGHT

--- a/code/game/objects/items/storage/secure.dm
+++ b/code/game/objects/items/storage/secure.dm
@@ -186,7 +186,7 @@
 	. = ..()
 	AddElement(/datum/element/wall_mount)
 
-MAPPING_DIRECTIONAL_HELPERS(/obj/item/storage/secure/safe, 32)
+INVERT_MAPPING_DIRECTIONAL_HELPERS(/obj/item/storage/secure/safe, 0)
 
 /obj/item/storage/secure/safe/Initialize(mapload)
 	. = ..()
@@ -208,6 +208,8 @@ MAPPING_DIRECTIONAL_HELPERS(/obj/item/storage/secure/safe, 32)
 /obj/item/storage/secure/safe/hos
 	name = "head of security's safe"
 
+INVERT_MAPPING_DIRECTIONAL_HELPERS(/obj/item/storage/secure/safe/hos, 0)
+
 /**
  * This safe is meant to be damn robust. To break in, you're supposed to get creative, or use acid or an explosion.
  *
@@ -226,7 +228,7 @@ There appears to be a small amount of surface corrosion. It doesn't look like it
 	armor = list(MELEE = 100, BULLET = 100, LASER = 100, ENERGY = 100, BOMB = 70, BIO = 0, FIRE = 80, ACID = 70)
 	max_integrity = 300
 
-MAPPING_DIRECTIONAL_HELPERS(/obj/item/storage/secure/safe/caps_spare, 32)
+INVERT_MAPPING_DIRECTIONAL_HELPERS(/obj/item/storage/secure/safe/caps_spare, 32)
 
 /obj/item/storage/secure/safe/caps_spare/Initialize(mapload)
 	. = ..()

--- a/code/game/objects/items/storage/secure.dm
+++ b/code/game/objects/items/storage/secure.dm
@@ -130,7 +130,7 @@
 	. = ..()
 	if(!atom_storage || !has_door)
 		return
-	var/mutable_appearance/door_overlay = mutable_appearance(icon, "[initial(icon_state)]_door")
+	var/mutable_appearance/door_overlay = mutable_appearance(icon, "[initial(icon_state)]_door") // Wallening todo: This needs attention for wall safes.
 	if(dir == SOUTH)
 		door_overlay.pixel_y = -1
 	else if(dir == WEST)

--- a/code/modules/awaymissions/mission_code/stationCollision.dm
+++ b/code/modules/awaymissions/mission_code/stationCollision.dm
@@ -128,6 +128,8 @@ GLOBAL_VAR_INIT(sc_safecode5, "[rand(0,9)]")
 /obj/item/storage/secure/safe/sc_ssafe
 	name = "Captain's secure safe"
 
+INVERT_MAPPING_DIRECTIONAL_HELPERS(/obj/item/storage/secure/safe/sc_ssafe, 0)
+
 /obj/item/storage/secure/safe/sc_ssafe/Initialize(mapload)
 	. = ..()
 	lock_code = "[GLOB.sc_safecode1][GLOB.sc_safecode2][GLOB.sc_safecode3][GLOB.sc_safecode4][GLOB.sc_safecode5]"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Safes have undergone the #135 treatment. The fire axes on Pubbystation have been updated to the directional helpers (Why is the south-facing fire axe cabinet/safe/light switch invisible? Should I move them?)
![image](https://user-images.githubusercontent.com/50649185/197937850-c676b929-12d5-42e9-a104-c1807174c29a.png)

Additionally adds one todo about the safe door overlay being busted. (See #131 )

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Additional Notes
#137 and #136 opened up because of this PR, lmao. Hydra type beat.
Closes #136.