### PR TITLE
Reduce mob offset to 4 pixels

### DIFF
--- a/code/__DEFINES/layers.dm
+++ b/code/__DEFINES/layers.dm
@@ -369,3 +369,5 @@
 #define MAX_EXPECTED_Z_DEPTH 3
 
 #define WALLENING_OFFSET 12
+/// How many pixels do we increment mobs away from the tile to appear more centered?
+#define WALLENING_MOB_OFFSET 4

--- a/code/game/objects/structures/beds_chairs/chair.dm
+++ b/code/game/objects/structures/beds_chairs/chair.dm
@@ -1,5 +1,5 @@
 /obj/structure/chair
-	SET_BASE_VISUAL_PIXEL(0, WALLENING_OFFSET)
+	SET_BASE_VISUAL_PIXEL(0, WALLENING_MOB_OFFSET)
 	name = "chair"
 	desc = "You sit in this. Either by will or force."
 	icon = 'icons/obj/chairs.dmi'

--- a/code/modules/mob/mob_defines.dm
+++ b/code/modules/mob/mob_defines.dm
@@ -7,7 +7,7 @@
  * Has a lot of the creature game world logic, such as health etc
  */
 /mob
-	SET_BASE_VISUAL_PIXEL(0, WALLENING_OFFSET)
+	SET_BASE_VISUAL_PIXEL(0, WALLENING_MOB_OFFSET)
 	density = TRUE
 	layer = MOB_LAYER
 	animate_movement = SLIDE_STEPS


### PR DESCRIPTION
## About The Pull Request

This is an _opinionated change_ but I think the 12 pixel offset, while it looks great on a lot of structures, doesn't work on mobs. It pulls them way too far away from the centre of their actual "hitbox" in a way which really negatively impacts gameplay interactions.

See this laser gun, when clicking behind someone in a way you'd think would hit them:
![dreamseeker_IyvDK2ExJW](https://github.com/user-attachments/assets/7c588448-9e3e-48a4-8db7-1f2414a63a2f)


Reducing the offset to 4 instead of 12 resolves this issue:
![dreamseeker_eZinHAGfj3](https://github.com/user-attachments/assets/8e90999d-97b3-4f9f-934a-90b52994bdb0)

I also applied it to chairs because they need to be on a line with mobs, alternately we need to make buckling to chairs offset you onto the chair which it does not currently do.

In action:
![image](https://github.com/user-attachments/assets/5d7fd239-5034-4a6e-9758-e1ec6e9f811e)
