### PR TITLE
Ensures mobs always render properly with windows

### DIFF
--- a/code/__DEFINES/layers.dm
+++ b/code/__DEFINES/layers.dm
@@ -191,6 +191,7 @@
 #define HIGH_BUBBLE_LAYER 5.03
 #define GASFIRE_LAYER 5.05
 #define RIPPLE_LAYER 5.1
+#define HIGHEST_GAME_LAYER 5.2
 
 //---------- LIGHTING -------------
 

--- a/code/controllers/subsystem/vis_overlays.dm
+++ b/code/controllers/subsystem/vis_overlays.dm
@@ -29,18 +29,18 @@ SUBSYSTEM_DEF(vis_overlays)
 			return
 
 //the "thing" var can be anything with vis_contents which includes images - in the future someone should totally allow vis overlays to be passed in as an arg instead of all this bullshit
-/datum/controller/subsystem/vis_overlays/proc/add_vis_overlay(atom/movable/thing, icon, iconstate, layer, plane, dir, alpha = 255, add_appearance_flags = NONE, unique = FALSE)
+/datum/controller/subsystem/vis_overlays/proc/add_vis_overlay(atom/movable/thing, icon, iconstate, layer, plane, dir, alpha = 255, add_appearance_flags = NONE, pixel_x = 0, pixel_y = 0, pixel_z = 0, unique = FALSE)
 	var/obj/effect/overlay/vis/overlay
 	if(!unique)
-		. = "[icon]|[iconstate]|[layer]|[plane]|[dir]|[alpha]|[add_appearance_flags]"
+		. = "[icon]|[iconstate]|[layer]|[plane]|[dir]|[alpha]|[add_appearance_flags][pixel_x][pixel_y][pixel_z]"
 		overlay = vis_overlay_cache[.]
 		if(!overlay)
-			overlay = _create_new_vis_overlay(icon, iconstate, layer, plane, dir, alpha, add_appearance_flags)
+			overlay = _create_new_vis_overlay(icon, iconstate, layer, plane, dir, alpha, add_appearance_flags, pixel_x, pixel_y, pixel_z)
 			vis_overlay_cache[.] = overlay
 		else
 			overlay.unused = 0
 	else
-		overlay = _create_new_vis_overlay(icon, iconstate, layer, plane, dir, alpha, add_appearance_flags)
+		overlay = _create_new_vis_overlay(icon, iconstate, layer, plane, dir, alpha, add_appearance_flags, pixel_x, pixel_y, pixel_z)
 		overlay.cache_expiration = -1
 		var/cache_id = "[text_ref(overlay)]@{[world.time]}"
 		vis_overlay_cache[cache_id] = overlay
@@ -56,7 +56,7 @@ SUBSYSTEM_DEF(vis_overlays)
 		thing.managed_vis_overlays += overlay
 	return overlay
 
-/datum/controller/subsystem/vis_overlays/proc/_create_new_vis_overlay(icon, iconstate, layer, plane, dir, alpha, add_appearance_flags)
+/datum/controller/subsystem/vis_overlays/proc/_create_new_vis_overlay(icon, iconstate, layer, plane, dir, alpha, add_appearance_flags, pixel_x, pixel_y, pixel_z)
 	var/obj/effect/overlay/vis/overlay = new
 	overlay.icon = icon
 	overlay.icon_state = iconstate
@@ -65,6 +65,9 @@ SUBSYSTEM_DEF(vis_overlays)
 	overlay.dir = dir
 	overlay.alpha = alpha
 	overlay.appearance_flags |= add_appearance_flags
+	overlay.pixel_x = pixel_x
+	overlay.pixel_y = pixel_y
+	overlay.pixel_z = pixel_z
 	return overlay
 
 

--- a/code/datums/elements/render_over_keep_hitbox.dm
+++ b/code/datums/elements/render_over_keep_hitbox.dm
@@ -5,34 +5,68 @@
  * Used in plastic flaps, and directional windows!
  */
 /datum/element/render_over_keep_hitbox
+	element_flags = ELEMENT_BESPOKE
+	argument_hash_start_idx = 1
+	var/use_position_layering = FALSE
 
-/datum/element/render_over_keep_hitbox/Attach(datum/target)
+/datum/element/render_over_keep_hitbox/Attach(datum/target, use_position_layering)
 	. = ..()
 	if(!isstructure(target))
 		return ELEMENT_INCOMPATIBLE
 	var/obj/structure/obj_target = target
 
+	src.use_position_layering = use_position_layering
+	RegisterSignal(obj_target, COMSIG_ATOM_UPDATE_OVERLAYS, PROC_REF(update_overlay))
 	RegisterSignal(obj_target, COMSIG_MOVABLE_Z_CHANGED, PROC_REF(on_changed_z_level))
+	if(use_position_layering)
+		RegisterSignal(obj_target, COMSIG_ATOM_DIR_CHANGE, PROC_REF(on_changed_dir))
 	obj_target.alpha = 0
+	obj_target.layer = 0
 	gen_overlay(obj_target)
 
 /datum/element/render_over_keep_hitbox/Detach(obj/structure/target, ...)
-	UnregisterSignal(target, COMSIG_MOVABLE_Z_CHANGED)
+	UnregisterSignal(target, COMSIG_MOVABLE_Z_CHANGED, COMSIG_ATOM_DIR_CHANGE)
 	target.alpha = initial(target.alpha)
-	SSvis_overlays.remove_vis_overlay(target.managed_vis_overlays)
+	target.layer = initial(target.layer)
+	target.pixel_y = 0
+	target.pixel_z = 0
+	SSvis_overlays.remove_vis_overlay(target, target.managed_vis_overlays)
 	return ..()
+
+/datum/element/render_over_keep_hitbox/proc/update_overlay(obj/structure/target, list/new_overlays)
+	gen_overlay(target)
 
 /datum/element/render_over_keep_hitbox/proc/on_changed_z_level(obj/structure/target, turf/old_turf, turf/new_turf, same_z_layer)
 	SIGNAL_HANDLER
 
 	if(same_z_layer)
 		return
-	SSvis_overlays.remove_vis_overlay(target.managed_vis_overlays)
+	SSvis_overlays.remove_vis_overlay(target, target.managed_vis_overlays)
 	gen_overlay(target)
 
+/datum/element/render_over_keep_hitbox/proc/on_changed_dir(obj/structure/target, old_dir, new_dir)
+	SSvis_overlays.remove_vis_overlay(target, target.managed_vis_overlays)
+	gen_directional_overlay(target, new_dir)
+
 /datum/element/render_over_keep_hitbox/proc/gen_overlay(obj/structure/target)
+	if(use_position_layering)
+		gen_directional_overlay(target, target.dir)
+	else
+		gen_square_overlay(target)
+
+// OK, so, this makes windows render properly.
+// We're using side_map to handle layering for us
+// So things decides layering based on (simplifying)
+// Plane
+// Position (x and y + pixel_x/y, NOT the position of pixels on the sprite) blocked out in chunks of 32x32 because we're using tile movement
+// Layer
+// What we're doing here is shifting south windows DOWN onto the tile below them both visually and positionally
+// Then shifting them back up ONLY visually, so they layer as if they were below us
+// And since windows draw above mobs, this just WORKS
+// More details in the proc itself
+/datum/element/render_over_keep_hitbox/proc/gen_square_overlay(obj/structure/target)
 	var/turf/our_turf = get_turf(target)
-	//you see mobs under it, but you hit them like they are above it
+	// This version uses layer to ensure we draw above mobs
 	SSvis_overlays.add_vis_overlay(
 		target,
 		target.icon,
@@ -42,3 +76,42 @@
 		target.dir,
 		add_appearance_flags = RESET_ALPHA
 	)
+
+/datum/element/render_over_keep_hitbox/proc/gen_directional_overlay(obj/structure/target, direction)
+	var/turf/our_turf = get_turf(target)
+	//you see mobs under it, but you hit them like they are above it
+	var/offset = 0
+	var/layer = 0
+	// If we're to the north, offset our structure up
+	// But if we're to the south, offset our overlay down
+	// We want north things to draw over things above them, but not below them
+	// So we move their position up, and set their layer to the max
+	// This way they render over things on their tile, above them
+	// For south things, we move them down, and set their layer to draw below things on their tile
+	if(direction & NORTH)
+		// Ima be honest I have no idea why this works, but it can't be 32 otherwise it'll draw over both top and bottom
+		// I think it has to do with the offsetting of the parent. not sure.
+		offset = 12
+		layer = HIGHEST_GAME_LAYER
+		// Offset physically up so we render under things on our tile, and above things above us
+		target.pixel_y = 32
+		target.pixel_z = -32
+	else
+		offset = -32
+		layer = ON_WALL_LAYER
+		target.pixel_y = 0
+		target.pixel_z = 0
+
+	// This one offsets physical but not visual position to do the same
+	SSvis_overlays.add_vis_overlay(
+		target,
+		target.icon,
+		target.icon_state,
+		layer,
+		MUTATE_PLANE(GAME_PLANE, our_turf),
+		target.dir,
+		add_appearance_flags = RESET_ALPHA,
+		pixel_y = offset,
+		pixel_z = -offset
+	)
+

--- a/code/game/objects/structures/windows/window.dm
+++ b/code/game/objects/structures/windows/window.dm
@@ -54,7 +54,7 @@
 		AddElement(/datum/element/can_barricade)
 		AddComponent(/datum/component/window_smoothing)
 	else
-		AddElement(/datum/element/render_over_keep_hitbox)
+		AddElement(/datum/element/render_over_keep_hitbox, TRUE)
 
 	//windows only block while reinforced and fulltile, so we'll use the proc
 	real_explosion_block = explosion_block
@@ -71,7 +71,6 @@
 
 	if (flags_1 & ON_BORDER_1)
 		AddElement(/datum/element/connect_loc, loc_connections)
-	update_pixel_offsets()
 
 /obj/structure/window/examine(mob/user)
 	. = ..()
@@ -360,28 +359,7 @@
 	else
 		set_opacity(initial(opacity))
 
-/obj/structure/window/setDir(newdir)
-	. = ..()
-	update_pixel_offsets()
 
-/// OK, so, this makes windows render properly.
-/// We're using side_map to handle layering for us
-/// So things decides layering based on (simplifying)
-/// Plane
-/// Position (x and y + pixel_x/y, NOT the position of pixels on the sprite) blocked out in chunks of 32x32 because we're using tile movement
-/// Layer
-/// What we're doing here is shifting south windows DOWN onto the tile below them both visually and positionally
-/// Then shifting them back up ONLY visually, so they layer as if they were below us
-/// And since windows draw above mobs, this just WORKS
-/obj/structure/window/proc/update_pixel_offsets()
-	if(fulltile)
-		return
-	if(dir & SOUTH)
-		pixel_y = -32
-		pixel_z = 32
-	else
-		pixel_y = 0
-		pixel_z = 0
 
 /obj/structure/window/wash(clean_types)
 	. = ..()


### PR DESCRIPTION


<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

This involved a lot of pixel offsetting, some of which is mildly cursed. But it works. mobs always render properly, and windows are properly clickthrough