### PR TITLE
Fixes material airlock roundstart runtime.

### DIFF
--- a/code/game/machinery/doors/airlock_types.dm
+++ b/code/game/machinery/doors/airlock_types.dm
@@ -644,6 +644,7 @@
 	name = "Airlock"
 	material_flags = MATERIAL_EFFECTS | MATERIAL_ADD_PREFIX | MATERIAL_GREYSCALE | MATERIAL_AFFECT_STATISTICS
 	greyscale_config = /datum/greyscale_config/material_airlock
+	greyscale_colors = "#a5a7ac"
 	assemblytype = /obj/structure/door_assembly/door_assembly_material
 
 /obj/machinery/door/airlock/material/close(forced, force_crush)


### PR DESCRIPTION
## About The Pull Request

Quick simple fix, stops the roundstart runtime based on martial airlock assemblies from firing due to having a default set of 7 greyscale colors as opposed to the expected 1.
![image](https://user-images.githubusercontent.com/41715314/219843558-8c151908-df71-437f-ac95-7e756ecb20d8.png)

Fixes #142 .
## Why It's Good For The Game

💥 🐛 👍 
