### PR TITLE
Removes Already-Addressed Comment regarding Borg X-Ray Module Icon

### DIFF
--- a/code/game/objects/items/robot/items/hud.dm
+++ b/code/game/objects/items/robot/items/hud.dm
@@ -2,8 +2,6 @@
 	var/sight_mode = null
 	icon = 'icons/obj/clothing/glasses.dmi'
 
-// Wallening todo: what the fuck is this item man
-// It uses the securearea sign as an icon, so it'll be broken... if it was ever actually used
 /obj/item/borg/sight/xray
 	name = "\proper X-ray vision"
 	icon_state = "securityhudnight"


### PR DESCRIPTION
This was already addressed in https://github.com/tgstation/tgstation/pull/81720, we just didn't remove the comment when upstream/master was merged three months ago. Splitting it out into it's own PR so it doesn't clog up anything else i'm staring at.