### PR TITLE
Fixes the wall-mounted component on wallening

### DIFF
--- a/code/datums/components/wall_mounted.dm
+++ b/code/datums/components/wall_mounted.dm
@@ -1,4 +1,9 @@
-// This element should be applied to wall-mounted machines/structures, so that if the wall it's "hanging" from is broken or deconstructed, the wall-hung structure will deconstruct.
+/**
+ * This element should be applied to wall-mounted machines/structures,
+ * so that if the wall it's "hanging" from is broken or deconstructed,
+ * the wall-hung structure will deconstruct.
+ */
+
 /datum/component/wall_mounted
 	dupe_mode = COMPONENT_DUPE_ALLOWED
 	/// The wall our object is currently linked to.
@@ -93,7 +98,7 @@
 		return FALSE //For now, we're going to keep the component off of shuttles to avoid the turf changing issue. We'll hit that later really;
 	var/turf/attachable_wall
 	if(directional)
-		attachable_wall = get_step(src, dir)
+		attachable_wall = get_step(src, turn(dir,180))
 	else
 		attachable_wall = loc ///Pull from the curent object loc
 	if(!iswallturf(attachable_wall))


### PR DESCRIPTION
## About The Pull Request

What it says on the tin, on live we changed all the directions in preparation for wallening, to the point that the wallhanging component was still expected flipped map directions. This flips it back, so wall-hanging behavior works yet again.

![image](https://github.com/user-attachments/assets/c43da01a-dd2d-4ea0-bdf3-0541c382160d)
_A Rod-ed line of walls and their wall-hanging components, dropped the ground._

## Why It's Good For The Game

🐛 💥 
