### PR TITLE
vehicle offsets

### DIFF
--- a/code/datums/elements/ridable.dm
+++ b/code/datums/elements/ridable.dm
@@ -20,6 +20,9 @@
 	if(!ismovable(target))
 		return COMPONENT_INCOMPATIBLE
 
+	if(!isliving(target))
+		target.pixel_z = WALLENING_OFFSET
+
 	if(component_type == /datum/component/riding)
 		stack_trace("Tried attaching a ridable element to [target] with basic/abstract /datum/component/riding component type. Please designate a specific riding component subtype when adding the ridable element.")
 		return COMPONENT_INCOMPATIBLE
@@ -35,6 +38,8 @@
 		RegisterSignal(target, COMSIG_MOB_STATCHANGE, PROC_REF(on_stat_change))
 
 /datum/element/ridable/Detach(atom/movable/target)
+	if(!isliving(target))
+		target.pixel_z = target.base_pixel_z
 	target.can_buckle = initial(target.can_buckle)
 	UnregisterSignal(target, list(COMSIG_MOVABLE_PREBUCKLE, COMSIG_SPEED_POTION_APPLIED, COMSIG_MOB_STATCHANGE))
 	return ..()

--- a/code/datums/elements/ridable.dm
+++ b/code/datums/elements/ridable.dm
@@ -39,7 +39,6 @@
 		RegisterSignal(target, COMSIG_MOB_STATCHANGE, PROC_REF(on_stat_change))
 
 /datum/element/ridable/Detach(atom/movable/target)
-
 	if(!isliving(target))
 		target.pixel_z = target::pixel_z
 		target.base_pixel_z = target::base_pixel_z

--- a/code/datums/elements/ridable.dm
+++ b/code/datums/elements/ridable.dm
@@ -21,7 +21,7 @@
 		return COMPONENT_INCOMPATIBLE
 
 	if(!isliving(target))
-		target.pixel_z = WALLENING_OFFSET
+		target.pixel_z = DEPTH_OFFSET
 
 	if(component_type == /datum/component/riding)
 		stack_trace("Tried attaching a ridable element to [target] with basic/abstract /datum/component/riding component type. Please designate a specific riding component subtype when adding the ridable element.")

--- a/code/datums/elements/ridable.dm
+++ b/code/datums/elements/ridable.dm
@@ -22,6 +22,7 @@
 
 	if(!isliving(target))
 		target.pixel_z = DEPTH_OFFSET
+		target.base_pixel_z = DEPTH_OFFSET
 
 	if(component_type == /datum/component/riding)
 		stack_trace("Tried attaching a ridable element to [target] with basic/abstract /datum/component/riding component type. Please designate a specific riding component subtype when adding the ridable element.")
@@ -38,8 +39,11 @@
 		RegisterSignal(target, COMSIG_MOB_STATCHANGE, PROC_REF(on_stat_change))
 
 /datum/element/ridable/Detach(atom/movable/target)
+
 	if(!isliving(target))
-		target.pixel_z = target.base_pixel_z
+		target.pixel_z = target::pixel_z
+		target.base_pixel_z = target::base_pixel_z
+
 	target.can_buckle = initial(target.can_buckle)
 	UnregisterSignal(target, list(COMSIG_MOVABLE_PREBUCKLE, COMSIG_SPEED_POTION_APPLIED, COMSIG_MOB_STATCHANGE))
 	return ..()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! --> lets vehicles use the wallening offset to match rider's position. another solution would be instead of giving vehicles this offset, we factor it in when calculating the rider's position. idk which solution would be preferable. also may need to wait for #283
closes #278

## Why It's Good For The Game

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. --> fixes riders not matching vehicle's positions

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and its effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: riders now match their vehicles position
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
