### PR TITLE
Partially fixes window smoothing

### DIFF
--- a/code/datums/components/window_smoothing.dm
+++ b/code/datums/components/window_smoothing.dm
@@ -68,7 +68,7 @@ GLOBAL_LIST_EMPTY(window_appearances)
 	// we check to the south east and west too because action hates me
 	// OF NOTE:
 	// what we are checking here is if there's a wall below, OR if there's a wall to the south(east|west) and
-	// a SMOOTHING TARGET to the south, east or west.
+	// a SMOOTHING TARGET to the south.
 	// This ensures we only use the alt display if there's a wall there, AND we're smoothing into it
 	var/wall_below = isclosedturf(get_step(our_turf, SOUTH)) || \
 		(junction & (SOUTH) && isclosedturf(get_step(our_turf, SOUTHEAST))) || \

--- a/code/datums/components/window_smoothing.dm
+++ b/code/datums/components/window_smoothing.dm
@@ -71,8 +71,8 @@ GLOBAL_LIST_EMPTY(window_appearances)
 	// a SMOOTHING TARGET to the south, east or west.
 	// This ensures we only use the alt display if there's a wall there, AND we're smoothing into it
 	var/wall_below = isclosedturf(get_step(our_turf, SOUTH)) || \
-		(junction & (SOUTH|EAST) && isclosedturf(get_step(our_turf, SOUTHEAST))) || \
-		(junction & (SOUTH|WEST) && isclosedturf(get_step(our_turf, SOUTHWEST)))
+		(junction & (SOUTH) && isclosedturf(get_step(our_turf, SOUTHEAST))) || \
+		(junction & (SOUTH) && isclosedturf(get_step(our_turf, SOUTHWEST)))
 	// If there's a wall below us, we render different
 	our_appearances += get_window_appearance(offset, icon_path, junction, "lower", wall_below, FALSE)
 


### PR DESCRIPTION

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

We were using alt icon states improperly, leading to weird smoothing when a wall was directly below a window
Things still look wrong mind, but now they're at least uniformly wrong

Works on #184

Before
![image](https://user-images.githubusercontent.com/58055496/234503459-3aa61d80-720a-4417-9cc3-e92e9039b161.png)
After
![image](https://user-images.githubusercontent.com/58055496/234503504-276307c5-073b-4a3d-8f53-17a454a1706a.png)
