### PR TITLE
fixes RCD built doors not having the correct direction

### DIFF
--- a/code/__DEFINES/construction/rcd.dm
+++ b/code/__DEFINES/construction/rcd.dm
@@ -16,6 +16,9 @@
 /// The typepath of the structure the rcd is trying to build
 #define RCD_DESIGN_PATH "rcd_design_path"
 
+/// The direction of the structure we will build
+#define RCD_BUILD_DIRECTION "rcd_build_direction"
+
 /// Time taken for an rcd hologram to disappear
 #define RCD_HOLOGRAM_FADE_TIME (15 SECONDS)
 

--- a/code/game/atom/atom_act.dm
+++ b/code/game/atom/atom_act.dm
@@ -224,7 +224,7 @@
  * Default behaviour is to send [COMSIG_ATOM_RCD_ACT] and return FALSE
  */
 /atom/proc/rcd_act(mob/user, obj/item/construction/rcd/the_rcd, list/rcd_data)
-	SEND_SIGNAL(src, COMSIG_ATOM_RCD_ACT, user, the_rcd, rcd_data["[RCD_DESIGN_MODE]"])
+	SEND_SIGNAL(src, COMSIG_ATOM_RCD_ACT, user, the_rcd, rcd_data[RCD_DESIGN_MODE])
 	return FALSE
 
 ///Return the values you get when an RCD eats you?

--- a/code/game/machinery/doors/airlock.dm
+++ b/code/game/machinery/doors/airlock.dm
@@ -1658,7 +1658,7 @@
 	return FALSE
 
 /obj/machinery/door/airlock/rcd_act(mob/user, obj/item/construction/rcd/the_rcd, list/rcd_data)
-	switch(rcd_data["[RCD_DESIGN_MODE]"])
+	switch(rcd_data[RCD_DESIGN_MODE])
 		if(RCD_DECONSTRUCT)
 			qdel(src)
 			return TRUE

--- a/code/game/machinery/doors/firedoor.dm
+++ b/code/game/machinery/doors/firedoor.dm
@@ -967,7 +967,7 @@
 	return FALSE
 
 /obj/structure/firelock_frame/rcd_act(mob/user, obj/item/construction/rcd/the_rcd, list/rcd_data)
-	switch(rcd_data["[RCD_DESIGN_MODE]"])
+	switch(rcd_data[RCD_DESIGN_MODE])
 		if(RCD_UPGRADE_SIMPLE_CIRCUITS)
 			user.balloon_alert(user, "circuit installed")
 			constructionStep = CONSTRUCTION_PANEL_OPEN

--- a/code/game/machinery/doors/windowdoor.dm
+++ b/code/game/machinery/doors/windowdoor.dm
@@ -510,7 +510,7 @@
 	return FALSE
 
 /obj/machinery/door/window/rcd_act(mob/user, obj/item/construction/rcd/the_rcd, list/rcd_data)
-	if(rcd_data["[RCD_DESIGN_MODE]"] == RCD_DECONSTRUCT)
+	if(rcd_data[RCD_DESIGN_MODE] == RCD_DECONSTRUCT)
 		qdel(src)
 		return TRUE
 	return FALSE

--- a/code/game/machinery/firealarm.dm
+++ b/code/game/machinery/firealarm.dm
@@ -405,7 +405,7 @@
 	return FALSE
 
 /obj/machinery/firealarm/rcd_act(mob/user, obj/item/construction/rcd/the_rcd, list/rcd_data)
-	switch(rcd_data["[RCD_DESIGN_MODE]"])
+	switch(rcd_data[RCD_DESIGN_MODE])
 		if(RCD_WALLFRAME)
 			balloon_alert(user, "circuit installed")
 			buildstage = FIRE_ALARM_BUILD_NO_WIRES

--- a/code/game/objects/items/rcd/RCD.dm
+++ b/code/game/objects/items/rcd/RCD.dm
@@ -65,9 +65,9 @@
 	design_category = GLOB.rcd_designs[root_category][1]
 	var/list/design = GLOB.rcd_designs[root_category][design_category][1]
 
-	rcd_design_path = design["[RCD_DESIGN_PATH]"]
+	rcd_design_path = design[RCD_DESIGN_PATH]
 	design_title = initial(rcd_design_path.name)
-	mode = design["[RCD_DESIGN_MODE]"]
+	mode = design[RCD_DESIGN_MODE]
 	construction_mode = mode
 
 	GLOB.rcd_list += src
@@ -96,12 +96,12 @@
 	mode = RCD_TURF
 	user.visible_message(span_suicide("[user] sets the RCD to 'Wall' and points it down [user.p_their()] throat! It looks like [user.p_theyre()] trying to commit suicide!"))
 	if(checkResource(16, user)) // It takes 16 resources to construct a wall
-		var/success = T.rcd_act(user, src, list("[RCD_DESIGN_MODE]" = RCD_TURF, "[RCD_DESIGN_PATH]" = /turf/open/floor/plating/rcd, "[RCD_BUILD_DIRECTION]" = selected_direction))
+		var/success = T.rcd_act(user, src, list(RCD_DESIGN_MODE = RCD_TURF, RCD_DESIGN_PATH = /turf/open/floor/plating/rcd, RCD_BUILD_DIRECTION = selected_direction))
 		T = get_turf(user)
 		// If the RCD placed a floor instead of a wall, having a wall without plating under it is cursed
 		// There isn't an easy programmatical way to check if rcd_act will place a floor or a wall, so just repeat using it for free
 		if(success && isopenturf(T))
-			T.rcd_act(user, src, list("[RCD_DESIGN_MODE]" = RCD_TURF, "[RCD_DESIGN_PATH]" = /turf/open/floor/plating/rcd))
+			T.rcd_act(user, src, list(RCD_DESIGN_MODE = RCD_TURF, RCD_DESIGN_PATH = /turf/open/floor/plating/rcd))
 		useResource(16, user)
 		activate()
 		playsound(loc, 'sound/machines/click.ogg', 50, 1)
@@ -120,8 +120,8 @@
  * * [mob][user]- the user
  */
 /obj/item/construction/rcd/proc/can_place(atom/target, list/rcd_results, mob/user)
-	var/rcd_mode = rcd_results["[RCD_DESIGN_MODE]"]
-	var/atom/movable/rcd_structure = rcd_results["[RCD_DESIGN_PATH]"]
+	var/rcd_mode = rcd_results[RCD_DESIGN_MODE]
+	var/atom/movable/rcd_structure = rcd_results[RCD_DESIGN_PATH]
 	/**
 	 *For anything that does not go an a wall we have to make sure that turf is clear for us to put the structure on it
 	 *If we are just trying to destory something then this check is not nessassary
@@ -214,9 +214,9 @@
 	var/list/rcd_results = target.rcd_vals(user, src)
 	if(!rcd_results)
 		return FALSE
-	rcd_results["[RCD_DESIGN_MODE]"] = mode
-	rcd_results["[RCD_DESIGN_PATH]"] = rcd_design_path
-	rcd_results["[RCD_BUILD_DIRECTION]"] = selected_direction || user.dir
+	rcd_results[RCD_DESIGN_MODE] = mode
+	rcd_results[RCD_DESIGN_PATH] = rcd_design_path
+	rcd_results[RCD_BUILD_DIRECTION] = selected_direction || user.dir
 
 	var/delay = rcd_results["delay"] * delay_mod
 	if (
@@ -230,10 +230,10 @@
 
 	var/target_name = target.name //Store this information before it gets mutated by the rcd.
 	var/target_path = target.type
-	var/atom/design_path = rcd_results["[RCD_DESIGN_PATH]"]
+	var/atom/design_path = rcd_results[RCD_DESIGN_PATH]
 	var/location = AREACOORD(target)
 	if(_rcd_create_effect(target, user, delay, rcd_results))
-		log_tool("[key_name(user)] used [src] to [rcd_results["[RCD_DESIGN_MODE]"] != RCD_DECONSTRUCT ? "construct [initial(design_path.name)]([design_path])" : "deconstruct [target_name]([target_path])"] at [location]")
+		log_tool("[key_name(user)] used [src] to [rcd_results[RCD_DESIGN_MODE] != RCD_DECONSTRUCT ? "construct [initial(design_path.name)]([design_path])" : "deconstruct [target_name]([target_path])"] at [location]")
 
 	current_active_effects -= 1
 
@@ -247,7 +247,7 @@
  * * rcd_results- list of params which contains the cost & build mode to create the structure
  */
 /obj/item/construction/rcd/proc/_rcd_create_effect(atom/target, mob/user, delay, list/rcd_results)
-	var/obj/effect/constructing_effect/rcd_effect = new(get_turf(target), delay, rcd_results["[RCD_DESIGN_MODE]"], upgrade)
+	var/obj/effect/constructing_effect/rcd_effect = new(get_turf(target), delay, rcd_results[RCD_DESIGN_MODE], upgrade)
 
 	//resource & structure placement sanity checks before & after delay along with beam effects
 	if(!checkResource(rcd_results["cost"], user) || !can_place(target, rcd_results, user))
@@ -354,7 +354,7 @@
 
 		if("select_direction")
 			var/new_dir = text2dir(params["selected_direction"])
-			selected_direction = (isnull(new_dir) || new_dir == selected_direction) ? null : new_dir
+			selected_direction = (isnull(new_dir) || new_dir == selected_direction || !(new_dir in GLOB.cardinals)) ? null : new_dir
 			return TRUE
 
 		if("design")
@@ -384,9 +384,9 @@
 			if(design == null) //not a valid design
 				return TRUE
 			design_category = category_name
-			mode = design["[RCD_DESIGN_MODE]"]
+			mode = design[RCD_DESIGN_MODE]
 			construction_mode = mode
-			rcd_design_path = design["[RCD_DESIGN_PATH]"]
+			rcd_design_path = design[RCD_DESIGN_PATH]
 			design_title = initial(rcd_design_path.name)
 			blueprint_changed = TRUE
 

--- a/code/game/objects/items/rcd/RCD.dm
+++ b/code/game/objects/items/rcd/RCD.dm
@@ -29,7 +29,8 @@
 	var/construction_mode
 	/// The path of the structure the rcd is currently creating
 	var/atom/movable/rcd_design_path
-
+	///our currently selected direction
+	var/selected_direction
 	/// Owner of this rcd. It can either be a construction console, player, or mech.
 	var/atom/owner
 	/// used by arcd, can this rcd work from a range
@@ -95,7 +96,7 @@
 	mode = RCD_TURF
 	user.visible_message(span_suicide("[user] sets the RCD to 'Wall' and points it down [user.p_their()] throat! It looks like [user.p_theyre()] trying to commit suicide!"))
 	if(checkResource(16, user)) // It takes 16 resources to construct a wall
-		var/success = T.rcd_act(user, src, list("[RCD_DESIGN_MODE]" = RCD_TURF, "[RCD_DESIGN_PATH]" = /turf/open/floor/plating/rcd))
+		var/success = T.rcd_act(user, src, list("[RCD_DESIGN_MODE]" = RCD_TURF, "[RCD_DESIGN_PATH]" = /turf/open/floor/plating/rcd, "[RCD_BUILD_DIRECTION]" = selected_direction))
 		T = get_turf(user)
 		// If the RCD placed a floor instead of a wall, having a wall without plating under it is cursed
 		// There isn't an easy programmatical way to check if rcd_act will place a floor or a wall, so just repeat using it for free
@@ -215,6 +216,7 @@
 		return FALSE
 	rcd_results["[RCD_DESIGN_MODE]"] = mode
 	rcd_results["[RCD_DESIGN_PATH]"] = rcd_design_path
+	rcd_results["[RCD_BUILD_DIRECTION]"] = selected_direction || user.dir
 
 	var/delay = rcd_results["delay"] * delay_mod
 	if (
@@ -332,6 +334,7 @@
 	//main categories
 	data["selected_category"] = design_category
 	data["selected_design"] = design_title
+	data["selected_direction"] = dir2text(selected_direction)
 
 	//merge airlock_electronics ui data with this
 	var/list/airlock_data = airlock_electronics.ui_data(user)
@@ -348,6 +351,11 @@
 			if(GLOB.rcd_designs[new_root] != null) //is a valid category
 				root_category = new_root
 				update_static_data_for_all_viewers()
+
+		if("select_direction")
+			var/new_dir = text2dir(params["selected_direction"])
+			selected_direction = (isnull(new_dir) || new_dir == selected_direction) ? null : new_dir
+			return TRUE
 
 		if("design")
 			//read and validate params from UI

--- a/code/game/objects/structures/door_assembly.dm
+++ b/code/game/objects/structures/door_assembly.dm
@@ -377,7 +377,7 @@
 	return FALSE
 
 /obj/structure/door_assembly/rcd_act(mob/user, obj/item/construction/rcd/the_rcd, list/rcd_data)
-	if(rcd_data["[RCD_DESIGN_MODE]"] == RCD_DECONSTRUCT)
+	if(rcd_data[RCD_DESIGN_MODE] == RCD_DECONSTRUCT)
 		qdel(src)
 		return TRUE
 	return FALSE

--- a/code/game/objects/structures/girders.dm
+++ b/code/game/objects/structures/girders.dm
@@ -491,7 +491,7 @@
 	return FALSE
 
 /obj/structure/girder/rcd_act(mob/user, obj/item/construction/rcd/the_rcd, list/rcd_data)
-	switch(rcd_data["[RCD_DESIGN_MODE]"])
+	switch(rcd_data[RCD_DESIGN_MODE])
 		if(RCD_TURF)
 			if(the_rcd.rcd_design_path != /turf/open/floor/plating/rcd)
 				return FALSE

--- a/code/game/objects/structures/grille.dm
+++ b/code/game/objects/structures/grille.dm
@@ -137,11 +137,11 @@
 
 			//checks if its a valid build direction
 			if(!initial(window_path.fulltile))
-				if(!valid_build_direction(loc, user.dir, is_fulltile = FALSE))
+				if(!valid_build_direction(loc, rcd_data["[RCD_BUILD_DIRECTION]"], is_fulltile = FALSE))
 					balloon_alert(user, "window already here!")
 					return FALSE
 
-			var/obj/structure/window/WD = new window_path(T, user.dir)
+			var/obj/structure/window/WD = new window_path(T, rcd_data["[RCD_BUILD_DIRECTION]"])
 			WD.set_anchored(TRUE)
 			return TRUE
 	return FALSE

--- a/code/game/objects/structures/grille.dm
+++ b/code/game/objects/structures/grille.dm
@@ -117,7 +117,7 @@
 	return FALSE
 
 /obj/structure/grille/rcd_act(mob/user, obj/item/construction/rcd/the_rcd, list/rcd_data)
-	switch(rcd_data["[RCD_DESIGN_MODE]"])
+	switch(rcd_data[RCD_DESIGN_MODE])
 		if(RCD_DECONSTRUCT)
 			qdel(src)
 			return TRUE
@@ -131,17 +131,17 @@
 			if(!clear_tile(user))
 				return FALSE
 
-			var/obj/structure/window/window_path = rcd_data["[RCD_DESIGN_PATH]"]
+			var/obj/structure/window/window_path = rcd_data[RCD_DESIGN_PATH]
 			if(!ispath(window_path))
 				CRASH("Invalid window path type in RCD: [window_path]")
 
 			//checks if its a valid build direction
 			if(!initial(window_path.fulltile))
-				if(!valid_build_direction(loc, rcd_data["[RCD_BUILD_DIRECTION]"], is_fulltile = FALSE))
+				if(!valid_build_direction(loc, rcd_data[RCD_BUILD_DIRECTION], is_fulltile = FALSE))
 					balloon_alert(user, "window already here!")
 					return FALSE
 
-			var/obj/structure/window/WD = new window_path(T, rcd_data["[RCD_BUILD_DIRECTION]"])
+			var/obj/structure/window/WD = new window_path(T, rcd_data[RCD_BUILD_DIRECTION])
 			WD.set_anchored(TRUE)
 			return TRUE
 	return FALSE

--- a/code/game/objects/structures/lattice.dm
+++ b/code/game/objects/structures/lattice.dm
@@ -67,8 +67,8 @@
 	return FALSE
 
 /obj/structure/lattice/rcd_act(mob/user, obj/item/construction/rcd/the_rcd, list/rcd_data)
-	if(rcd_data["[RCD_DESIGN_MODE]"] == RCD_TURF)
-		var/design_structure = rcd_data["[RCD_DESIGN_PATH]"]
+	if(rcd_data[RCD_DESIGN_MODE] == RCD_TURF)
+		var/design_structure = rcd_data[RCD_DESIGN_PATH]
 		if(design_structure == /turf/open/floor/plating)
 			var/turf/T = src.loc
 			if(isgroundlessturf(T))

--- a/code/game/objects/structures/tables_racks.dm
+++ b/code/game/objects/structures/tables_racks.dm
@@ -354,7 +354,7 @@
 	return FALSE
 
 /obj/structure/table/rcd_act(mob/user, obj/item/construction/rcd/the_rcd, list/rcd_data)
-	if(rcd_data["[RCD_DESIGN_MODE]"] == RCD_DECONSTRUCT)
+	if(rcd_data[RCD_DESIGN_MODE] == RCD_DECONSTRUCT)
 		qdel(src)
 		return TRUE
 	return FALSE

--- a/code/game/objects/structures/windows/window.dm
+++ b/code/game/objects/structures/windows/window.dm
@@ -126,7 +126,7 @@
 	return FALSE
 
 /obj/structure/window/rcd_act(mob/user, obj/item/construction/rcd/the_rcd, list/rcd_data)
-	if(rcd_data["[RCD_DESIGN_MODE]"] == RCD_DECONSTRUCT)
+	if(rcd_data[RCD_DESIGN_MODE] == RCD_DECONSTRUCT)
 		qdel(src)
 		return TRUE
 	return FALSE

--- a/code/game/turfs/closed/wall/reinf_walls.dm
+++ b/code/game/turfs/closed/wall/reinf_walls.dm
@@ -221,7 +221,7 @@
 
 
 /turf/closed/wall/r_wall/rcd_act(mob/user, obj/item/construction/rcd/the_rcd, list/rcd_data)
-	if(the_rcd.canRturf || rcd_data["[RCD_DESIGN_MODE]"] == RCD_WALLFRAME)
+	if(the_rcd.canRturf || rcd_data[RCD_DESIGN_MODE] == RCD_WALLFRAME)
 		return ..()
 
 /turf/closed/wall/r_wall/rust_turf()

--- a/code/game/turfs/closed/walls.dm
+++ b/code/game/turfs/closed/walls.dm
@@ -340,9 +340,9 @@
 	return FALSE
 
 /turf/closed/wall/rcd_act(mob/user, obj/item/construction/rcd/the_rcd, list/rcd_data)
-	switch(rcd_data["[RCD_DESIGN_MODE]"])
+	switch(rcd_data[RCD_DESIGN_MODE])
 		if(RCD_WALLFRAME)
-			var/obj/item/wallframe/wallmount = rcd_data["[RCD_DESIGN_PATH]"]
+			var/obj/item/wallframe/wallmount = rcd_data[RCD_DESIGN_PATH]
 			var/obj/item/wallframe/new_wallmount = new wallmount(user.drop_location())
 			return try_wallmount(new_wallmount, user, src)
 		if(RCD_DECONSTRUCT)

--- a/code/game/turfs/open/chasm.dm
+++ b/code/game/turfs/open/chasm.dm
@@ -42,7 +42,7 @@
 	return FALSE
 
 /turf/open/chasm/rcd_act(mob/user, obj/item/construction/rcd/the_rcd, list/rcd_data)
-	if(rcd_data["[RCD_DESIGN_MODE]"] == RCD_TURF && rcd_data["[RCD_DESIGN_PATH]"] == /turf/open/floor/plating/rcd)
+	if(rcd_data[RCD_DESIGN_MODE] == RCD_TURF && rcd_data[RCD_DESIGN_PATH] == /turf/open/floor/plating/rcd)
 		place_on_top(/turf/open/floor/plating, flags = CHANGETURF_INHERIT_AIR)
 		return TRUE
 	return FALSE

--- a/code/game/turfs/open/floor.dm
+++ b/code/game/turfs/open/floor.dm
@@ -283,10 +283,10 @@
 
 			//allow directional windows to be built without grills
 			if(!initial(window_path.fulltile))
-				if(!valid_build_direction(src, user.dir, is_fulltile = FALSE))
+				if(!valid_build_direction(src, rcd_data["[RCD_BUILD_DIRECTION]"], is_fulltile = FALSE))
 					balloon_alert(user, "window already here!")
 					return FALSE
-				var/obj/structure/window/WD = new window_path(src, user.dir)
+				var/obj/structure/window/WD = new window_path(src, rcd_data["[RCD_BUILD_DIRECTION]"])
 				WD.set_anchored(TRUE)
 				return TRUE
 
@@ -300,7 +300,7 @@
 			var/obj/machinery/door/airlock_type = rcd_data["[RCD_DESIGN_PATH]"]
 
 			if(ispath(airlock_type, /obj/machinery/door/window))
-				if(!valid_build_direction(src, user.dir, is_fulltile = FALSE))
+				if(!valid_build_direction(src, rcd_data["[RCD_BUILD_DIRECTION]"], is_fulltile = FALSE))
 					balloon_alert(user, "there's already a windoor!")
 					return FALSE
 				for(var/obj/machinery/door/door in src)
@@ -309,7 +309,7 @@
 					balloon_alert(user, "there's already a door!")
 					return FALSE
 				//create the assembly and let it finish itself
-				var/obj/structure/windoor_assembly/assembly = new (src, user.dir)
+				var/obj/structure/windoor_assembly/assembly = new (src, rcd_data["[RCD_BUILD_DIRECTION]"])
 				assembly.secure = ispath(airlock_type, /obj/machinery/door/window/brigdoor)
 				assembly.electronics = the_rcd.airlock_electronics.create_copy(assembly)
 				assembly.finish_door()
@@ -328,8 +328,10 @@
 			else
 				assembly.airlock_type = airlock_type
 			assembly.electronics = the_rcd.airlock_electronics.create_copy(assembly)
-			assembly.finish_door()
+			var/atom/new_door = assembly.finish_door()
+			new_door?.setDir(rcd_data["[RCD_BUILD_DIRECTION]"])
 			return TRUE
+
 		if(RCD_STRUCTURE)
 			var/atom/movable/design_type = rcd_data["[RCD_DESIGN_PATH]"]
 
@@ -352,7 +354,7 @@
 				/obj/structure/bed,
 			)
 			if(is_path_in_list(locate_type, dir_types))
-				design.setDir(user.dir)
+				design.setDir(rcd_data["[RCD_BUILD_DIRECTION]"])
 			return TRUE
 		if(RCD_DECONSTRUCT)
 			if(rcd_proof)

--- a/code/game/turfs/open/floor.dm
+++ b/code/game/turfs/open/floor.dm
@@ -264,9 +264,9 @@
 
 /// if you are updating this make to to update /turf/open/misc/rcd_act() too
 /turf/open/floor/rcd_act(mob/user, obj/item/construction/rcd/the_rcd, list/rcd_data)
-	switch(rcd_data["[RCD_DESIGN_MODE]"])
+	switch(rcd_data[RCD_DESIGN_MODE])
 		if(RCD_TURF)
-			if(rcd_data["[RCD_DESIGN_PATH]"] != /turf/open/floor/plating/rcd)
+			if(rcd_data[RCD_DESIGN_PATH] != /turf/open/floor/plating/rcd)
 				return FALSE
 
 			var/obj/structure/girder/girder = locate() in src
@@ -277,16 +277,16 @@
 			return TRUE
 		if(RCD_WINDOWGRILLE)
 			//check if we are building a window
-			var/obj/structure/window/window_path = rcd_data["[RCD_DESIGN_PATH]"]
+			var/obj/structure/window/window_path = rcd_data[RCD_DESIGN_PATH]
 			if(!ispath(window_path))
 				CRASH("Invalid window path type in RCD: [window_path]")
 
 			//allow directional windows to be built without grills
 			if(!initial(window_path.fulltile))
-				if(!valid_build_direction(src, rcd_data["[RCD_BUILD_DIRECTION]"], is_fulltile = FALSE))
+				if(!valid_build_direction(src, rcd_data[RCD_BUILD_DIRECTION], is_fulltile = FALSE))
 					balloon_alert(user, "window already here!")
 					return FALSE
-				var/obj/structure/window/WD = new window_path(src, rcd_data["[RCD_BUILD_DIRECTION]"])
+				var/obj/structure/window/WD = new window_path(src, rcd_data[RCD_BUILD_DIRECTION])
 				WD.set_anchored(TRUE)
 				return TRUE
 
@@ -297,10 +297,10 @@
 			new_grille.set_anchored(TRUE)
 			return TRUE
 		if(RCD_AIRLOCK)
-			var/obj/machinery/door/airlock_type = rcd_data["[RCD_DESIGN_PATH]"]
+			var/obj/machinery/door/airlock_type = rcd_data[RCD_DESIGN_PATH]
 
 			if(ispath(airlock_type, /obj/machinery/door/window))
-				if(!valid_build_direction(src, rcd_data["[RCD_BUILD_DIRECTION]"], is_fulltile = FALSE))
+				if(!valid_build_direction(src, rcd_data[RCD_BUILD_DIRECTION], is_fulltile = FALSE))
 					balloon_alert(user, "there's already a windoor!")
 					return FALSE
 				for(var/obj/machinery/door/door in src)
@@ -309,7 +309,7 @@
 					balloon_alert(user, "there's already a door!")
 					return FALSE
 				//create the assembly and let it finish itself
-				var/obj/structure/windoor_assembly/assembly = new (src, rcd_data["[RCD_BUILD_DIRECTION]"])
+				var/obj/structure/windoor_assembly/assembly = new (src, rcd_data[RCD_BUILD_DIRECTION])
 				assembly.secure = ispath(airlock_type, /obj/machinery/door/window/brigdoor)
 				assembly.electronics = the_rcd.airlock_electronics.create_copy(assembly)
 				assembly.finish_door()
@@ -329,11 +329,11 @@
 				assembly.airlock_type = airlock_type
 			assembly.electronics = the_rcd.airlock_electronics.create_copy(assembly)
 			var/atom/new_door = assembly.finish_door()
-			new_door?.setDir(rcd_data["[RCD_BUILD_DIRECTION]"])
+			new_door?.setDir(rcd_data[RCD_BUILD_DIRECTION])
 			return TRUE
 
 		if(RCD_STRUCTURE)
-			var/atom/movable/design_type = rcd_data["[RCD_DESIGN_PATH]"]
+			var/atom/movable/design_type = rcd_data[RCD_DESIGN_PATH]
 
 			//map absolute types to basic subtypes
 			var/atom/movable/locate_type = design_type
@@ -354,7 +354,7 @@
 				/obj/structure/bed,
 			)
 			if(is_path_in_list(locate_type, dir_types))
-				design.setDir(rcd_data["[RCD_BUILD_DIRECTION]"])
+				design.setDir(rcd_data[RCD_BUILD_DIRECTION])
 			return TRUE
 		if(RCD_DECONSTRUCT)
 			if(rcd_proof)

--- a/code/game/turfs/open/floor/plating.dm
+++ b/code/game/turfs/open/floor/plating.dm
@@ -166,7 +166,7 @@
 		return list("delay" = 0, "cost" = 1)
 
 /turf/open/floor/plating/foam/rcd_act(mob/user, obj/item/construction/rcd/the_rcd, list/rcd_data)
-	if(rcd_data["[RCD_DESIGN_MODE]"] == RCD_TURF && rcd_data["[RCD_DESIGN_PATH]"] == /turf/open/floor/plating/rcd)
+	if(rcd_data[RCD_DESIGN_MODE] == RCD_TURF && rcd_data[RCD_DESIGN_PATH] == /turf/open/floor/plating/rcd)
 		ChangeTurf(/turf/open/floor/plating, flags = CHANGETURF_INHERIT_AIR)
 		return TRUE
 	return FALSE

--- a/code/game/turfs/open/lava.dm
+++ b/code/game/turfs/open/lava.dm
@@ -165,7 +165,7 @@
 	return FALSE
 
 /turf/open/lava/rcd_act(mob/user, obj/item/construction/rcd/the_rcd, list/rcd_data)
-	if(rcd_data["[RCD_DESIGN_MODE]"] == RCD_TURF && rcd_data["[RCD_DESIGN_PATH]"] == /turf/open/floor/plating/rcd)
+	if(rcd_data[RCD_DESIGN_MODE] == RCD_TURF && rcd_data[RCD_DESIGN_PATH] == /turf/open/floor/plating/rcd)
 		place_on_top(/turf/open/floor/plating, flags = CHANGETURF_INHERIT_AIR)
 		return TRUE
 	return FALSE

--- a/code/game/turfs/open/misc.dm
+++ b/code/game/turfs/open/misc.dm
@@ -84,8 +84,8 @@
 	return FALSE
 
 /turf/open/misc/rcd_act(mob/user, obj/item/construction/rcd/the_rcd, list/rcd_data)
-	if(rcd_data["[RCD_DESIGN_MODE]"] == RCD_TURF)
-		if(rcd_data["[RCD_DESIGN_PATH]"] != /turf/open/floor/plating/rcd)
+	if(rcd_data[RCD_DESIGN_MODE] == RCD_TURF)
+		if(rcd_data[RCD_DESIGN_PATH] != /turf/open/floor/plating/rcd)
 			return FALSE
 
 		place_on_top(/turf/open/floor/plating, flags = CHANGETURF_INHERIT_AIR)

--- a/code/game/turfs/open/openspace.dm
+++ b/code/game/turfs/open/openspace.dm
@@ -145,7 +145,7 @@
 	return FALSE
 
 /turf/open/openspace/rcd_act(mob/user, obj/item/construction/rcd/the_rcd, list/rcd_data)
-	if(rcd_data["[RCD_DESIGN_MODE]"] == RCD_TURF && rcd_data["[RCD_DESIGN_PATH]"] == /turf/open/floor/plating/rcd)
+	if(rcd_data[RCD_DESIGN_MODE] == RCD_TURF && rcd_data[RCD_DESIGN_PATH] == /turf/open/floor/plating/rcd)
 		place_on_top(/turf/open/floor/plating, flags = CHANGETURF_INHERIT_AIR)
 		return TRUE
 	return FALSE

--- a/code/game/turfs/open/space/space.dm
+++ b/code/game/turfs/open/space/space.dm
@@ -229,10 +229,10 @@ GLOBAL_LIST_EMPTY(starlight)
 
 /turf/open/space/rcd_act(mob/user, obj/item/construction/rcd/the_rcd, list/rcd_data)
 	if(the_rcd.mode == RCD_TURF)
-		if(rcd_data["[RCD_DESIGN_PATH]"] == /turf/open/floor/plating/rcd)
+		if(rcd_data[RCD_DESIGN_PATH] == /turf/open/floor/plating/rcd)
 			place_on_top(/turf/open/floor/plating, flags = CHANGETURF_INHERIT_AIR)
 			return TRUE
-		else if(rcd_data["[RCD_DESIGN_PATH]"] == /obj/structure/lattice/catwalk)
+		else if(rcd_data[RCD_DESIGN_PATH] == /obj/structure/lattice/catwalk)
 			var/obj/structure/lattice/lattice = locate(/obj/structure/lattice, src)
 			if(lattice)
 				qdel(lattice)

--- a/code/modules/atmospherics/machinery/air_alarm/air_alarm_interact.dm
+++ b/code/modules/atmospherics/machinery/air_alarm/air_alarm_interact.dm
@@ -51,7 +51,7 @@
 	return FALSE
 
 /obj/machinery/airalarm/rcd_act(mob/user, obj/item/construction/rcd/the_rcd, list/rcd_data)
-	if(rcd_data["[RCD_DESIGN_MODE]"] == RCD_WALLFRAME)
+	if(rcd_data[RCD_DESIGN_MODE] == RCD_WALLFRAME)
 		balloon_alert(user, "circuit installed")
 		buildstage = AIR_ALARM_BUILD_NO_WIRES
 		update_appearance()

--- a/code/modules/power/apc/apc_tool_act.dm
+++ b/code/modules/power/apc/apc_tool_act.dm
@@ -396,7 +396,7 @@
 	return FALSE
 
 /obj/machinery/power/apc/rcd_act(mob/user, obj/item/construction/rcd/the_rcd, list/rcd_data)
-	if(!(the_rcd.upgrade & RCD_UPGRADE_SIMPLE_CIRCUITS) || rcd_data["[RCD_DESIGN_MODE]"] != RCD_WALLFRAME)
+	if(!(the_rcd.upgrade & RCD_UPGRADE_SIMPLE_CIRCUITS) || rcd_data[RCD_DESIGN_MODE] != RCD_WALLFRAME)
 		return FALSE
 
 	if(!has_electronics)

--- a/tgui/packages/tgui/interfaces/RapidConstructionDevice.tsx
+++ b/tgui/packages/tgui/interfaces/RapidConstructionDevice.tsx
@@ -3,7 +3,15 @@ import { capitalizeAll } from 'common/string';
 import { useState } from 'react';
 
 import { useBackend } from '../backend';
-import { Box, Button, LabeledList, Section, Stack, Tabs } from '../components';
+import {
+  Box,
+  Button,
+  Flex,
+  LabeledList,
+  Section,
+  Stack,
+  Tabs,
+} from '../components';
 import { Window } from '../layouts';
 import { AirLockMainSection } from './AirlockElectronics';
 
@@ -16,6 +24,7 @@ type Data = {
   categories: Category[];
   selected_category: string;
   selected_design: string;
+  selected_direction: string;
   display_tabs: BooleanLike;
 };
 
@@ -36,6 +45,71 @@ export const MatterItem = (props) => {
     <LabeledList.Item label="Units Left">
       &nbsp;{matterLeft} Units
     </LabeledList.Item>
+  );
+};
+
+export const DirectionsList = (props) => {
+  const { data, act } = useBackend<Data>();
+  const { matterLeft, selected_direction } = data;
+  return (
+    <Flex>
+      <Flex.Item mt={2}>
+        <Button
+          selected={selected_direction === 'west'}
+          color="transparent"
+          icon="arrow-left"
+          width="20px"
+          onClick={() =>
+            act('select_direction', {
+              selected_direction: 'west',
+            })
+          }
+        />
+      </Flex.Item>
+      <Flex.Item>
+        <Stack vertical>
+          <Stack.Item>
+            <Button
+              selected={selected_direction === 'north'}
+              color="transparent"
+              icon="arrow-up"
+              width="20px"
+              onClick={() =>
+                act('select_direction', {
+                  selected_direction: 'north',
+                })
+              }
+            />
+          </Stack.Item>
+          <Stack.Item>
+            <Button
+              selected={selected_direction === 'south'}
+              color="transparent"
+              width="20px"
+              icon="arrow-down"
+              onClick={() =>
+                act('select_direction', {
+                  selected_direction: 'south',
+                })
+              }
+            />
+          </Stack.Item>
+        </Stack>
+      </Flex.Item>
+      <Flex.Item mt={2}>
+        <Button
+          selected={selected_direction === 'east'}
+          color="transparent"
+          icon="arrow-right"
+          width="20px"
+          onClick={() =>
+            act('select_direction', {
+              selected_direction: 'east',
+            })
+          }
+        />
+      </Flex.Item>
+    </Flex>
   );
 };
 
@@ -78,11 +152,18 @@ export const InfoSection = (props) => {
 
   return (
     <Section>
-      <LabeledList>
-        <MatterItem />
-        {silo_upgraded ? <SiloItem /> : ''}
-        <CategoryItem />
-      </LabeledList>
+      <Flex>
+        <Flex.Item>
+          <LabeledList>
+            <MatterItem />
+            {silo_upgraded ? <SiloItem /> : ''}
+            <CategoryItem />
+          </LabeledList>
+        </Flex.Item>
+        <Flex.Item mt={-1}>
+          <DirectionsList />
+        </Flex.Item>
+      </Flex>
     </Section>
   );
 };


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! --> fixes rcd built doors. also as a bonus, i added a little qol where players can select the direction of objects they want to build through the ui
![image](https://github.com/user-attachments/assets/64621e25-d58b-4917-a2c5-474d5224b5b4)
if no direction is selected (or deselected), built objects will inherit the player's direction as they do now. if this QOL is out of scope i can remove it and just leave the fix