### PR TITLE
Fixes safes not rendering correctly when shut

### DIFF
--- a/code/game/objects/items/storage/secure.dm
+++ b/code/game/objects/items/storage/secure.dm
@@ -130,6 +130,8 @@
 	. = ..()
 	if(!atom_storage || !has_door)
 		return
+	if(atom_storage.locked) //No door if we're locked.
+		return
 	var/mutable_appearance/door_overlay = mutable_appearance(icon, "[initial(icon_state)]_door") // Wallening todo: This needs attention for wall safes.
 	if(dir == SOUTH)
 		door_overlay.pixel_y = -1


### PR DESCRIPTION
Safes were rendering their overlay when locked, which was not intended.

closes #131