### PR TITLE
Makes temporary shatter work with frames

### DIFF
--- a/code/__DEFINES/dcs/signals/signals_atom/signals_atom_main.dm
+++ b/code/__DEFINES/dcs/signals/signals_atom/signals_atom_main.dm
@@ -55,8 +55,6 @@
 #define COMSIG_ATOM_SET_SMOOTHED_ICON_STATE "set_smoothed_icon_state"
 ///from base of [/atom/proc/smooth_icon]: ()
 #define COMSIG_ATOM_SMOOTHED_ICON "atom_smoothed_icon"
-/// from base of whenever the smoothing needs to go: ()
-#define COMSIG_ATOM_REMOVE_SMOOTHING "atom_remove_smoothing"
 ///from [/datum/controller/subsystem/processing/dcs/proc/rotate_decals]: (list/datum/element/decal/rotating)
 #define COMSIG_ATOM_DECALS_ROTATING "atom_decals_rotating"
 ///from base of atom/Entered(): (atom/movable/arrived, atom/old_loc, list/atom/old_locs)

--- a/code/__DEFINES/dcs/signals/signals_atom/signals_atom_main.dm
+++ b/code/__DEFINES/dcs/signals/signals_atom/signals_atom_main.dm
@@ -55,6 +55,8 @@
 #define COMSIG_ATOM_SET_SMOOTHED_ICON_STATE "set_smoothed_icon_state"
 ///from base of [/atom/proc/smooth_icon]: ()
 #define COMSIG_ATOM_SMOOTHED_ICON "atom_smoothed_icon"
+/// from base of whenever the smoothing needs to go: ()
+#define COMSIG_ATOM_REMOVE_SMOOTHING "atom_remove_smoothing"
 ///from [/datum/controller/subsystem/processing/dcs/proc/rotate_decals]: (list/datum/element/decal/rotating)
 #define COMSIG_ATOM_DECALS_ROTATING "atom_decals_rotating"
 ///from base of atom/Entered(): (atom/movable/arrived, atom/old_loc, list/atom/old_locs)

--- a/code/datums/components/glass_passer.dm
+++ b/code/datums/components/glass_passer.dm
@@ -26,9 +26,9 @@
 /datum/component/glass_passer/proc/cross_over(mob/passer, atom/crosser)
 	SIGNAL_HANDLER
 
-	if(istype(crosser, /obj/structure/grille))
-		var/obj/structure/grille/grillefriend = crosser
-		if(grillefriend.is_shocked()) //prevent passage of shocked
+	if(istype(crosser, /obj/structure/window_frame))
+		var/obj/structure/window_frame/framefriend = crosser
+		if(framefriend.is_shocked()) //prevent passage of shocked
 			crosser.balloon_alert(passer, "is shocked!")
 			return COMPONENT_BLOCK_CROSS
 

--- a/code/datums/components/temporary_glass_shatter.dm
+++ b/code/datums/components/temporary_glass_shatter.dm
@@ -11,20 +11,20 @@
 	SIGNAL_HANDLER
 
 	if(istype(target, /obj/structure/window))
-		var/obj/structure/grille/grille = locate(/obj/structure/grille) in get_turf(target)
-		if(grille?.is_shocked())
+		var/obj/structure/window_frame/frame = locate(/obj/structure/grille) in get_turf(target)
+		if(frame?.is_shocked())
 			target.balloon_alert(tapper, "is shocked!")
 			return COMPONENT_CANCEL_ATTACK_CHAIN
 
 		var/obj/structure/window/window = target
 		window.temporary_shatter()
-	else if(istype(target, /obj/structure/grille))
-		var/obj/structure/grille/grille = target
-		if(grille.is_shocked())
+	else if(istype(target, /obj/structure/window_frame))
+		var/obj/structure/window_frame/frame = target
+		if(frame.is_shocked())
 			target.balloon_alert(tapper, "is shocked!")
 			return COMPONENT_CANCEL_ATTACK_CHAIN
 
-		grille.temporary_shatter()
+		frame.temporary_shatter()
 	else
 		return
 	return COMPONENT_CANCEL_ATTACK_CHAIN

--- a/code/datums/components/window_smoothing.dm
+++ b/code/datums/components/window_smoothing.dm
@@ -52,7 +52,7 @@ GLOBAL_LIST_EMPTY(window_appearances)
 	reset_icon()
 	RegisterSignal(parent, COMSIG_ATOM_SET_SMOOTHED_ICON_STATE, PROC_REF(on_junction_change))
 	RegisterSignal(parent, COMSIG_ATOM_UPDATE_ICON, PROC_REF(update_icon))
-	RegisterSignal(parent, COMSIG_MOVABLE_MOVED, PROC_REF(remove_smoothing))
+	RegisterSignal(parent, COMSIG_MOVABLE_MOVED, PROC_REF(on_moved))
 
 /datum/component/window_smoothing/proc/reset_icon()
 	var/atom/parent_atom = parent
@@ -67,7 +67,12 @@ GLOBAL_LIST_EMPTY(window_appearances)
 
 /datum/component/window_smoothing/proc/add_smoothing(new_junction)
 	var/atom/parent = src.parent
+
+	if(!parent.loc) //we shouldnt add frills if we're in nullspace
+		return
+
 	var/junction = new_junction
+
 	if(isnull(junction))
 		junction = parent.smoothing_junction
 
@@ -130,6 +135,11 @@ GLOBAL_LIST_EMPTY(window_appearances)
 	reset_icon()
 
 /datum/component/window_smoothing/proc/tied_turf_deleted(turf/source)
+	SIGNAL_HANDLER
+	remove_smoothing()
+	add_smoothing()
+
+/datum/component/window_smoothing/proc/on_moved(atom/movable/parent, turf/old_turf, dir)
 	SIGNAL_HANDLER
 	remove_smoothing()
 	add_smoothing()

--- a/code/datums/components/window_smoothing.dm
+++ b/code/datums/components/window_smoothing.dm
@@ -52,7 +52,7 @@ GLOBAL_LIST_EMPTY(window_appearances)
 	reset_icon()
 	RegisterSignal(parent, COMSIG_ATOM_SET_SMOOTHED_ICON_STATE, PROC_REF(on_junction_change))
 	RegisterSignal(parent, COMSIG_ATOM_UPDATE_ICON, PROC_REF(update_icon))
-	RegisterSignal(parent, COMSIG_ATOM_REMOVE_SMOOTHING, PROC_REF(remove_smoothing))
+	RegisterSignal(parent, COMSIG_MOVABLE_MOVED, PROC_REF(remove_smoothing))
 
 /datum/component/window_smoothing/proc/reset_icon()
 	var/atom/parent_atom = parent

--- a/code/datums/components/window_smoothing.dm
+++ b/code/datums/components/window_smoothing.dm
@@ -52,6 +52,7 @@ GLOBAL_LIST_EMPTY(window_appearances)
 	reset_icon()
 	RegisterSignal(parent, COMSIG_ATOM_SET_SMOOTHED_ICON_STATE, PROC_REF(on_junction_change))
 	RegisterSignal(parent, COMSIG_ATOM_UPDATE_ICON, PROC_REF(update_icon))
+	RegisterSignal(parent, COMSIG_ATOM_REMOVE_SMOOTHING, PROC_REF(remove_smoothing))
 
 /datum/component/window_smoothing/proc/reset_icon()
 	var/atom/parent_atom = parent

--- a/code/game/objects/structures/grille.dm
+++ b/code/game/objects/structures/grille.dm
@@ -20,8 +20,6 @@
 	canSmoothWith = SMOOTH_GROUP_GRILLE
 	var/rods_type = /obj/item/stack/rods
 	var/rods_amount = 2
-	/// Whether or not we're disappearing but dramatically
-	var/dramatically_disappearing = FALSE
 
 /datum/armor/structure_grille
 	melee = 50
@@ -396,31 +394,6 @@
 
 /obj/structure/grille/get_dumping_location()
 	return null
-
-/obj/structure/grille/proc/temporary_shatter(time_to_go = 0 SECONDS, time_to_return = 4 SECONDS)
-	if(dramatically_disappearing)
-		return
-
-	//dissapear in 1 second
-	dramatically_disappearing = TRUE
-	addtimer(CALLBACK(src, TYPE_PROC_REF(/atom/movable, moveToNullspace)), time_to_go) //woosh
-
-	// come back in 1 + 4 seconds
-	addtimer(VARSET_CALLBACK(src, atom_integrity, atom_integrity), time_to_go + time_to_return) //set the health back (icon is updated on move)
-	addtimer(CALLBACK(src, TYPE_PROC_REF(/atom/movable, forceMove), loc), time_to_go + time_to_return) //we back boys
-	addtimer(VARSET_CALLBACK(src, dramatically_disappearing, FALSE), time_to_go + time_to_return) //also set the var back
-
-/// Do some very specific checks to see if we *would* get shocked. Returns TRUE if it's shocked
-/obj/structure/grille/proc/is_shocked()
-	var/turf/turf = get_turf(src)
-	var/obj/structure/cable/cable = turf.get_cable_node()
-	var/list/powernet_info = get_powernet_info_from_source(cable)
-
-	if(!powernet_info)
-		return FALSE
-
-	var/datum/powernet/powernet = powernet_info["powernet"]
-	return !!powernet.get_electrocute_damage()
 
 /obj/structure/grille/broken // Pre-broken grilles for map placement
 	icon = 'icons/obj/smooth_structures/tall_structure_variations.dmi'

--- a/code/game/objects/structures/window_frames.dm
+++ b/code/game/objects/structures/window_frames.dm
@@ -8,7 +8,7 @@
 	smoothing_flags = SMOOTH_BITMASK|SMOOTH_OBJ
 	smoothing_groups = SMOOTH_GROUP_WINDOW_FRAMES
 	canSmoothWith = SMOOTH_GROUP_WINDOW_FRAMES
-	pass_flags_self = PASSTABLE | LETPASSTHROW
+	pass_flags_self = PASSTABLE | LETPASSTHROW | PASSGRILLE | PASSWINDOW
 	opacity = FALSE
 	density = TRUE
 	rad_insulation = null
@@ -39,6 +39,9 @@
 
 	var/sheet_type = /obj/item/stack/sheet/iron
 	var/sheet_amount = 2
+
+	/// Whether or not we're disappearing but dramatically
+	var/dramatically_disappearing = FALSE
 
 /datum/armor/window_frame
 	melee = 50
@@ -290,6 +293,31 @@
 	. = ..()
 	create_grill_overlays(.)
 	create_frame_overlay(.)
+
+/obj/structure/window_frame/proc/temporary_shatter(time_to_go = 0 SECONDS, time_to_return = 4 SECONDS)
+	if(dramatically_disappearing)
+		return
+
+	//dissapear in 1 second
+	dramatically_disappearing = TRUE
+	addtimer(CALLBACK(src, TYPE_PROC_REF(/atom/movable, moveToNullspace)), time_to_go) //woosh
+
+	// come back in 1 + 4 seconds
+	addtimer(VARSET_CALLBACK(src, atom_integrity, atom_integrity), time_to_go + time_to_return) //set the health back (icon is updated on move)
+	addtimer(CALLBACK(src, TYPE_PROC_REF(/atom/movable, forceMove), loc), time_to_go + time_to_return) //we back boys
+	addtimer(VARSET_CALLBACK(src, dramatically_disappearing, FALSE), time_to_go + time_to_return) //also set the var back
+
+/// Do some very specific checks to see if we *would* get shocked. Returns TRUE if it's shocked
+/obj/structure/window_frame/proc/is_shocked()
+	var/turf/turf = get_turf(src)
+	var/obj/structure/cable/cable = turf.get_cable_node()
+	var/list/powernet_info = get_powernet_info_from_source(cable)
+
+	if(!powernet_info)
+		return FALSE
+
+	var/datum/powernet/powernet = powernet_info["powernet"]
+	return !!powernet.get_electrocute_damage()
 
 /obj/structure/window_frame/grille
 	has_grille = TRUE

--- a/code/game/objects/structures/windows/window.dm
+++ b/code/game/objects/structures/windows/window.dm
@@ -684,7 +684,6 @@ MAPPING_DIRECTIONAL_HELPERS_EMPTY(/obj/structure/window/spawner)
 /obj/structure/window/Moved(atom/old_loc, movement_dir, forced, list/old_locs, momentum_change)
 	. = ..()
 
-	SEND_SIGNAL(src, COMSIG_ATOM_REMOVE_SMOOTHING)
 	if(loc)
 		update_nearby_icons()
 

--- a/code/game/objects/structures/windows/window.dm
+++ b/code/game/objects/structures/windows/window.dm
@@ -657,7 +657,6 @@
 
 MAPPING_DIRECTIONAL_HELPERS_EMPTY(/obj/structure/window/spawner)
 
-#warn shatter frames
 /obj/structure/window/proc/temporary_shatter(time_to_go = 1 SECONDS, time_to_return = 4 SECONDS, take_grill = TRUE)
 	if(dramatically_disappearing)
 		return
@@ -677,14 +676,15 @@ MAPPING_DIRECTIONAL_HELPERS_EMPTY(/obj/structure/window/spawner)
 	addtimer(VARSET_CALLBACK(src, atom_integrity, atom_integrity), time_to_go + time_to_return) //set the health back (icon is updated on move)
 	addtimer(CALLBACK(src, TYPE_PROC_REF(/atom/movable, forceMove), loc), time_to_go + time_to_return) //we back boys
 	addtimer(VARSET_CALLBACK(src, dramatically_disappearing, FALSE), time_to_go + time_to_return) //also set the var back
-	addtimer(CALLBACK(src, TYPE_PROC_REF(/atom, update_appearance)), time_to_go + time_to_return)
 
-	var/obj/structure/grille/grill = take_grill ? (locate(/obj/structure/grille) in loc) : null
-	if(grill)
-		grill.temporary_shatter(time_to_go, time_to_return)
+	var/obj/structure/window_frame/frame = take_grill ? (locate(/obj/structure/window_frame) in loc) : null
+	if(frame)
+		frame.temporary_shatter(time_to_go, time_to_return)
 
 /obj/structure/window/Moved(atom/old_loc, movement_dir, forced, list/old_locs, momentum_change)
 	. = ..()
+
+	SEND_SIGNAL(src, COMSIG_ATOM_REMOVE_SMOOTHING)
 	if(loc)
 		update_nearby_icons()
 


### PR DESCRIPTION
Also gives window frames passgrile and passwindow so voidwalkers can move through them (I can remove passwindow, don't think a lot of stuff uses it)
Removes the smoothed frilles when windows are moved so the frills dont linger when theyre voidwalker nullspace'd
And, as the title states, makes voidwalkers temp shatter work with window frames instead of grilles