### PR TITLE
Arcane's ruins work Part 2, my other ruins

### DIFF
--- a/_maps/RandomRuins/LavaRuins/lavaland_surface_elephant_graveyard.dmm
+++ b/_maps/RandomRuins/LavaRuins/lavaland_surface_elephant_graveyard.dmm
@@ -365,7 +365,9 @@
 /turf/open/misc/asteroid/basalt/wasteland,
 /area/ruin/unpowered/elephant_graveyard)
 "uy" = (
-/obj/effect/decal/cleanable/cobweb,
+/obj/effect/decal/cleanable/cobweb{
+	pixel_y = 12
+	},
 /obj/structure/closet/crate/grave/filled/lead_researcher,
 /obj/effect/decal/cleanable/blood/gibs/old,
 /obj/effect/mob_spawn/corpse/human/skeleton,

--- a/_maps/RandomRuins/LavaRuins/lavaland_surface_elephant_graveyard.dmm
+++ b/_maps/RandomRuins/LavaRuins/lavaland_surface_elephant_graveyard.dmm
@@ -26,14 +26,13 @@
 /turf/open/floor/mineral/titanium/white,
 /area/ruin/powered/graveyard_shuttle)
 "aW" = (
-/obj/structure/filingcabinet/chestdrawer,
-/obj/item/clothing/mask/gas/explorer/folded,
+/obj/structure/sign/warning/no_smoking/circle/directional/north,
+/obj/machinery/suit_storage_unit/mining/eva,
+/obj/effect/decal/cleanable/cobweb/cobweb2{
+	pixel_y = 22
+	},
 /turf/open/floor/mineral/titanium/white,
 /area/ruin/powered/graveyard_shuttle)
-"bc" = (
-/obj/structure/sign/poster/ripped,
-/turf/closed/wall,
-/area/ruin/unpowered/elephant_graveyard)
 "bf" = (
 /turf/closed/mineral/strong/wasteland,
 /area/ruin/unpowered/elephant_graveyard)
@@ -53,35 +52,24 @@
 /obj/machinery/iv_drip,
 /turf/open/floor/mineral/titanium/white,
 /area/ruin/powered/graveyard_shuttle)
-"bt" = (
-/obj/structure/table,
-/turf/closed/mineral/strong/wasteland,
-/area/ruin/unpowered/elephant_graveyard)
 "by" = (
-/obj/structure/closet/emcloset,
-/obj/item/light/bulb,
 /obj/effect/turf_decal/box/white,
 /turf/open/floor/mineral/titanium/purple,
 /area/ruin/powered/graveyard_shuttle)
 "bA" = (
-/obj/machinery/suit_storage_unit/mining/eva,
 /obj/effect/turf_decal/box/white,
+/obj/item/wallframe/camera{
+	pixel_x = 4;
+	pixel_y = -9
+	},
+/obj/effect/decal/cleanable/oil,
 /turf/open/floor/mineral/titanium/purple,
 /area/ruin/powered/graveyard_shuttle)
 "bE" = (
 /obj/machinery/power/shuttle_engine/heater,
-/obj/structure/window/spawner/directional/north,
-/obj/effect/decal/cleanable/cobweb/cobweb2,
+/obj/structure/window/half/directional/north,
 /turf/open/floor/mineral/titanium/purple,
 /area/ruin/powered/graveyard_shuttle)
-"bJ" = (
-/obj/structure/sign/warning/xeno_mining,
-/turf/closed/wall,
-/area/ruin/unpowered/elephant_graveyard)
-"bK" = (
-/obj/structure/sign/warning/explosives,
-/turf/closed/wall,
-/area/ruin/unpowered/elephant_graveyard)
 "bS" = (
 /obj/effect/decal/cleanable/oil/slippery,
 /obj/machinery/rnd/destructive_analyzer,
@@ -89,15 +77,30 @@
 /area/ruin/powered/graveyard_shuttle)
 "cm" = (
 /obj/structure/table/optable,
-/obj/item/storage/backpack/explorer,
-/obj/item/reagent_containers/cup/soda_cans/cola,
-/obj/item/restraints/handcuffs/cable/zipties/used,
+/obj/item/storage/backpack/explorer{
+	pixel_x = -8;
+	pixel_y = 5
+	},
+/obj/item/reagent_containers/cup/soda_cans/cola{
+	pixel_x = 4;
+	pixel_y = 2
+	},
+/obj/machinery/light/small/broken/directional/east,
 /turf/open/floor/mineral/titanium/white,
 /area/ruin/powered/graveyard_shuttle)
+"cs" = (
+/obj/structure/cable,
+/obj/effect/decal/cleanable/blood/footprints{
+	dir = 8
+	},
+/turf/open/misc/asteroid/basalt/wasteland,
+/area/ruin/unpowered/elephant_graveyard)
 "cO" = (
 /obj/structure/bed,
 /obj/item/trash/pistachios,
-/obj/item/trash/chips,
+/obj/item/trash/chips{
+	pixel_x = -8
+	},
 /obj/item/bedsheet/brown,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/misc/asteroid/basalt/wasteland,
@@ -108,11 +111,20 @@
 	},
 /turf/open/misc/asteroid/basalt/wasteland,
 /area/ruin/unpowered/elephant_graveyard)
+"da" = (
+/obj/structure/flora/ash/tall_shroom,
+/turf/open/misc/asteroid/basalt/lava_land_surface,
+/area/lavaland/surface)
 "di" = (
 /obj/structure/filingcabinet/chestdrawer,
-/obj/effect/decal/cleanable/cobweb,
+/obj/effect/decal/cleanable/cobweb{
+	pixel_y = 21
+	},
 /obj/item/paper/fluff/ruins/elephant_graveyard/hypothesis,
 /obj/effect/decal/cleanable/dirt,
+/obj/item/clothing/mask/gas/explorer/folded,
+/obj/item/storage/box/lights/tubes,
+/obj/structure/sign/warning/secure_area/directional/north,
 /turf/open/floor/mineral/titanium/white,
 /area/ruin/powered/graveyard_shuttle)
 "do" = (
@@ -126,10 +138,16 @@
 "ei" = (
 /obj/effect/decal/cleanable/blood/gibs/old,
 /obj/effect/decal/cleanable/blood/splatter,
+/obj/item/flashlight/flare/torch,
 /turf/open/misc/asteroid/basalt/wasteland,
 /area/ruin/unpowered/elephant_graveyard)
 "eu" = (
 /obj/effect/decal/cleanable/blood/old,
+/turf/open/misc/asteroid/basalt/wasteland,
+/area/ruin/unpowered/elephant_graveyard)
+"eQ" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/lattice/catwalk/mining,
 /turf/open/misc/asteroid/basalt/wasteland,
 /area/ruin/unpowered/elephant_graveyard)
 "gl" = (
@@ -147,7 +165,6 @@
 /area/ruin/unpowered/elephant_graveyard)
 "gY" = (
 /obj/structure/table,
-/obj/machinery/power/floodlight,
 /obj/structure/cable,
 /turf/open/misc/asteroid/basalt/wasteland,
 /area/ruin/unpowered/elephant_graveyard)
@@ -178,20 +195,28 @@
 /area/ruin/unpowered/elephant_graveyard)
 "kQ" = (
 /obj/structure/table,
-/obj/item/clothing/gloves/color/black,
+/obj/item/clothing/gloves/color/black{
+	pixel_y = 8;
+	pixel_x = -2
+	},
 /turf/open/misc/asteroid/basalt/wasteland,
 /area/ruin/unpowered/elephant_graveyard)
 "lt" = (
 /obj/structure/table,
 /obj/structure/cable,
-/obj/item/clipboard,
+/obj/item/clipboard{
+	pixel_y = 14;
+	pixel_x = -3
+	},
 /turf/open/misc/asteroid/basalt/wasteland,
 /area/ruin/unpowered/elephant_graveyard)
 "lK" = (
 /obj/structure/cable,
 /obj/item/reagent_containers/cup/bottle/frostoil{
 	desc = "A small bottle. Contains cold sauce. There's a label on here: APPLY ON SEVERE BURNS.";
-	volume = 10
+	volume = 10;
+	pixel_y = -4;
+	pixel_x = 6
 	},
 /turf/open/misc/asteroid/basalt/wasteland,
 /area/ruin/unpowered/elephant_graveyard)
@@ -200,13 +225,29 @@
 /obj/effect/spawner/random/decoration/glowstick,
 /turf/open/misc/asteroid/basalt/wasteland,
 /area/ruin/unpowered/elephant_graveyard)
-"nl" = (
-/obj/structure/table,
-/obj/item/pen,
-/obj/item/pen,
-/obj/item/pen,
+"mI" = (
+/obj/structure/sign/warning/no_smoking/circle/directional/north,
 /turf/open/misc/asteroid/basalt/wasteland,
 /area/ruin/unpowered/elephant_graveyard)
+"nl" = (
+/obj/structure/table,
+/obj/item/pen{
+	pixel_x = -1
+	},
+/obj/item/pen{
+	pixel_y = 13;
+	pixel_x = 4
+	},
+/obj/item/pen{
+	pixel_y = 6;
+	pixel_x = -2
+	},
+/turf/open/misc/asteroid/basalt/wasteland,
+/area/ruin/unpowered/elephant_graveyard)
+"ns" = (
+/obj/structure/flora/ash/stem_shroom,
+/turf/open/misc/asteroid/basalt/lava_land_surface,
+/area/lavaland/surface)
 "nv" = (
 /obj/structure/reagent_dispensers/water_cooler,
 /turf/open/misc/asteroid/basalt/wasteland,
@@ -217,9 +258,20 @@
 	},
 /turf/open/misc/asteroid/basalt/wasteland,
 /area/ruin/unpowered/elephant_graveyard)
+"nW" = (
+/obj/structure/stone_tile/block/cracked{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/ash,
+/turf/open/misc/asteroid/basalt/wasteland,
+/area/ruin/unpowered/elephant_graveyard)
 "nX" = (
-/obj/item/trash/can,
-/obj/structure/bedsheetbin/empty,
+/obj/item/trash/can{
+	pixel_y = 16
+	},
+/obj/structure/bedsheetbin/empty{
+	pixel_y = 12
+	},
 /obj/structure/table,
 /turf/open/misc/asteroid/basalt/wasteland,
 /area/ruin/unpowered/elephant_graveyard)
@@ -240,14 +292,27 @@
 /obj/structure/stone_tile/slab/cracked,
 /turf/open/misc/asteroid/basalt/wasteland,
 /area/ruin/unpowered/elephant_graveyard)
+"pl" = (
+/obj/effect/decal/cleanable/blood/footprints,
+/turf/open/misc/asteroid/basalt/wasteland,
+/area/ruin/unpowered/elephant_graveyard)
 "pI" = (
-/obj/item/light/bulb/broken,
 /obj/effect/turf_decal/caution/stand_clear/white,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/mineral/titanium/purple,
 /area/ruin/powered/graveyard_shuttle)
+"qW" = (
+/obj/structure/statue/bone/rib{
+	dir = 1;
+	pixel_x = -3
+	},
+/turf/open/misc/asteroid/basalt/wasteland,
+/area/ruin/unpowered/elephant_graveyard)
 "rb" = (
-/obj/item/chair,
+/obj/item/chair{
+	pixel_y = 6;
+	pixel_x = 1
+	},
 /turf/open/misc/asteroid/basalt/wasteland,
 /area/ruin/unpowered/elephant_graveyard)
 "rg" = (
@@ -259,9 +324,18 @@
 /area/ruin/unpowered/elephant_graveyard)
 "rH" = (
 /obj/structure/closet/crate/bin,
-/obj/item/trash/candle,
-/obj/item/trash/can/food/beans,
-/obj/item/trash/can,
+/obj/item/trash/candle{
+	pixel_y = -4;
+	pixel_x = 3
+	},
+/obj/item/trash/can/food/beans{
+	pixel_y = -7;
+	pixel_x = -7
+	},
+/obj/item/trash/can{
+	pixel_y = 4;
+	pixel_x = 6
+	},
 /obj/effect/decal/cleanable/dirt,
 /obj/item/cigbutt,
 /turf/open/misc/asteroid/basalt/wasteland,
@@ -269,13 +343,21 @@
 "sg" = (
 /obj/structure/table,
 /obj/structure/cable,
-/obj/item/t_scanner/adv_mining_scanner/lesser,
+/obj/item/t_scanner/adv_mining_scanner/lesser{
+	pixel_y = 8
+	},
 /turf/open/misc/asteroid/basalt/wasteland,
 /area/ruin/unpowered/elephant_graveyard)
 "tf" = (
 /turf/open/misc/asteroid/basalt/wasteland{
 	icon_state = "wasteland_dug"
 	},
+/area/ruin/unpowered/elephant_graveyard)
+"tm" = (
+/obj/structure/cable,
+/obj/structure/lattice/catwalk/mining,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/misc/asteroid/basalt/wasteland,
 /area/ruin/unpowered/elephant_graveyard)
 "uj" = (
 /obj/structure/bed,
@@ -289,6 +371,10 @@
 /obj/effect/mob_spawn/corpse/human/skeleton,
 /turf/open/misc/asteroid/basalt/wasteland,
 /area/ruin/unpowered/elephant_graveyard)
+"uS" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/misc/asteroid/basalt/wasteland,
+/area/ruin/unpowered/elephant_graveyard)
 "vk" = (
 /obj/structure/closet/crate/grave/filled,
 /obj/effect/decal/cleanable/dirt,
@@ -296,8 +382,18 @@
 /turf/open/misc/asteroid/basalt/wasteland,
 /area/ruin/unpowered/elephant_graveyard)
 "vP" = (
-/obj/item/light/bulb/broken,
+/obj/item/light/bulb/broken{
+	pixel_x = -2;
+	pixel_y = -2
+	},
 /obj/effect/decal/cleanable/dirt,
+/obj/structure/closet/emcloset,
+/obj/item/light/bulb/broken,
+/obj/item/light/bulb{
+	pixel_y = 2;
+	pixel_x = 2
+	},
+/obj/machinery/light/small/dim/directional/west,
 /turf/open/floor/mineral/titanium/white,
 /area/ruin/powered/graveyard_shuttle)
 "vS" = (
@@ -307,13 +403,22 @@
 /area/ruin/unpowered/elephant_graveyard)
 "wk" = (
 /obj/structure/table,
-/obj/item/tape/random,
-/obj/item/tape/random,
+/obj/item/tape/random{
+	pixel_y = 6
+	},
+/obj/item/tape/random{
+	pixel_y = 10
+	},
 /turf/open/misc/asteroid/basalt/wasteland,
 /area/ruin/unpowered/elephant_graveyard)
 "wp" = (
-/obj/item/knife/combat/bone,
-/obj/item/organ/internal/tongue,
+/obj/item/knife/combat/bone{
+	pixel_y = 4
+	},
+/obj/item/organ/internal/tongue{
+	pixel_x = 5;
+	pixel_y = -7
+	},
 /obj/effect/decal/cleanable/blood/old,
 /turf/open/misc/asteroid/basalt/wasteland,
 /area/ruin/unpowered/elephant_graveyard)
@@ -331,6 +436,11 @@
 /obj/effect/decal/cleanable/oil/streak,
 /obj/effect/decal/cleanable/glass,
 /turf/open/misc/asteroid/basalt/wasteland,
+/area/ruin/unpowered/elephant_graveyard)
+"zw" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/power/floodlight,
+/turf/open/floor/plating/lavaland_baseturf,
 /area/ruin/unpowered/elephant_graveyard)
 "zY" = (
 /obj/effect/decal/cleanable/blood/drip,
@@ -353,7 +463,10 @@
 /area/ruin/unpowered/elephant_graveyard)
 "AT" = (
 /obj/structure/cable,
-/obj/item/food/deadmouse,
+/obj/item/food/deadmouse{
+	pixel_x = 6;
+	pixel_y = 11
+	},
 /obj/item/assembly/mousetrap,
 /turf/open/misc/asteroid/basalt/wasteland,
 /area/ruin/unpowered/elephant_graveyard)
@@ -386,7 +499,10 @@
 /turf/open/misc/asteroid/basalt/lava_land_surface,
 /area/lavaland/surface)
 "Di" = (
-/obj/item/organ/internal/lungs,
+/obj/item/organ/internal/lungs{
+	pixel_x = 11;
+	pixel_y = -4
+	},
 /obj/item/organ/internal/liver,
 /obj/effect/decal/cleanable/blood/old,
 /turf/open/misc/asteroid/basalt/wasteland,
@@ -399,6 +515,7 @@
 /area/ruin/unpowered/elephant_graveyard)
 "DB" = (
 /obj/structure/stone_tile,
+/obj/effect/decal/cleanable/blood/drip,
 /turf/open/misc/asteroid/basalt/wasteland,
 /area/ruin/unpowered/elephant_graveyard)
 "DU" = (
@@ -406,16 +523,32 @@
 /turf/open/misc/asteroid/basalt/wasteland,
 /area/ruin/unpowered/elephant_graveyard)
 "Eh" = (
-/obj/item/organ/internal/brain,
+/obj/item/organ/internal/brain{
+	pixel_x = -4;
+	pixel_y = -2
+	},
 /turf/open/misc/asteroid/basalt/wasteland,
 /area/ruin/unpowered/elephant_graveyard)
 "EI" = (
 /obj/effect/decal/remains/human,
-/obj/item/restraints/handcuffs/cable/zipties/used,
+/obj/item/restraints/handcuffs/cable/zipties/used{
+	pixel_x = -7;
+	pixel_y = -2
+	},
 /turf/open/misc/asteroid/basalt/wasteland,
 /area/ruin/unpowered/elephant_graveyard)
 "EW" = (
 /obj/structure/reagent_dispensers/fueltank,
+/turf/open/misc/asteroid/basalt/wasteland,
+/area/ruin/unpowered/elephant_graveyard)
+"EZ" = (
+/obj/structure/flora/rock/pile/style_2,
+/turf/open/misc/asteroid/basalt/lava_land_surface,
+/area/lavaland/surface)
+"Gc" = (
+/obj/structure/statue/bone/rib{
+	pixel_x = 5
+	},
 /turf/open/misc/asteroid/basalt/wasteland,
 /area/ruin/unpowered/elephant_graveyard)
 "GC" = (
@@ -423,9 +556,23 @@
 /obj/item/cigbutt,
 /turf/open/misc/asteroid/basalt/wasteland,
 /area/ruin/unpowered/elephant_graveyard)
+"GT" = (
+/obj/structure/flora/ash/fireblossom,
+/turf/open/misc/asteroid/basalt/lava_land_surface,
+/area/lavaland/surface)
 "Hq" = (
-/obj/structure/barricade/wooden,
-/obj/structure/mineral_door/wood,
+/obj/structure/barricade/wooden{
+	dir = 8
+	},
+/obj/structure/mineral_door/wood{
+	dir = 8
+	},
+/turf/open/misc/asteroid/basalt/wasteland,
+/area/ruin/unpowered/elephant_graveyard)
+"Hz" = (
+/obj/structure/statue/bone/rib{
+	pixel_x = 3
+	},
 /turf/open/misc/asteroid/basalt/wasteland,
 /area/ruin/unpowered/elephant_graveyard)
 "Iy" = (
@@ -435,14 +582,17 @@
 "Iz" = (
 /obj/structure/table,
 /obj/structure/cable,
-/obj/item/paper_bin,
+/obj/item/paper_bin{
+	pixel_y = 11
+	},
 /turf/open/misc/asteroid/basalt/wasteland,
 /area/ruin/unpowered/elephant_graveyard)
 "IR" = (
 /obj/effect/decal/cleanable/glass,
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/door/airlock/shuttle{
-	name = "Archaeology Shuttle Airlock"
+	name = "Archaeology Shuttle Airlock";
+	dir = 8
 	},
 /turf/open/floor/mineral/titanium/purple,
 /area/ruin/powered/graveyard_shuttle)
@@ -457,20 +607,31 @@
 /area/ruin/unpowered/elephant_graveyard)
 "JT" = (
 /obj/structure/table,
-/obj/item/taperecorder,
+/obj/item/taperecorder{
+	pixel_y = 12;
+	pixel_x = 4
+	},
 /turf/open/misc/asteroid/basalt/wasteland,
 /area/ruin/unpowered/elephant_graveyard)
 "Kg" = (
 /obj/effect/decal/remains/human,
 /obj/effect/decal/cleanable/dirt,
-/obj/item/clothing/head/fedora/curator,
-/obj/item/clothing/suit/jacket/curator,
+/obj/item/clothing/head/fedora/curator{
+	pixel_y = 7
+	},
+/obj/item/clothing/suit/jacket/curator{
+	pixel_x = -2;
+	pixel_y = -8
+	},
 /turf/open/floor/mineral/titanium/white,
 /area/ruin/powered/graveyard_shuttle)
 "Kj" = (
 /obj/item/organ/internal/heart,
 /obj/item/organ/internal/eyes,
-/obj/item/organ/internal/ears,
+/obj/item/organ/internal/ears{
+	pixel_y = 6;
+	pixel_x = 12
+	},
 /obj/effect/decal/cleanable/blood/gibs/old,
 /turf/open/misc/asteroid/basalt/wasteland,
 /area/ruin/unpowered/elephant_graveyard)
@@ -484,12 +645,18 @@
 /obj/structure/barricade/sandbags,
 /turf/open/misc/asteroid/basalt/wasteland,
 /area/ruin/unpowered/elephant_graveyard)
-"LN" = (
-/obj/structure/sign/warning/no_smoking/circle,
-/turf/closed/wall,
-/area/ruin/unpowered/elephant_graveyard)
+"KC" = (
+/obj/structure/flora/rock/style_3,
+/turf/open/misc/asteroid/basalt/lava_land_surface,
+/area/lavaland/surface)
 "LR" = (
 /obj/item/paper/fluff/ruins/elephant_graveyard,
+/turf/open/misc/asteroid/basalt/wasteland,
+/area/ruin/unpowered/elephant_graveyard)
+"LV" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/sign/warning/xeno_mining/directional/north,
+/obj/structure/fluff/minepost,
 /turf/open/misc/asteroid/basalt/wasteland,
 /area/ruin/unpowered/elephant_graveyard)
 "Mx" = (
@@ -503,13 +670,22 @@
 /area/ruin/unpowered/elephant_graveyard)
 "MF" = (
 /obj/effect/decal/remains/human,
-/obj/item/tank/internals/emergency_oxygen/empty,
+/obj/item/tank/internals/emergency_oxygen/empty{
+	pixel_y = -8;
+	pixel_x = 7
+	},
 /obj/effect/decal/cleanable/blood/old,
 /turf/open/misc/asteroid/basalt/wasteland,
 /area/ruin/unpowered/elephant_graveyard)
 "MI" = (
 /obj/structure/cable,
 /obj/machinery/power/floodlight,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating/lavaland_baseturf,
+/area/ruin/unpowered/elephant_graveyard)
+"NA" = (
+/obj/structure/lattice/catwalk/mining,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/misc/asteroid/basalt/wasteland,
 /area/ruin/unpowered/elephant_graveyard)
 "NO" = (
@@ -518,36 +694,72 @@
 /area/ruin/unpowered/elephant_graveyard)
 "Oa" = (
 /obj/effect/decal/cleanable/generic,
-/obj/item/cigbutt,
+/obj/item/cigbutt{
+	pixel_y = 4;
+	pixel_x = -5
+	},
 /turf/open/misc/asteroid/basalt/wasteland,
 /area/ruin/unpowered/elephant_graveyard)
 "Ou" = (
 /obj/structure/statue/bone/rib,
 /turf/open/misc/asteroid/basalt/wasteland,
 /area/ruin/unpowered/elephant_graveyard)
+"Ow" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/fluff/minepost,
+/turf/open/misc/asteroid/basalt/lava_land_surface,
+/area/ruin/unpowered/elephant_graveyard)
 "PN" = (
 /obj/machinery/power/floodlight,
 /obj/structure/cable,
-/turf/open/misc/asteroid/basalt/wasteland,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating/lavaland_baseturf,
 /area/ruin/unpowered/elephant_graveyard)
 "Ql" = (
 /obj/structure/barricade/wooden,
 /obj/item/paper/fluff/ruins/elephant_graveyard,
 /turf/open/misc/asteroid/basalt/wasteland,
 /area/ruin/unpowered/elephant_graveyard)
-"SR" = (
-/obj/structure/sign/warning/no_smoking/circle,
-/turf/closed/wall/mineral/titanium,
-/area/ruin/powered/graveyard_shuttle)
+"Qo" = (
+/obj/structure/statue/bone/rib{
+	dir = 1;
+	pixel_x = -5
+	},
+/turf/open/misc/asteroid/basalt/wasteland,
+/area/ruin/unpowered/elephant_graveyard)
+"SB" = (
+/obj/structure/lattice/catwalk/mining,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/misc/asteroid/basalt/wasteland,
+/area/ruin/unpowered/elephant_graveyard)
+"SJ" = (
+/obj/effect/decal/cleanable/blood/footprints{
+	dir = 8
+	},
+/turf/open/misc/asteroid/basalt/wasteland,
+/area/ruin/unpowered/elephant_graveyard)
 "Td" = (
 /obj/structure/table,
 /obj/structure/cable,
-/obj/item/paper/crumpled/muddy/fluff/elephant_graveyard/rnd_notes,
+/obj/item/paper/crumpled/muddy/fluff/elephant_graveyard/rnd_notes{
+	pixel_y = 11
+	},
+/turf/open/misc/asteroid/basalt/wasteland,
+/area/ruin/unpowered/elephant_graveyard)
+"Tu" = (
+/obj/structure/sign/warning/explosives/directional/north,
+/turf/open/misc/asteroid/basalt/wasteland,
+/area/ruin/unpowered/elephant_graveyard)
+"Ui" = (
+/obj/structure/fluff/minepost,
 /turf/open/misc/asteroid/basalt/wasteland,
 /area/ruin/unpowered/elephant_graveyard)
 "UC" = (
 /obj/structure/table,
-/obj/item/storage/medkit/o2,
+/obj/item/storage/medkit/o2{
+	pixel_y = 8
+	},
 /turf/open/misc/asteroid/basalt/wasteland,
 /area/ruin/unpowered/elephant_graveyard)
 "UE" = (
@@ -560,7 +772,10 @@
 /turf/open/misc/asteroid/basalt/wasteland,
 /area/ruin/unpowered/elephant_graveyard)
 "Vv" = (
-/obj/item/cigbutt,
+/obj/item/cigbutt{
+	pixel_x = -6;
+	pixel_y = -2
+	},
 /turf/open/misc/asteroid/basalt/wasteland,
 /area/ruin/unpowered/elephant_graveyard)
 "VM" = (
@@ -582,8 +797,14 @@
 /area/ruin/unpowered/elephant_graveyard)
 "WW" = (
 /obj/effect/decal/remains/human,
-/obj/item/clothing/under/misc/overalls,
-/obj/item/clothing/mask/bandana/green,
+/obj/item/clothing/under/misc/overalls{
+	pixel_x = -3;
+	pixel_y = -6
+	},
+/obj/item/clothing/mask/bandana/green{
+	pixel_x = 4;
+	pixel_y = 4
+	},
 /turf/open/misc/asteroid/basalt/wasteland,
 /area/ruin/unpowered/elephant_graveyard)
 "WX" = (
@@ -600,12 +821,23 @@
 /turf/open/misc/asteroid/basalt/wasteland,
 /area/ruin/unpowered/elephant_graveyard)
 "XK" = (
-/obj/item/food/deadmouse,
+/obj/item/food/deadmouse{
+	pixel_y = 11;
+	pixel_x = 5
+	},
 /obj/item/assembly/mousetrap,
 /turf/open/misc/asteroid/basalt/wasteland{
 	icon_state = "wasteland_dug"
 	},
 /area/ruin/unpowered/elephant_graveyard)
+"XL" = (
+/obj/effect/turf_decal/delivery/white,
+/obj/item/restraints/handcuffs/cable/zipties/used{
+	pixel_x = 4;
+	pixel_y = -3
+	},
+/turf/open/floor/circuit/off,
+/area/ruin/powered/graveyard_shuttle)
 "XY" = (
 /obj/structure/table,
 /obj/structure/cable,
@@ -623,10 +855,14 @@
 /obj/effect/spawner/structure/window/reinforced/shuttle,
 /turf/open/misc/asteroid/basalt/lava_land_surface,
 /area/ruin/powered/graveyard_shuttle)
-"ZC" = (
-/obj/structure/sign/warning/secure_area,
-/turf/closed/wall/mineral/titanium,
-/area/ruin/powered/graveyard_shuttle)
+"YO" = (
+/obj/structure/flora/ash/leaf_shroom,
+/turf/open/misc/asteroid/basalt/lava_land_surface,
+/area/lavaland/surface)
+"YV" = (
+/obj/structure/flora/rock/pile/style_3,
+/turf/open/misc/asteroid/basalt/lava_land_surface,
+/area/lavaland/surface)
 "ZH" = (
 /obj/structure/stone_tile/surrounding_tile,
 /turf/open/misc/asteroid/basalt/wasteland{
@@ -801,9 +1037,9 @@ gB
 bf
 bf
 bf
-gu
-dr
-bJ
+aA
+LV
+aA
 bf
 bf
 bf
@@ -831,12 +1067,12 @@ bf
 bf
 bf
 aA
-bc
 aA
-LN
-gB
+aA
+aA
+mI
 WW
-gB
+gu
 Xe
 gB
 gB
@@ -868,16 +1104,16 @@ bf
 lK
 Br
 Br
-Br
+tm
 PN
-gB
+NA
 gB
 tf
 gB
 gB
-gB
-gB
-bK
+aA
+Tu
+aA
 bf
 bf
 bf
@@ -906,7 +1142,7 @@ Br
 Cn
 gB
 gB
-gB
+NA
 Cn
 Eh
 gB
@@ -988,7 +1224,7 @@ Kj
 wp
 gB
 gB
-gB
+eu
 gB
 dr
 bf
@@ -1016,8 +1252,8 @@ gB
 WX
 gB
 Dw
-Dw
-Dw
+Qo
+qW
 Dw
 gB
 gB
@@ -1052,14 +1288,14 @@ Xe
 gB
 gB
 gB
-gB
+tf
 ZH
 do
 Bf
 gB
 do
 gB
-nA
+nW
 gB
 gB
 cZ
@@ -1081,14 +1317,14 @@ ac
 (13,1,1) = {"
 bf
 uy
-gB
+Ui
 bf
 Xe
 Br
 gB
 gB
 gB
-gB
+tf
 AI
 gB
 tf
@@ -1102,7 +1338,7 @@ Cn
 gB
 Xe
 gB
-gB
+NA
 bf
 bf
 gB
@@ -1127,18 +1363,18 @@ gB
 iR
 gB
 Ou
+Gc
+Hz
 Ou
-Ou
-Ou
-gB
-gB
+zY
+zY
 tf
 gB
 gB
 UE
 gB
 gB
-dr
+eQ
 MI
 bf
 Xe
@@ -1163,8 +1399,8 @@ gB
 gB
 gB
 gB
-gB
-gB
+NA
+uS
 gB
 gB
 gB
@@ -1176,10 +1412,10 @@ gB
 gB
 gB
 gB
-Br
+tm
 bf
 ac
-gB
+Ui
 gB
 dr
 ac
@@ -1199,13 +1435,13 @@ Br
 Br
 Br
 gB
-gB
-dr
-gB
+SB
+zw
+SB
 Cn
 gB
 km
-gB
+eu
 gB
 gB
 gB
@@ -1242,7 +1478,7 @@ mH
 kQ
 JT
 gB
-gB
+zY
 km
 gB
 km
@@ -1250,7 +1486,7 @@ gB
 gB
 dr
 Xe
-Br
+JD
 bf
 bf
 ac
@@ -1278,7 +1514,7 @@ rb
 gB
 gB
 wk
-gB
+SJ
 gB
 dr
 gB
@@ -1309,20 +1545,20 @@ zY
 gB
 bf
 gB
-bt
+bf
 XY
 EI
-gB
-gB
+eu
+pl
 UC
 gB
+JD
+Br
+JD
 Br
 Br
 Br
-Br
-Br
-Br
-Br
+JD
 Br
 AT
 bf
@@ -1331,7 +1567,7 @@ ac
 ac
 ac
 ac
-NO
+Ow
 dr
 ac
 ac
@@ -1352,7 +1588,7 @@ lt
 Iz
 Br
 Br
-Br
+cs
 rg
 bf
 ac
@@ -1381,7 +1617,7 @@ ab
 ac
 ac
 bf
-UK
+Ui
 dr
 bf
 bf
@@ -1426,7 +1662,7 @@ bf
 bf
 bf
 bf
-gB
+SJ
 bf
 bf
 bf
@@ -1445,7 +1681,7 @@ ab
 ab
 ab
 ab
-Cu
+ns
 Cu
 "}
 (23,1,1) = {"
@@ -1476,8 +1712,8 @@ ab
 ab
 ab
 ab
-Cu
-Cu
+YO
+EZ
 Cu
 Iy
 Cu
@@ -1499,15 +1735,16 @@ AB
 bf
 aH
 aH
-ZC
+aH
 IR
-ZC
+aH
 aH
 aH
 aH
 Iy
 Cu
 Cu
+GT
 Cu
 Cu
 Cu
@@ -1516,8 +1753,7 @@ Cu
 Cu
 Cu
 Cu
-Cu
-Cu
+da
 ab
 ab
 ab
@@ -1543,15 +1779,15 @@ by
 aH
 aH
 jx
+GT
 Cu
 Cu
 Cu
 Cu
+GT
 Cu
 Cu
-Cu
-Cu
-Cu
+YV
 ab
 ab
 ab
@@ -1573,17 +1809,17 @@ ab
 YM
 aO
 Kg
-bi
+XL
 bp
 bi
 pI
 bE
 aH
 jx
+GT
+GT
 Cu
-Cu
-Cu
-Cu
+KC
 ab
 ab
 ab
@@ -1648,12 +1884,12 @@ ab
 aH
 aH
 aH
-SR
 aH
 aH
 aH
 aH
-Cu
+aH
+EZ
 Cu
 ab
 ab

--- a/_maps/RandomRuins/SpaceRuins/clericden.dmm
+++ b/_maps/RandomRuins/SpaceRuins/clericden.dmm
@@ -56,27 +56,39 @@
 /area/ruin/space)
 "o" = (
 /obj/structure/table/wood/fancy,
-/obj/item/reagent_containers/cup/glass/bottle/holywater,
+/obj/item/reagent_containers/cup/glass/bottle/holywater{
+	pixel_y = 12
+	},
 /turf/open/floor/carpet/airless,
 /area/ruin/space)
 "p" = (
 /obj/structure/table/wood/fancy,
-/obj/item/melee/cleric_mace,
+/obj/item/melee/cleric_mace{
+	pixel_y = 8
+	},
 /turf/open/floor/carpet/airless,
 /area/ruin/space)
 "q" = (
-/obj/effect/decal/cleanable/shreds,
+/obj/effect/decal/cleanable/shreds{
+	pixel_x = 5;
+	pixel_y = -3
+	},
 /turf/open/floor/carpet/airless,
 /area/ruin/space)
 "r" = (
 /obj/effect/decal/cleanable/shreds,
 /obj/effect/decal/remains/human,
-/obj/item/disk/design_disk/cleric_mace,
+/obj/item/disk/design_disk/cleric_mace{
+	pixel_x = -4;
+	pixel_y = 9
+	},
 /obj/structure/trap/cult,
 /turf/open/floor/carpet/airless,
 /area/ruin/space)
 "s" = (
-/obj/effect/decal/cleanable/shreds,
+/obj/effect/decal/cleanable/shreds{
+	pixel_y = -4
+	},
 /turf/open/floor/carpet/royalblack/airless,
 /area/ruin/space)
 "t" = (
@@ -88,7 +100,10 @@
 "v" = (
 /obj/effect/decal/cleanable/blood/splatter,
 /obj/effect/decal/cleanable/blood/footprints,
-/obj/effect/decal/cleanable/shreds,
+/obj/effect/decal/cleanable/shreds{
+	pixel_y = 6;
+	pixel_x = -1
+	},
 /turf/open/floor/carpet/airless,
 /area/ruin/space)
 "w" = (
@@ -105,6 +120,7 @@
 /area/ruin/space)
 "z" = (
 /obj/item/paper/fluff/ruins/clericsden/contact,
+/obj/effect/mapping_helpers/broken_floor,
 /turf/open/floor/plating/airless,
 /area/ruin/space)
 "A" = (
@@ -132,10 +148,6 @@
 /mob/living/basic/construct/proteon/hostile,
 /turf/open/floor/carpet/airless,
 /area/ruin/space)
-"F" = (
-/obj/item/flashlight/flare/torch,
-/turf/open/floor/plating/airless,
-/area/ruin/space)
 "G" = (
 /obj/effect/decal/cleanable/blood/tracks,
 /obj/structure/trap/cult,
@@ -152,7 +164,10 @@
 "J" = (
 /obj/structure/rack,
 /obj/item/tank/internals/emergency_oxygen,
-/obj/item/clothing/mask/breath,
+/obj/item/clothing/mask/breath{
+	pixel_y = 6;
+	pixel_x = 6
+	},
 /turf/open/floor/iron/dark/airless,
 /area/ruin/space)
 "K" = (
@@ -161,6 +176,7 @@
 /area/ruin/space)
 "L" = (
 /obj/machinery/door/airlock/wood,
+/obj/effect/mapping_helpers/broken_floor,
 /turf/open/floor/plating/airless,
 /area/ruin/space)
 "M" = (
@@ -177,6 +193,10 @@
 /obj/structure/barricade/wooden/crude,
 /turf/open/floor/plating/airless,
 /area/ruin/space)
+"P" = (
+/obj/effect/mapping_helpers/burnt_floor,
+/turf/open/floor/plating/airless,
+/area/ruin/space)
 "Q" = (
 /obj/item/book/bible,
 /obj/effect/decal/cleanable/blood,
@@ -191,10 +211,21 @@
 /obj/effect/decal/cleanable/blood/drip,
 /turf/open/misc/asteroid/airless,
 /area/ruin/space)
+"T" = (
+/obj/structure/table/wood,
+/obj/item/flashlight/flare/torch{
+	pixel_y = 14
+	},
+/turf/open/floor/carpet/royalblack/airless,
+/area/ruin/space)
 "U" = (
 /obj/effect/decal/remains/human,
 /obj/item/paper/fluff/ruins/clericsden/warning,
 /turf/open/misc/asteroid/airless,
+/area/ruin/space)
+"Y" = (
+/obj/effect/mapping_helpers/broken_floor,
+/turf/open/floor/plating/airless,
 /area/ruin/space)
 
 (1,1,1) = {"
@@ -305,10 +336,10 @@ i
 R
 e
 x
-m
+Y
 e
 x
-m
+Y
 e
 m
 J
@@ -341,7 +372,7 @@ a
 a
 f
 h
-m
+Y
 o
 q
 u
@@ -381,7 +412,7 @@ S
 a
 b
 d
-m
+P
 n
 s
 t
@@ -389,7 +420,7 @@ n
 A
 C
 n
-A
+T
 C
 n
 H
@@ -408,9 +439,9 @@ x
 z
 e
 x
-F
-e
 m
+e
+Y
 J
 e
 d

--- a/_maps/RandomRuins/SpaceRuins/hellfactory.dmm
+++ b/_maps/RandomRuins/SpaceRuins/hellfactory.dmm
@@ -334,6 +334,11 @@
 /obj/structure/cable,
 /turf/open/floor/iron/grimy,
 /area/ruin/space/has_grav/hellfactoryoffice)
+"aY" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/mapping_helpers/broken_floor,
+/turf/open/floor/plating,
+/area/ruin/space/has_grav/hellfactory)
 "aZ" = (
 /obj/machinery/light/directional/east,
 /turf/open/floor/iron/checker,
@@ -513,15 +518,6 @@
 /obj/structure/window/reinforced/spawner/directional/east,
 /turf/open/floor/plating,
 /area/ruin/space/has_grav/hellfactory)
-"bK" = (
-/obj/structure/rack,
-/obj/item/book/manual/random{
-	pixel_x = 5;
-	pixel_y = 6
-	},
-/obj/item/poster/random_contraband,
-/turf/open/floor/iron,
-/area/ruin/space/has_grav/hellfactory)
 "bL" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
@@ -583,10 +579,6 @@
 /obj/structure/window/reinforced/spawner/directional/east,
 /turf/open/floor/plating,
 /area/ruin/space/has_grav/hellfactory)
-"bZ" = (
-/obj/machinery/door/puzzle/keycard/stockroom,
-/turf/open/floor/iron/dark,
-/area/ruin/space/has_grav/hellfactory)
 "ca" = (
 /obj/machinery/door/airlock,
 /turf/open/floor/iron,
@@ -624,6 +616,18 @@
 	dispensable_reagents = list(/datum/reagent/blood);
 	reagent_id = /datum/reagent/blood
 	},
+/turf/open/floor/iron,
+/area/ruin/space/has_grav/hellfactory)
+"cg" = (
+/obj/effect/spawner/random/food_or_drink/donkpockets{
+	pixel_x = -6;
+	pixel_y = 13
+	},
+/obj/item/stack/package_wrap{
+	pixel_y = 4
+	},
+/obj/item/stack/wrapping_paper,
+/obj/structure/rack,
 /turf/open/floor/iron,
 /area/ruin/space/has_grav/hellfactory)
 "ch" = (
@@ -677,6 +681,7 @@
 /area/ruin/space/has_grav/hellfactory)
 "cr" = (
 /obj/structure/closet/crate/trashcart,
+/obj/item/storage/toolbox/emergency/old,
 /turf/open/floor/plating,
 /area/ruin/space/has_grav/hellfactory)
 "cs" = (
@@ -685,38 +690,38 @@
 /turf/open/floor/iron,
 /area/ruin/space/has_grav/hellfactory)
 "cu" = (
-/obj/effect/turf_decal{
+/obj/effect/mapping_helpers/broken_floor,
+/obj/effect/turf_decal/stripes/line{
 	dir = 9
 	},
-/obj/effect/mapping_helpers/broken_floor,
 /turf/open/floor/plating,
 /area/ruin/space/has_grav/hellfactory)
 "cv" = (
-/obj/effect/turf_decal{
+/obj/effect/turf_decal/caution/stand_clear/white,
+/obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
-/obj/effect/turf_decal/caution/stand_clear/white,
 /turf/open/floor/plating,
 /area/ruin/space/has_grav/hellfactory)
 "cw" = (
-/obj/effect/turf_decal{
+/obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
 /turf/open/floor/plating,
 /area/ruin/space/has_grav/hellfactory)
 "cx" = (
-/obj/effect/turf_decal{
-	dir = 1
-	},
 /obj/effect/turf_decal/caution/stand_clear/white,
 /obj/effect/mapping_helpers/broken_floor,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
 /turf/open/floor/plating,
 /area/ruin/space/has_grav/hellfactory)
 "cy" = (
-/obj/effect/turf_decal{
+/obj/item/stack/tile/iron/base,
+/obj/effect/turf_decal/stripes/line{
 	dir = 5
 	},
-/obj/item/stack/tile/iron/base,
 /turf/open/floor/plating,
 /area/ruin/space/has_grav/hellfactory)
 "cz" = (
@@ -726,6 +731,15 @@
 /area/ruin/space/has_grav/hellfactory)
 "cA" = (
 /obj/item/trash/raisins,
+/obj/item/crowbar/large/emergency{
+	pixel_x = -6;
+	pixel_y = 6
+	},
+/obj/effect/decal/cleanable/shreds{
+	pixel_x = -11;
+	pixel_y = 9
+	},
+/obj/effect/mapping_helpers/burnt_floor,
 /turf/open/floor/plating,
 /area/ruin/space/has_grav/hellfactory)
 "cB" = (
@@ -763,17 +777,7 @@
 /turf/open/floor/plating,
 /area/ruin/space/has_grav/hellfactory)
 "cL" = (
-/obj/item/bedsheet/brown{
-	dir = 4
-	},
-/obj/structure/bed{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/ruin/space/has_grav/hellfactory)
-"cM" = (
-/obj/item/storage/toolbox/emergency/old,
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/mapping_helpers/broken_floor,
 /turf/open/floor/plating,
 /area/ruin/space/has_grav/hellfactory)
 "cN" = (
@@ -821,7 +825,8 @@
 /area/ruin/space/has_grav/hellfactory)
 "hk" = (
 /obj/machinery/atmospherics/components/tank/water_vapor{
-	dir = 8
+	dir = 8;
+	pixel_y = 12
 	},
 /obj/machinery/light/small/directional/north,
 /turf/open/floor/iron/grimy,
@@ -830,11 +835,22 @@
 /obj/effect/decal/cleanable/blood/old,
 /turf/open/floor/plastic,
 /area/ruin/space/has_grav/hellfactory)
+"ih" = (
+/mob/living/basic/mouse,
+/turf/open/floor/iron,
+/area/ruin/space/has_grav/hellfactory)
 "iE" = (
 /obj/structure/closet/crate,
 /obj/item/stack/sheet/glass,
 /obj/item/reagent_containers/cup/glass/flask,
 /turf/open/floor/iron,
+/area/ruin/space/has_grav/hellfactory)
+"jl" = (
+/obj/machinery/door/puzzle/keycard/stockroom{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/box,
+/turf/open/floor/plating,
 /area/ruin/space/has_grav/hellfactory)
 "lP" = (
 /obj/item/chair/plastic{
@@ -938,22 +954,28 @@
 	},
 /turf/open/floor/iron,
 /area/ruin/space/has_grav/hellfactory)
+"AA" = (
+/obj/item/weldingtool/empty{
+	pixel_y = 10;
+	pixel_x = -7
+	},
+/turf/open/floor/plating,
+/area/ruin/space/has_grav/hellfactory)
 "BA" = (
 /obj/machinery/light/directional/north,
+/obj/item/book/manual/random{
+	pixel_x = 5;
+	pixel_y = 6
+	},
+/obj/structure/rack,
+/obj/item/poster/random_contraband,
+/obj/machinery/door/window/half/left/directional/west,
 /turf/open/floor/iron,
 /area/ruin/space/has_grav/hellfactory)
 "BC" = (
 /obj/machinery/light/floor,
 /obj/effect/turf_decal/bot_white/left,
 /turf/open/floor/iron/dark,
-/area/ruin/space/has_grav/hellfactory)
-"Fs" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/table,
-/obj/machinery/microwave{
-	pixel_y = 11
-	},
-/turf/open/floor/iron,
 /area/ruin/space/has_grav/hellfactory)
 "FL" = (
 /obj/effect/decal/cleanable/dirt,
@@ -1003,6 +1025,10 @@
 "NU" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/sign/poster/random/directional/north,
+/obj/item/reagent_containers/cup/glass/bottle/hooch{
+	pixel_x = -6;
+	pixel_y = 5
+	},
 /turf/open/floor/plating,
 /area/ruin/space/has_grav/hellfactory)
 "OJ" = (
@@ -1017,17 +1043,23 @@
 /obj/machinery/light/small/directional/north,
 /turf/open/floor/iron/checker,
 /area/ruin/space/has_grav/hellfactory)
-"QS" = (
-/obj/structure/rack,
-/obj/item/stack/wrapping_paper,
-/obj/item/stack/package_wrap{
-	pixel_y = 8
-	},
-/obj/effect/spawner/random/food_or_drink/donkpockets,
-/turf/open/floor/iron,
-/area/ruin/space/has_grav/hellfactory)
 "RX" = (
 /obj/structure/sign/warning/chem_diamond/directional/north,
+/turf/open/floor/iron,
+/area/ruin/space/has_grav/hellfactory)
+"Sg" = (
+/obj/item/bedsheet/brown{
+	dir = 4
+	},
+/obj/structure/bed/maint,
+/mob/living/basic/mouse,
+/turf/open/floor/plating,
+/area/ruin/space/has_grav/hellfactory)
+"Sw" = (
+/obj/machinery/microwave{
+	pixel_y = 11
+	},
+/obj/structure/table,
 /turf/open/floor/iron,
 /area/ruin/space/has_grav/hellfactory)
 "Sz" = (
@@ -1273,7 +1305,7 @@ ah
 ac
 zr
 aA
-aA
+ih
 by
 by
 by
@@ -1437,7 +1469,7 @@ aW
 ac
 BA
 aA
-bK
+aA
 aL
 ca
 aL
@@ -1462,9 +1494,9 @@ ah
 aA
 bn
 aW
-aA
+Sw
 bL
-Fs
+bL
 aL
 cb
 aL
@@ -1488,17 +1520,17 @@ ao
 ah
 aB
 bL
-bZ
+ac
+cg
 aA
 aA
-QS
 aL
 cc
 aL
 xK
 ac
 ac
-aW
+jl
 ac
 aW
 aa
@@ -1526,7 +1558,7 @@ aW
 ac
 Zh
 cA
-by
+AA
 ab
 aa
 aa
@@ -1577,10 +1609,10 @@ ab
 OX
 iE
 qK
-by
+cL
 Sz
 by
-cM
+Wh
 cN
 aa
 aa
@@ -1606,7 +1638,7 @@ aL
 ab
 ab
 NU
-Wh
+aY
 by
 ab
 mh
@@ -1634,7 +1666,7 @@ aA
 by
 Wh
 cO
-by
+cL
 ab
 aa
 aa
@@ -1659,7 +1691,7 @@ aB
 ab
 as
 aL
-by
+Sg
 cl
 by
 ab

--- a/_maps/RandomRuins/SpaceRuins/hellfactory.dmm
+++ b/_maps/RandomRuins/SpaceRuins/hellfactory.dmm
@@ -69,7 +69,9 @@
 /area/ruin/space/has_grav/hellfactoryoffice)
 "al" = (
 /obj/structure/table/reinforced,
-/obj/item/storage/cans/sixbeer,
+/obj/item/storage/cans/sixbeer{
+	pixel_y = 12
+	},
 /turf/open/floor/iron/grimy,
 /area/ruin/space/has_grav/hellfactoryoffice)
 "an" = (
@@ -82,7 +84,9 @@
 /area/ruin/space/has_grav/hellfactoryoffice)
 "ap" = (
 /obj/structure/table/reinforced,
-/obj/machinery/computer/security/wooden_tv,
+/obj/machinery/computer/security/wooden_tv{
+	pixel_y = 16
+	},
 /turf/open/floor/iron/grimy,
 /area/ruin/space/has_grav/hellfactoryoffice)
 "aq" = (
@@ -90,12 +94,17 @@
 	name = "bossman's hologrid";
 	reward = /obj/item/stack/spacecash/c10000
 	},
+/obj/machinery/light/small/directional/north,
 /turf/open/floor/iron/grimy,
 /area/ruin/space/has_grav/hellfactoryoffice)
 "ar" = (
 /obj/structure/closet/crate,
-/obj/item/stack/sheet/iron/five,
-/obj/item/grenade/firecracker,
+/obj/item/stack/sheet/iron/five{
+	pixel_x = -3
+	},
+/obj/item/grenade/firecracker{
+	pixel_x = 4
+	},
 /turf/open/floor/iron,
 /area/ruin/space/has_grav/hellfactory)
 "as" = (
@@ -104,8 +113,13 @@
 /area/ruin/space/has_grav/hellfactory)
 "at" = (
 /obj/structure/closet/crate/preopen,
-/obj/item/reagent_containers/cup/beaker/large,
-/obj/item/reagent_containers/cup/beaker/large,
+/obj/item/reagent_containers/cup/beaker/large{
+	pixel_x = 6;
+	pixel_y = 3
+	},
+/obj/item/reagent_containers/cup/beaker/large{
+	pixel_x = -4
+	},
 /turf/open/floor/plating,
 /area/ruin/space/has_grav/hellfactory)
 "au" = (
@@ -162,7 +176,9 @@
 /turf/open/floor/iron/grimy,
 /area/ruin/space/has_grav/hellfactoryoffice)
 "az" = (
-/obj/item/trash/raisins,
+/obj/item/trash/raisins{
+	pixel_x = -9
+	},
 /turf/open/floor/iron/grimy,
 /area/ruin/space/has_grav/hellfactoryoffice)
 "aA" = (
@@ -186,33 +202,47 @@
 /turf/open/floor/iron/grimy,
 /area/ruin/space/has_grav/hellfactoryoffice)
 "aF" = (
-/obj/item/trash/can,
+/obj/item/trash/can{
+	pixel_x = -16
+	},
 /turf/open/floor/iron/grimy,
 /area/ruin/space/has_grav/hellfactoryoffice)
 "aG" = (
 /obj/structure/table/reinforced,
-/obj/item/storage/cans/sixsoda,
+/obj/item/storage/cans/sixsoda{
+	pixel_y = 12
+	},
 /turf/open/floor/iron/grimy,
 /area/ruin/space/has_grav/hellfactoryoffice)
 "aH" = (
 /obj/structure/table/reinforced,
-/obj/item/trash/popcorn,
+/obj/item/trash/popcorn{
+	pixel_y = 5;
+	pixel_x = 16
+	},
 /turf/open/floor/iron/grimy,
 /area/ruin/space/has_grav/hellfactoryoffice)
 "aI" = (
 /obj/structure/table/reinforced,
-/obj/item/gps/spaceruin,
+/obj/item/gps/spaceruin{
+	pixel_y = 14;
+	pixel_x = -2
+	},
 /turf/open/floor/iron/grimy,
 /area/ruin/space/has_grav/hellfactoryoffice)
 "aJ" = (
 /obj/structure/table/reinforced,
-/obj/item/trash/candle,
+/obj/item/trash/candle{
+	pixel_y = 12
+	},
 /obj/structure/cable,
 /turf/open/floor/iron/grimy,
 /area/ruin/space/has_grav/hellfactoryoffice)
 "aK" = (
 /obj/structure/table/reinforced,
-/obj/item/rsf,
+/obj/item/rsf{
+	pixel_y = 13
+	},
 /turf/open/floor/iron/grimy,
 /area/ruin/space/has_grav/hellfactoryoffice)
 "aL" = (
@@ -280,13 +310,10 @@
 /area/ruin/space/has_grav/hellfactoryoffice)
 "aS" = (
 /obj/structure/closet/crate,
-/obj/item/stack/package_wrap,
+/obj/effect/spawner/random/exotic/languagebook{
+	pixel_x = -2
+	},
 /turf/open/floor/plating,
-/area/ruin/space/has_grav/hellfactory)
-"aT" = (
-/obj/effect/mine/gas/water_vapor,
-/obj/machinery/door/window/left/directional/south,
-/turf/open/floor/plastic,
 /area/ruin/space/has_grav/hellfactory)
 "aU" = (
 /turf/open/floor/plastic,
@@ -326,8 +353,12 @@
 /area/ruin/space/has_grav/hellfactory)
 "be" = (
 /obj/structure/table,
-/obj/item/paper_bin/carbon,
-/obj/effect/decal/cleanable/cobweb,
+/obj/item/paper_bin/carbon{
+	pixel_y = 8
+	},
+/obj/effect/decal/cleanable/cobweb{
+	pixel_y = 12
+	},
 /turf/open/floor/iron,
 /area/ruin/space/has_grav/hellfactory)
 "bf" = (
@@ -353,9 +384,11 @@
 /obj/item/stamp/denied,
 /obj/item/stamp{
 	pixel_x = 6;
-	pixel_y = 6
+	pixel_y = 11
 	},
-/obj/structure/window/spawner/directional/west,
+/obj/structure/railing{
+	dir = 8
+	},
 /turf/open/floor/iron,
 /area/ruin/space/has_grav/hellfactory)
 "bn" = (
@@ -368,7 +401,9 @@
 /turf/open/floor/plating,
 /area/ruin/space/has_grav/hellfactory)
 "bp" = (
-/obj/structure/chair/plastic,
+/obj/structure/chair/plastic{
+	pixel_y = 8
+	},
 /turf/open/floor/iron,
 /area/ruin/space/has_grav/hellfactory)
 "br" = (
@@ -376,11 +411,11 @@
 	reward = /obj/item/keycard/office
 	},
 /obj/structure/cable,
-/turf/open/floor/plating,
+/turf/open/floor/carpet/lone,
 /area/ruin/space/has_grav/hellfactory)
 "bs" = (
 /obj/machinery/conveyor/auto,
-/obj/structure/window/reinforced/spawner/directional/west,
+/obj/machinery/light/small/directional/west,
 /turf/open/floor/plating,
 /area/ruin/space/has_grav/hellfactory)
 "bt" = (
@@ -396,7 +431,6 @@
 /obj/machinery/conveyor/auto{
 	dir = 8
 	},
-/obj/structure/window/reinforced/spawner/directional/north,
 /turf/open/floor/plating,
 /area/ruin/space/has_grav/hellfactory)
 "bv" = (
@@ -409,15 +443,26 @@
 /area/ruin/space/has_grav/hellfactory)
 "bw" = (
 /obj/structure/table,
-/obj/structure/window/spawner/directional/west,
-/obj/item/pen/fourcolor,
+/obj/item/pen/fourcolor{
+	pixel_y = 6
+	},
+/obj/structure/railing{
+	dir = 8
+	},
+/obj/item/clothing/glasses/science{
+	pixel_y = -5
+	},
 /turf/open/floor/iron,
 /area/ruin/space/has_grav/hellfactory)
 "bx" = (
 /obj/structure/table,
-/obj/item/storage/toolbox/mechanical,
-/obj/structure/window/spawner/directional/west,
-/obj/structure/window/spawner/directional/south,
+/obj/item/storage/toolbox/mechanical{
+	pixel_y = 13;
+	pixel_x = 4
+	},
+/obj/structure/railing{
+	dir = 10
+	},
 /turf/open/floor/iron,
 /area/ruin/space/has_grav/hellfactory)
 "by" = (
@@ -426,7 +471,6 @@
 "bB" = (
 /obj/structure/fermenting_barrel,
 /obj/machinery/conveyor/auto,
-/obj/structure/window/reinforced/spawner/directional/west,
 /turf/open/floor/plating,
 /area/ruin/space/has_grav/hellfactory)
 "bC" = (
@@ -435,10 +479,6 @@
 	dir = 1
 	},
 /obj/structure/window/reinforced/spawner/directional/east,
-/turf/open/floor/plating,
-/area/ruin/space/has_grav/hellfactory)
-"bD" = (
-/obj/effect/turf_decal/arrows,
 /turf/open/floor/plating,
 /area/ruin/space/has_grav/hellfactory)
 "bE" = (
@@ -457,9 +497,7 @@
 "bG" = (
 /obj/structure/closet/crate,
 /obj/machinery/conveyor/auto,
-/obj/structure/window/reinforced/spawner/directional/west,
-/obj/item/reagent_containers/cup/glass/flask,
-/obj/item/stack/sheet/glass,
+/obj/effect/spawner/random/engineering/material_rare,
 /turf/open/floor/plating,
 /area/ruin/space/has_grav/hellfactory)
 "bH" = (
@@ -472,16 +510,15 @@
 /obj/machinery/conveyor/auto{
 	dir = 1
 	},
-/turf/open/floor/plating,
-/area/ruin/space/has_grav/hellfactory)
-"bJ" = (
-/obj/effect/turf_decal/delivery,
+/obj/structure/window/reinforced/spawner/directional/east,
 /turf/open/floor/plating,
 /area/ruin/space/has_grav/hellfactory)
 "bK" = (
-/obj/machinery/light/directional/south,
 /obj/structure/rack,
-/obj/item/book/manual/random,
+/obj/item/book/manual/random{
+	pixel_x = 5;
+	pixel_y = 6
+	},
 /obj/item/poster/random_contraband,
 /turf/open/floor/iron,
 /area/ruin/space/has_grav/hellfactory)
@@ -499,13 +536,6 @@
 "bN" = (
 /obj/structure/ore_box,
 /obj/machinery/conveyor/auto,
-/obj/structure/window/reinforced/spawner/directional/west,
-/turf/open/floor/plating,
-/area/ruin/space/has_grav/hellfactory)
-"bP" = (
-/obj/effect/turf_decal/arrows{
-	dir = 1
-	},
 /turf/open/floor/plating,
 /area/ruin/space/has_grav/hellfactory)
 "bR" = (
@@ -525,7 +555,6 @@
 	dir = 4
 	},
 /obj/structure/window/reinforced/spawner/directional/south,
-/obj/structure/window/reinforced/spawner/directional/west,
 /turf/open/floor/plating,
 /area/ruin/space/has_grav/hellfactory)
 "bU" = (
@@ -563,7 +592,6 @@
 /turf/open/floor/iron,
 /area/ruin/space/has_grav/hellfactory)
 "cb" = (
-/obj/machinery/light/small/directional/south,
 /obj/structure/curtain,
 /obj/structure/mirror/directional/north,
 /turf/open/floor/holofloor/wood,
@@ -571,6 +599,7 @@
 "cc" = (
 /obj/structure/bed,
 /obj/effect/spawner/random/bedsheet,
+/obj/machinery/light/small/directional/north,
 /turf/open/floor/holofloor/wood,
 /area/ruin/space/has_grav/hellfactory)
 "cd" = (
@@ -603,7 +632,6 @@
 /turf/open/floor/iron,
 /area/ruin/space/has_grav/hellfactory)
 "ci" = (
-/obj/machinery/light/small/directional/south,
 /obj/effect/decal/remains/human,
 /obj/structure/curtain,
 /obj/structure/mirror/directional/north,
@@ -621,6 +649,7 @@
 /obj/structure/cable,
 /obj/machinery/power/apc/auto_name/directional/north,
 /obj/effect/mapping_helpers/apc/cell_10k,
+/obj/item/stack/tile/iron/base,
 /turf/open/floor/plating,
 /area/ruin/space/has_grav/hellfactory)
 "cn" = (
@@ -673,7 +702,6 @@
 /obj/effect/turf_decal{
 	dir = 1
 	},
-/obj/item/stack/tile/iron/base,
 /turf/open/floor/plating,
 /area/ruin/space/has_grav/hellfactory)
 "cx" = (
@@ -688,7 +716,7 @@
 /obj/effect/turf_decal{
 	dir = 5
 	},
-/obj/structure/broken_flooring/corner/directional/south,
+/obj/item/stack/tile/iron/base,
 /turf/open/floor/plating,
 /area/ruin/space/has_grav/hellfactory)
 "cz" = (
@@ -709,20 +737,8 @@
 /obj/effect/turf_decal/delivery/white,
 /turf/open/floor/iron,
 /area/ruin/space/has_grav/hellfactory)
-"cE" = (
-/obj/structure/sign/warning/docking,
-/turf/closed/wall/rust,
-/area/ruin/space/has_grav/hellfactory)
 "cF" = (
 /obj/effect/turf_decal/delivery/white,
-/obj/machinery/door/poddoor,
-/obj/effect/mapping_helpers/broken_floor,
-/turf/open/floor/plating,
-/area/ruin/space/has_grav/hellfactory)
-"cG" = (
-/obj/effect/turf_decal/delivery/white,
-/obj/effect/turf_decal/delivery/red,
-/obj/item/stack/tile/iron/base,
 /obj/machinery/door/poddoor,
 /obj/effect/mapping_helpers/broken_floor,
 /turf/open/floor/plating,
@@ -737,13 +753,6 @@
 "cI" = (
 /obj/effect/turf_decal/delivery/white,
 /obj/effect/turf_decal/delivery/red,
-/obj/machinery/door/poddoor,
-/obj/effect/mapping_helpers/broken_floor,
-/turf/open/floor/plating,
-/area/ruin/space/has_grav/hellfactory)
-"cJ" = (
-/obj/effect/turf_decal/delivery/white,
-/obj/item/stack/tile/iron/base,
 /obj/machinery/door/poddoor,
 /obj/effect/mapping_helpers/broken_floor,
 /turf/open/floor/plating,
@@ -778,8 +787,9 @@
 /area/ruin/space/has_grav/hellfactory)
 "cP" = (
 /obj/effect/turf_decal/box/white/corners,
-/obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
+/obj/structure/broken_flooring/corner/directional/south,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
 /area/ruin/space/has_grav/hellfactory)
 "cQ" = (
@@ -793,8 +803,10 @@
 /area/ruin/space/has_grav/hellfactory)
 "cV" = (
 /obj/structure/table,
-/obj/item/stack/ducts/fifty,
-/obj/structure/window/spawner/directional/south,
+/obj/item/stack/ducts/fifty{
+	pixel_y = 15
+	},
+/obj/structure/railing,
 /turf/open/floor/iron,
 /area/ruin/space/has_grav/hellfactory)
 "dm" = (
@@ -811,6 +823,7 @@
 /obj/machinery/atmospherics/components/tank/water_vapor{
 	dir = 8
 	},
+/obj/machinery/light/small/directional/north,
 /turf/open/floor/iron/grimy,
 /area/ruin/space/has_grav/hellfactoryoffice)
 "hv" = (
@@ -819,12 +832,9 @@
 /area/ruin/space/has_grav/hellfactory)
 "iE" = (
 /obj/structure/closet/crate,
-/obj/effect/spawner/random/engineering/material_rare,
+/obj/item/stack/sheet/glass,
+/obj/item/reagent_containers/cup/glass/flask,
 /turf/open/floor/iron,
-/area/ruin/space/has_grav/hellfactory)
-"kD" = (
-/obj/structure/sign/poster/random/directional/east,
-/turf/open/floor/iron/checker,
 /area/ruin/space/has_grav/hellfactory)
 "lP" = (
 /obj/item/chair/plastic{
@@ -839,10 +849,10 @@
 /obj/structure/rack,
 /turf/open/floor/iron,
 /area/ruin/space/has_grav/hellfactory)
-"nd" = (
-/obj/structure/sign/warning/vacuum,
-/turf/closed/wall,
-/area/ruin/space/has_grav/hellfactory)
+"mh" = (
+/obj/structure/sign/warning/vacuum/directional/north,
+/turf/template_noop,
+/area/template_noop)
 "oH" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/light/small/directional/west,
@@ -851,19 +861,19 @@
 "oJ" = (
 /turf/open/floor/iron/dark,
 /area/ruin/space/has_grav/hellfactory)
-"oV" = (
-/obj/structure/sign/warning/cold_temp{
-	name = "\improper BLAST FREEZER"
-	},
-/turf/closed/wall/r_wall,
-/area/ruin/space/has_grav/hellfactory)
-"pf" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/sign/poster/random/directional/west,
-/turf/open/floor/iron,
-/area/ruin/space/has_grav/hellfactory)
 "po" = (
 /obj/machinery/light/floor/broken,
+/turf/open/floor/iron,
+/area/ruin/space/has_grav/hellfactory)
+"pT" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/arrows{
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/ruin/space/has_grav/hellfactory)
+"qB" = (
+/obj/effect/turf_decal/delivery,
 /turf/open/floor/iron,
 /area/ruin/space/has_grav/hellfactory)
 "qK" = (
@@ -871,14 +881,18 @@
 /obj/effect/spawner/random/exotic/languagebook,
 /turf/open/floor/iron,
 /area/ruin/space/has_grav/hellfactory)
+"sb" = (
+/obj/structure/sign/poster/ripped/directional/north,
+/turf/open/floor/iron,
+/area/ruin/space/has_grav/hellfactory)
 "sk" = (
 /obj/structure/extinguisher_cabinet/directional/north,
 /turf/open/floor/iron,
 /area/ruin/space/has_grav/hellfactory)
-"ux" = (
-/obj/machinery/light/small/directional/west,
-/turf/open/floor/iron,
-/area/ruin/space/has_grav/hellfactory)
+"sT" = (
+/obj/item/stack/tile/iron/base,
+/turf/template_noop,
+/area/template_noop)
 "uL" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/light/floor,
@@ -891,6 +905,12 @@
 /obj/effect/spawner/random/entertainment/money_large,
 /turf/open/floor/iron,
 /area/ruin/space/has_grav/hellfactory)
+"vI" = (
+/obj/structure/railing/corner/end/flip{
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/ruin/space/has_grav/hellfactory)
 "wv" = (
 /obj/machinery/power/apc/auto_name/directional/north,
 /obj/effect/mapping_helpers/apc/cell_10k,
@@ -901,34 +921,75 @@
 /obj/structure/bed,
 /obj/effect/spawner/random/bedsheet,
 /obj/effect/decal/cleanable/cobweb/cobweb2,
+/obj/machinery/light/small/directional/north,
 /turf/open/floor/holofloor/wood,
+/area/ruin/space/has_grav/hellfactory)
+"zr" = (
+/obj/structure/sign/warning/cold_temp/directional/north,
+/obj/effect/turf_decal/stripes/corner{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron,
+/area/ruin/space/has_grav/hellfactory)
+"zw" = (
+/obj/effect/turf_decal/stripes/corner{
+	dir = 1
+	},
+/turf/open/floor/iron,
+/area/ruin/space/has_grav/hellfactory)
+"BA" = (
+/obj/machinery/light/directional/north,
+/turf/open/floor/iron,
 /area/ruin/space/has_grav/hellfactory)
 "BC" = (
 /obj/machinery/light/floor,
 /obj/effect/turf_decal/bot_white/left,
 /turf/open/floor/iron/dark,
 /area/ruin/space/has_grav/hellfactory)
-"EJ" = (
-/obj/structure/sign/poster/random/directional/west,
-/turf/open/floor/iron,
-/area/ruin/space/has_grav/hellfactory)
 "Fs" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/table,
-/obj/machinery/microwave,
+/obj/machinery/microwave{
+	pixel_y = 11
+	},
+/turf/open/floor/iron,
+/area/ruin/space/has_grav/hellfactory)
+"FL" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/stripes/corner{
+	dir = 1
+	},
 /turf/open/floor/iron,
 /area/ruin/space/has_grav/hellfactory)
 "GE" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/checker,
 /area/ruin/space/has_grav/hellfactory)
-"GU" = (
-/obj/structure/sign/warning/chem_diamond,
-/turf/closed/wall,
+"Is" = (
+/obj/structure/closet/crate,
+/obj/item/stack/package_wrap,
+/turf/open/floor/iron,
+/area/ruin/space/has_grav/hellfactory)
+"IA" = (
+/obj/structure/sign/poster/random/directional/north,
+/turf/open/floor/iron/checker,
+/area/ruin/space/has_grav/hellfactory)
+"Jp" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/arrows{
+	dir = 4
+	},
+/turf/open/floor/iron,
 /area/ruin/space/has_grav/hellfactory)
 "KZ" = (
 /obj/machinery/modular_computer/preset/civilian,
+/obj/machinery/light/small/directional/east,
 /turf/open/floor/iron,
+/area/ruin/space/has_grav/hellfactory)
+"Lz" = (
+/obj/effect/spawner/structure/window/ice,
+/turf/open/floor/plating,
 /area/ruin/space/has_grav/hellfactory)
 "Ns" = (
 /obj/structure/closet/crate,
@@ -936,7 +997,7 @@
 	dir = 1
 	},
 /obj/structure/window/reinforced/spawner/directional/east,
-/obj/effect/spawner/random/exotic/languagebook,
+/obj/effect/spawner/random/engineering/material_rare,
 /turf/open/floor/plating,
 /area/ruin/space/has_grav/hellfactory)
 "NU" = (
@@ -951,15 +1012,22 @@
 /obj/machinery/light/directional/east,
 /turf/open/floor/plastic,
 /area/ruin/space/has_grav/hellfactory)
-"PO" = (
-/obj/machinery/light/small/directional/south,
-/turf/open/floor/plating,
+"OX" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/small/directional/north,
+/turf/open/floor/iron/checker,
 /area/ruin/space/has_grav/hellfactory)
 "QS" = (
 /obj/structure/rack,
 /obj/item/stack/wrapping_paper,
-/obj/item/stack/package_wrap,
+/obj/item/stack/package_wrap{
+	pixel_y = 8
+	},
 /obj/effect/spawner/random/food_or_drink/donkpockets,
+/turf/open/floor/iron,
+/area/ruin/space/has_grav/hellfactory)
+"RX" = (
+/obj/structure/sign/warning/chem_diamond/directional/north,
 /turf/open/floor/iron,
 /area/ruin/space/has_grav/hellfactory)
 "Sz" = (
@@ -977,6 +1045,7 @@
 "Vd" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/marker_beacon/burgundy,
+/obj/structure/sign/warning/docking/directional/north,
 /turf/template_noop,
 /area/ruin/space/has_grav/hellfactory)
 "VN" = (
@@ -987,10 +1056,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
 /area/ruin/space/has_grav/hellfactory)
-"Yd" = (
-/obj/machinery/light/small/directional/south,
-/turf/open/floor/iron/grimy,
-/area/ruin/space/has_grav/hellfactoryoffice)
 "Zh" = (
 /obj/structure/closet/crate/trashcart,
 /obj/item/stack/sheet/mineral/plasma,
@@ -1000,6 +1065,12 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/dark,
 /area/ruin/space/has_grav/hellfactory)
+"ZC" = (
+/obj/item/trash/can{
+	pixel_y = -10
+	},
+/turf/open/floor/iron/grimy,
+/area/ruin/space/has_grav/hellfactoryoffice)
 
 (1,1,1) = {"
 aa
@@ -1090,7 +1161,7 @@ ad
 au
 aC
 aM
-aT
+aV
 ba
 bl
 bl
@@ -1118,9 +1189,9 @@ av
 ab
 aN
 hv
-bb
-aA
-bL
+Lz
+zw
+Jp
 bt
 bb
 bb
@@ -1129,7 +1200,7 @@ bU
 ce
 aA
 bL
-aA
+cf
 cn
 cs
 aW
@@ -1145,15 +1216,15 @@ aw
 aD
 aN
 aU
-bb
-bL
-aA
+Lz
+FL
+qB
 bu
 bb
 bb
 bb
 bV
-cf
+aA
 aA
 aA
 UK
@@ -1173,8 +1244,8 @@ OJ
 aO
 aV
 bc
-bL
-bL
+zw
+pT
 bv
 bC
 bI
@@ -1199,20 +1270,20 @@ ah
 ah
 ah
 ah
-oV
+ac
+zr
 aA
 aA
-aA
-bD
-bJ
-bP
-GU
-aA
+by
+by
+by
+ab
+RX
 aA
 bL
 aA
 po
-cE
+aL
 aW
 Vd
 cQ
@@ -1223,7 +1294,7 @@ aa
 ah
 aj
 az
-aF
+ZC
 aQ
 ah
 be
@@ -1266,8 +1337,8 @@ gu
 by
 by
 cv
-cG
-aa
+cI
+sT
 aa
 aa
 "}
@@ -1278,12 +1349,12 @@ ah
 al
 ao
 aG
-Yd
+ao
 ah
 KZ
-ux
-bL
 aA
+bL
+vI
 Wh
 Wh
 oJ
@@ -1347,7 +1418,7 @@ cz
 cq
 cP
 cy
-cJ
+cF
 aa
 aa
 aa
@@ -1364,8 +1435,8 @@ ah
 ac
 aW
 ac
-by
-by
+BA
+aA
 bK
 aL
 ca
@@ -1374,7 +1445,7 @@ ca
 aL
 cq
 dm
-cE
+aL
 ac
 Vd
 cQ
@@ -1386,13 +1457,13 @@ ah
 ap
 ao
 aK
-Yd
+ao
 ah
 aA
 bn
 aW
-by
-Wh
+aA
+bL
 Fs
 aL
 cb
@@ -1418,8 +1489,8 @@ ah
 aB
 bL
 bZ
-by
-by
+aA
+aA
 QS
 aL
 cc
@@ -1474,16 +1545,16 @@ bo
 aL
 vB
 ab
-aB
+IA
 bR
-PO
+by
 ab
 as
 aL
 cr
 cB
 cL
-nd
+ab
 aa
 aa
 "}
@@ -1499,13 +1570,13 @@ aL
 bk
 aB
 ab
-qK
-EJ
+Is
+aA
 aB
 ab
-GE
+OX
 iE
-iE
+qK
 by
 Sz
 by
@@ -1520,7 +1591,7 @@ aa
 aW
 ab
 bL
-kD
+aB
 aB
 ab
 sk
@@ -1538,7 +1609,7 @@ NU
 Wh
 by
 ab
-aa
+mh
 aa
 "}
 (21,1,1) = {"
@@ -1548,7 +1619,7 @@ ac
 as
 aA
 ab
-aB
+IA
 aA
 bL
 aB
@@ -1558,11 +1629,11 @@ oH
 aB
 ab
 aB
-pf
+bL
 aA
 by
 Wh
-by
+cO
 by
 ab
 aa
@@ -1582,7 +1653,7 @@ aB
 aL
 by
 ab
-aA
+sb
 bS
 aB
 ab
@@ -1590,7 +1661,7 @@ as
 aL
 by
 cl
-cO
+by
 ab
 aa
 aa


### PR DESCRIPTION
## About The Pull Request

Does a quick runthrough of the other half of my ruins, making them compliant with wallening.
This one hits Cleric's Den, Heck Brewery, and the Elephant Graveyard ruins.
Updates table items, moves some items for clarity that were previously covered over in se/sw corners, and moved a few specific, and otherwise made a few low-stakes changes to where items were located so as to keep the vast majority of the ruin unchanged.

There's one or two instances of me adding some basic fluff items to maps but that's mostly because I cannot help myself and With the new perspective there were a few things that should make the maps better given the different space on the map.
Eg: Moving some of the rewards around on the heck brewery ruin, but in return moving the second keycard door around so that the player is expected to see the locked door first, then know to start looking for a keycard as they've already used one on this ruin, to introduce them to the holocrate puzzle.
