### PR TITLE
Cleans up duplicate bamboo walls

### DIFF
--- a/code/game/turfs/closed/wall/mineral_walls.dm
+++ b/code/game/turfs/closed/wall/mineral_walls.dm
@@ -218,19 +218,6 @@
 	canSmoothWith = SMOOTH_GROUP_ABDUCTOR_WALLS
 	custom_materials = list(/datum/material/alloy/alien = SHEET_MATERIAL_AMOUNT*2)
 
-// Wallening todo: why do we have two versions of bamboo
-/turf/closed/wall/mineral/bamboo
-	name = "bamboo wall"
-	desc = "A wall with constructed from bamboo."
-	icon = 'icons/turf/walls/bamboo_wall.dmi'
-	sheet_type = /obj/item/stack/sheet/mineral/bamboo
-	hardness = 50
-	explosive_resistance = 0
-	smoothing_flags = SMOOTH_BITMASK
-	smoothing_groups = SMOOTH_GROUP_BAMBOO_WALLS + SMOOTH_GROUP_CLOSED_TURFS + SMOOTH_GROUP_WALLS
-	canSmoothWith = SMOOTH_GROUP_BAMBOO_WALLS
-	custom_materials = list(/datum/material/bamboo = 4000)
-
 /turf/closed/wall/mineral/meat
 	name = "meat wall"
 	desc = "A wall of somone's compacted meat."


### PR DESCRIPTION
## About The Pull Request

I think this is just an artifact of a merge conflict resolution gone wrong, bamboo walls on upstream/master have the `explosive_resistance` variable unset and `hardness` set to 80 so I just kept the one that matched those (which is about 40 lines above the changes made in this PR). Just good to keep cleaning up those todos so there's less clutter for the more cerebral stuff.

Still works too:
![image](https://github.com/wall-nerds/wallening/assets/34697715/f2327abd-cff3-4099-8377-148001c5182f)