### PR TITLE
Arcane's Ruins Work part 3 (more lavaland ruins, cat-surgeon den)

### DIFF
--- a/_maps/RandomRuins/LavaRuins/lavaland_surface_gluttony.dmm
+++ b/_maps/RandomRuins/LavaRuins/lavaland_surface_gluttony.dmm
@@ -34,9 +34,18 @@
 	dir = 8
 	},
 /obj/structure/table/wood,
-/obj/item/food/meat/slab/human/mutant/lizard,
-/obj/item/food/meat/slab/human/mutant/lizard,
-/obj/item/food/meat/slab/human/mutant/lizard,
+/obj/item/food/meat/slab/human/mutant/lizard{
+	pixel_x = 3;
+	pixel_y = 2
+	},
+/obj/item/food/meat/slab/human/mutant/lizard{
+	pixel_y = 10;
+	pixel_x = -3
+	},
+/obj/item/food/meat/slab/human/mutant/lizard{
+	pixel_y = 17;
+	pixel_x = 5
+	},
 /turf/open/indestructible/necropolis,
 /area/ruin/powered/gluttony)
 "eb" = (
@@ -46,13 +55,16 @@
 /obj/structure/table/wood,
 /obj/item/food/meat/slab/corgi{
 	pixel_x = 3;
-	pixel_y = 1
+	pixel_y = 4
 	},
 /obj/item/food/meat/slab/corgi{
 	pixel_x = 5;
-	pixel_y = 5
+	pixel_y = 18
 	},
-/obj/item/knife/combat/bone,
+/obj/item/knife/combat/bone{
+	pixel_y = 10;
+	pixel_x = -4
+	},
 /turf/open/indestructible/necropolis,
 /area/ruin/powered/gluttony)
 "eq" = (
@@ -77,7 +89,10 @@
 /area/ruin/powered/gluttony)
 "fa" = (
 /obj/structure/table/wood,
-/obj/item/food/meat/slab/human,
+/obj/item/food/meat/slab/human{
+	pixel_y = 13;
+	pixel_x = -4
+	},
 /obj/structure/stone_tile/block/cracked{
 	dir = 8
 	},
@@ -111,7 +126,9 @@
 /turf/open/misc/asteroid/basalt/lava_land_surface,
 /area/lavaland/surface/outdoors)
 "ie" = (
-/obj/item/veilrender/vealrender,
+/obj/item/veilrender/vealrender{
+	pixel_y = 4
+	},
 /obj/structure/stone_tile/slab/cracked{
 	dir = 6
 	},
@@ -155,8 +172,13 @@
 	dir = 1
 	},
 /obj/structure/table/wood,
-/obj/item/spear/bonespear,
-/obj/item/slime_extract/silver,
+/obj/item/spear/bonespear{
+	pixel_y = 9
+	},
+/obj/item/slime_extract/silver{
+	pixel_y = 12;
+	pixel_x = -7
+	},
 /turf/open/indestructible/necropolis,
 /area/ruin/powered/gluttony)
 "ls" = (
@@ -224,6 +246,12 @@
 /area/ruin/powered/gluttony)
 "rg" = (
 /obj/structure/stone_tile/block/burnt,
+/obj/item/clothing/gloves/butchering{
+	pixel_x = -2;
+	pixel_y = 6
+	},
+/obj/effect/mob_spawn/corpse/human/miner,
+/obj/effect/decal/cleanable/blood,
 /turf/open/indestructible/necropolis,
 /area/ruin/powered/gluttony)
 "vU" = (
@@ -260,8 +288,14 @@
 	dir = 1
 	},
 /obj/structure/table/wood,
-/obj/item/food/meat/slab/goliath,
-/obj/item/food/meat/slab/human/mutant/ethereal,
+/obj/item/food/meat/slab/goliath{
+	pixel_y = 5;
+	pixel_x = 4
+	},
+/obj/item/food/meat/slab/human/mutant/ethereal{
+	pixel_y = 15;
+	pixel_x = -9
+	},
 /turf/open/indestructible/necropolis,
 /area/ruin/powered/gluttony)
 "zd" = (
@@ -282,7 +316,7 @@
 	dir = 4
 	},
 /obj/effect/decal/cleanable/blood/tracks{
-	dir = 5
+	dir = 8
 	},
 /turf/open/indestructible/necropolis,
 /area/ruin/powered/gluttony)
@@ -354,8 +388,6 @@
 /obj/structure/stone_tile/slab/cracked{
 	dir = 1
 	},
-/obj/effect/mob_spawn/corpse/human/miner,
-/obj/item/clothing/gloves/butchering,
 /turf/open/indestructible/necropolis,
 /area/ruin/powered/gluttony)
 "IM" = (
@@ -491,7 +523,9 @@
 	dir = 8
 	},
 /obj/structure/table/wood,
-/obj/item/food/meat/slab/human/mutant/moth,
+/obj/item/food/meat/slab/human/mutant/moth{
+	pixel_y = 10
+	},
 /turf/open/indestructible/necropolis,
 /area/ruin/powered/gluttony)
 "WR" = (
@@ -504,9 +538,6 @@
 "YG" = (
 /obj/structure/stone_tile/block/burnt{
 	dir = 4
-	},
-/obj/effect/decal/cleanable/blood/tracks{
-	dir = 10
 	},
 /turf/open/indestructible/necropolis,
 /area/ruin/powered/gluttony)

--- a/_maps/RandomRuins/LavaRuins/lavaland_surface_phonebooth.dmm
+++ b/_maps/RandomRuins/LavaRuins/lavaland_surface_phonebooth.dmm
@@ -13,13 +13,13 @@
 /area/ruin/powered/lavaland_phone_booth)
 "k" = (
 /obj/machinery/vending/snack/green{
-	onstation_override = 1
+	onstation_override = 1;
+	pixel_y = 16
 	},
 /obj/structure/window/reinforced/spawner/directional/east,
 /turf/open/floor/plating/lavaland_atmos,
 /area/ruin/powered/lavaland_phone_booth)
 "q" = (
-/obj/machinery/airalarm/directional/south,
 /obj/effect/turf_decal/tile/yellow/half/contrasted{
 	dir = 4
 	},
@@ -50,6 +50,7 @@
 /obj/machinery/light/small{
 	dir = 1
 	},
+/obj/machinery/airalarm/directional/north,
 /obj/structure/window/reinforced/spawner/directional/west,
 /turf/open/floor/plating/lavaland_atmos,
 /area/ruin/powered/lavaland_phone_booth)
@@ -66,7 +67,8 @@
 /area/ruin/powered/lavaland_phone_booth)
 "W" = (
 /obj/machinery/vending/cigarette{
-	onstation_override = 1
+	onstation_override = 1;
+	pixel_y = 16
 	},
 /obj/structure/window/reinforced/spawner/directional/east,
 /turf/open/floor/plating/lavaland_atmos,

--- a/_maps/RandomRuins/LavaRuins/lavaland_surface_shuttle_wreckage.dmm
+++ b/_maps/RandomRuins/LavaRuins/lavaland_surface_shuttle_wreckage.dmm
@@ -33,13 +33,25 @@
 /obj/effect/mob_spawn/corpse/human/charredskeleton,
 /turf/open/misc/asteroid/basalt/lava_land_surface,
 /area/ruin/unpowered)
+"eu" = (
+/obj/item/stack/sheet/mineral/titanium{
+	pixel_y = 8;
+	pixel_x = 5
+	},
+/obj/effect/mapping_helpers/broken_floor,
+/turf/open/floor/mineral/titanium/yellow{
+	initial_gas_mix = "LAVALAND_ATMOS"
+	},
+/area/ruin/unpowered)
 "eQ" = (
 /obj/item/shard/titanium,
 /obj/effect/decal/cleanable/glass,
 /turf/open/misc/asteroid/basalt/lava_land_surface,
 /area/ruin/unpowered)
 "fy" = (
-/obj/structure/door_assembly/door_assembly_shuttle,
+/obj/structure/door_assembly/door_assembly_shuttle{
+	dir = 4
+	},
 /turf/open/misc/asteroid/basalt/lava_land_surface,
 /area/ruin/unpowered)
 "fz" = (
@@ -165,12 +177,27 @@
 	initial_gas_mix = "LAVALAND_ATMOS"
 	},
 /area/ruin/unpowered)
+"wL" = (
+/obj/item/stack/sheet/mineral/titanium{
+	pixel_y = 9;
+	pixel_x = -3
+	},
+/turf/open/misc/asteroid/basalt/lava_land_surface,
+/area/ruin/unpowered)
 "xz" = (
-/obj/machinery/computer,
+/obj/machinery/computer{
+	layer = 3.6
+	},
 /turf/open/misc/asteroid/basalt/lava_land_surface,
 /area/ruin/unpowered)
 "yZ" = (
 /turf/closed/mineral/volcanic/lava_land_surface,
+/area/ruin/unpowered)
+"zf" = (
+/obj/item/shard/titanium,
+/obj/effect/decal/cleanable/glass,
+/obj/machinery/light/small/directional/west,
+/turf/open/misc/asteroid/basalt/lava_land_surface,
 /area/ruin/unpowered)
 "zk" = (
 /obj/effect/spawner/random/structure/crate,
@@ -202,10 +229,10 @@
 /obj/effect/mapping_helpers/burnt_floor,
 /turf/open/misc/asteroid/basalt/lava_land_surface,
 /area/ruin/unpowered)
-"Dy" = (
-/obj/item/shard/titanium,
-/obj/machinery/light/small/directional/east,
-/obj/effect/mapping_helpers/broken_floor,
+"DK" = (
+/obj/item/stack/sheet/mineral/titanium{
+	pixel_x = -6
+	},
 /turf/open/misc/asteroid/basalt/lava_land_surface,
 /area/ruin/unpowered)
 "DL" = (
@@ -348,10 +375,17 @@
 /obj/structure/table,
 /obj/item/storage/medkit/regular{
 	pixel_x = 2;
-	pixel_y = 3
+	pixel_y = 11
 	},
 /turf/open/misc/asteroid/basalt/lava_land_surface,
 /area/ruin/unpowered)
+"PH" = (
+/obj/item/food/meat/slab/human{
+	pixel_y = 13;
+	pixel_x = -4
+	},
+/turf/closed/mineral/volcanic/lava_land_surface,
+/area/lavaland/surface)
 "Qq" = (
 /obj/effect/mapping_helpers/broken_floor,
 /obj/effect/decal/cleanable/glass,
@@ -393,6 +427,13 @@
 /turf/open/floor/mineral/plastitanium/red{
 	initial_gas_mix = "LAVALAND_ATMOS"
 	},
+/area/ruin/unpowered)
+"Uj" = (
+/obj/item/stack/sheet/iron{
+	pixel_x = 5;
+	pixel_y = -4
+	},
+/turf/open/misc/asteroid/basalt/lava_land_surface,
 /area/ruin/unpowered)
 "Vs" = (
 /obj/item/stack/sheet/mineral/titanium,
@@ -436,6 +477,12 @@
 /turf/open/floor/mineral/titanium/blue{
 	initial_gas_mix = "LAVALAND_ATMOS"
 	},
+/area/ruin/unpowered)
+"ZJ" = (
+/obj/item/stack/sheet/iron{
+	pixel_y = 5
+	},
+/turf/open/misc/asteroid/basalt/lava_land_surface,
 /area/ruin/unpowered)
 
 (1,1,1) = {"
@@ -549,7 +596,7 @@ FL
 FL
 "}
 (6,1,1) = {"
-FL
+PH
 FL
 hT
 yZ
@@ -583,7 +630,7 @@ lu
 Vs
 dK
 Bb
-tp
+Uj
 sE
 Lz
 eQ
@@ -627,10 +674,10 @@ lu
 lu
 lu
 sE
-tp
+ZJ
 se
 FR
-HM
+DK
 yZ
 yZ
 FL
@@ -649,10 +696,10 @@ lu
 lu
 lu
 Ma
-HM
+wL
 Pa
 yZ
-CX
+eu
 yZ
 yZ
 uh
@@ -688,7 +735,7 @@ gP
 VN
 Ee
 Hy
-eQ
+zf
 rE
 rr
 Lz
@@ -734,7 +781,7 @@ lu
 lu
 Rm
 JN
-Dy
+Rm
 On
 Om
 GZ

--- a/_maps/RandomRuins/LavaRuins/lavaland_surface_survivalpod.dmm
+++ b/_maps/RandomRuins/LavaRuins/lavaland_surface_survivalpod.dmm
@@ -47,7 +47,10 @@
 /turf/open/floor/pod/dark,
 /area/ruin/powered)
 "l" = (
-/obj/item/pickaxe,
+/obj/item/pickaxe{
+	pixel_y = -6;
+	pixel_x = -3
+	},
 /obj/effect/decal/cleanable/blood,
 /turf/open/floor/pod/dark,
 /area/ruin/powered)
@@ -69,7 +72,9 @@
 /area/lavaland/surface/outdoors)
 "p" = (
 /obj/structure/table/survival_pod,
-/obj/item/knife/combat/survival,
+/obj/item/knife/combat/survival{
+	pixel_y = 8
+	},
 /turf/open/floor/pod/dark,
 /area/ruin/powered)
 "q" = (
@@ -86,7 +91,10 @@
 /area/ruin/powered)
 "r" = (
 /obj/structure/tubes,
-/obj/item/crowbar,
+/obj/item/crowbar{
+	pixel_x = -4;
+	pixel_y = 4
+	},
 /obj/effect/decal/cleanable/blood/drip,
 /turf/open/floor/pod/dark,
 /area/ruin/powered)

--- a/_maps/RandomRuins/SpaceRuins/clownplanet.dmm
+++ b/_maps/RandomRuins/SpaceRuins/clownplanet.dmm
@@ -29,10 +29,6 @@
 /mob/living/basic/clown/clownhulk/destroyer,
 /turf/open/floor/engine,
 /area/ruin/space/has_grav/powered/clownplanet)
-"ai" = (
-/obj/structure/sign/warning,
-/turf/closed/wall/mineral/sandstone,
-/area/ruin/space/has_grav/powered/clownplanet)
 "aj" = (
 /turf/open/floor/grass{
 	color = "#1eff00"
@@ -43,10 +39,6 @@
 /turf/open/floor/grass{
 	color = "#1eff00"
 	},
-/area/ruin/space/has_grav/powered/clownplanet)
-"al" = (
-/obj/structure/sign/warning/xeno_mining,
-/turf/closed/wall/mineral/sandstone,
 /area/ruin/space/has_grav/powered/clownplanet)
 "am" = (
 /obj/effect/turf_decal/stripes/line{
@@ -195,6 +187,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 5
 	},
+/obj/structure/sign/warning/directional/north,
 /turf/open/floor/grass{
 	color = "#1eff00"
 	},
@@ -209,6 +202,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 9
 	},
+/obj/structure/sign/warning/directional/north,
 /turf/open/floor/grass{
 	color = "#1eff00"
 	},
@@ -232,6 +226,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
+/obj/structure/sign/warning/xeno_mining/directional/north,
 /turf/open/floor/grass{
 	color = "#1eff00"
 	},
@@ -374,6 +369,15 @@
 /obj/structure/barricade/wooden,
 /obj/structure/barricade/wooden/crude,
 /turf/open/misc/asteroid,
+/area/ruin/space/has_grav/powered/clownplanet)
+"VA" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/structure/sign/warning/xeno_mining/directional/north,
+/turf/open/floor/grass{
+	color = "#1eff00"
+	},
 /area/ruin/space/has_grav/powered/clownplanet)
 
 (1,1,1) = {"
@@ -614,7 +618,7 @@ aa
 ae
 ae
 ac
-ai
+af
 aM
 aE
 ak
@@ -641,7 +645,7 @@ ae
 ac
 ad
 af
-al
+af
 aR
 aj
 aj
@@ -653,7 +657,7 @@ av
 av
 at
 aL
-az
+aj
 ab
 aD
 aD
@@ -705,7 +709,7 @@ av
 av
 at
 aL
-aj
+az
 aq
 ab
 aD
@@ -719,8 +723,8 @@ ae
 ad
 ac
 af
-al
-aL
+af
+VA
 au
 aj
 aU
@@ -744,7 +748,7 @@ ae
 ae
 ae
 ac
-ai
+af
 aO
 aP
 aj

--- a/_maps/RandomRuins/SpaceRuins/mrow_thats_right.dmm
+++ b/_maps/RandomRuins/SpaceRuins/mrow_thats_right.dmm
@@ -30,14 +30,16 @@
 /area/ruin/space/has_grav/powered/cat_man)
 "ai" = (
 /obj/structure/mop_bucket/janitorialcart,
-/obj/item/mop,
-/obj/item/reagent_containers/cup/bucket,
-/obj/effect/decal/cleanable/cobweb/cobweb2,
+/obj/effect/decal/cleanable/cobweb/cobweb2{
+	pixel_y = 12
+	},
 /turf/open/floor/plating,
 /area/ruin/space/has_grav/powered/cat_man)
 "aj" = (
 /obj/structure/table,
-/obj/item/reagent_containers/spray/cleaner,
+/obj/item/reagent_containers/spray/cleaner{
+	pixel_y = 8
+	},
 /turf/open/floor/plating,
 /area/ruin/space/has_grav/powered/cat_man)
 "ak" = (
@@ -49,7 +51,9 @@
 	dir = 6
 	},
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/cobweb,
+/obj/effect/decal/cleanable/cobweb{
+	pixel_y = 12
+	},
 /obj/structure/closet/emcloset,
 /turf/open/floor/plating,
 /area/ruin/space/has_grav/powered/cat_man)
@@ -103,14 +107,16 @@
 /turf/open/floor/plating,
 /area/ruin/space/has_grav/powered/cat_man)
 "au" = (
-/obj/machinery/door/airlock/external/ruin,
+/obj/machinery/door/airlock/external/ruin{
+	dir = 4
+	},
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 4
 	},
 /turf/open/floor/plating,
 /area/ruin/space/has_grav/powered/cat_man)
 "av" = (
-/obj/machinery/light/small/directional/south,
+/obj/machinery/light/small/directional/north,
 /turf/open/floor/plating,
 /area/ruin/space/has_grav/powered/cat_man)
 "aw" = (
@@ -175,11 +181,6 @@
 /turf/open/floor/iron,
 /area/ruin/space/has_grav/powered/cat_man)
 "aG" = (
-/obj/effect/turf_decal/tile/neutral/half/contrasted,
-/turf/open/floor/iron,
-/area/ruin/space/has_grav/powered/cat_man)
-"aH" = (
-/obj/machinery/firealarm/directional/south,
 /obj/effect/turf_decal/tile/neutral/half/contrasted,
 /turf/open/floor/iron,
 /area/ruin/space/has_grav/powered/cat_man)
@@ -268,6 +269,7 @@
 /obj/effect/turf_decal/tile/neutral/half/contrasted{
 	dir = 1
 	},
+/obj/machinery/firealarm/directional/north,
 /turf/open/floor/iron,
 /area/ruin/space/has_grav/powered/cat_man)
 "aW" = (
@@ -282,7 +284,8 @@
 /obj/item/reagent_containers/cup/bowl,
 /obj/item/food/meat/slab/synthmeat{
 	desc = "A slab of cat meat. Tastes like furball.";
-	name = "cat meat"
+	name = "cat meat";
+	pixel_y = 5
 	},
 /obj/machinery/light/small/directional/north,
 /turf/open/floor/plating,
@@ -293,21 +296,20 @@
 /area/ruin/space/has_grav/powered/cat_man)
 "ba" = (
 /obj/structure/table/wood,
-/obj/item/flashlight/lamp,
-/turf/open/floor/carpet,
-/area/ruin/space/has_grav/powered/cat_man)
-"bc" = (
-/obj/machinery/button/door/directional/west{
-	id = "meow";
-	name = "Emergency Kitty Lockdown"
+/obj/item/flashlight/lamp{
+	pixel_y = 12
 	},
-/turf/open/floor/iron,
+/turf/open/floor/carpet,
 /area/ruin/space/has_grav/powered/cat_man)
 "bd" = (
 /obj/structure/table/reinforced,
-/obj/item/hemostat,
+/obj/item/hemostat{
+	pixel_x = -4;
+	pixel_y = 10
+	},
 /obj/item/cautery{
-	pixel_x = 4
+	pixel_x = 4;
+	pixel_y = -2
 	},
 /turf/open/floor/iron,
 /area/ruin/space/has_grav/powered/cat_man)
@@ -391,6 +393,12 @@
 /obj/item/scalpel{
 	pixel_y = 12
 	},
+/obj/machinery/button/door/table{
+	pixel_y = 14;
+	pixel_x = -4;
+	name = "Emergency Kitty Lockdown";
+	id = "meow"
+	},
 /turf/open/floor/iron,
 /area/ruin/space/has_grav/powered/cat_man)
 "bt" = (
@@ -402,24 +410,45 @@
 /area/ruin/space/has_grav/powered/cat_man)
 "bu" = (
 /obj/structure/table/reinforced,
-/obj/item/clothing/gloves/latex,
-/obj/item/surgical_drapes,
+/obj/item/clothing/gloves/latex{
+	pixel_y = 7;
+	pixel_x = 1
+	},
+/obj/item/surgical_drapes{
+	pixel_y = 16;
+	pixel_x = -4
+	},
 /turf/open/floor/iron/white/side{
 	dir = 8
 	},
 /area/ruin/space/has_grav/powered/cat_man)
 "bw" = (
 /obj/structure/table/wood,
-/obj/item/paper_bin,
-/obj/item/pen,
+/obj/item/paper_bin{
+	pixel_y = 12
+	},
+/obj/item/pen{
+	pixel_y = 8;
+	pixel_x = 3
+	},
 /turf/open/floor/carpet,
 /area/ruin/space/has_grav/powered/cat_man)
 "bx" = (
 /obj/structure/rack,
-/obj/item/melee/baton/security/cattleprod,
-/obj/item/melee/baton/security/cattleprod,
-/obj/item/restraints/handcuffs,
-/obj/item/restraints/handcuffs,
+/obj/item/melee/baton/security/cattleprod{
+	pixel_y = 8;
+	pixel_x = -4
+	},
+/obj/item/melee/baton/security/cattleprod{
+	pixel_y = 7;
+	pixel_x = 4
+	},
+/obj/item/restraints/handcuffs{
+	pixel_y = 8
+	},
+/obj/item/restraints/handcuffs{
+	pixel_y = 4
+	},
 /turf/open/floor/carpet,
 /area/ruin/space/has_grav/powered/cat_man)
 "by" = (
@@ -428,8 +457,13 @@
 /area/ruin/space/has_grav/powered/cat_man)
 "bz" = (
 /obj/structure/table/reinforced,
-/obj/item/retractor,
-/obj/item/razor,
+/obj/item/retractor{
+	pixel_y = 12
+	},
+/obj/item/razor{
+	pixel_y = 20;
+	pixel_x = 7
+	},
 /turf/open/floor/iron,
 /area/ruin/space/has_grav/powered/cat_man)
 "bA" = (
@@ -475,7 +509,6 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/blood/old,
-/obj/machinery/light/small/directional/south,
 /obj/machinery/atmospherics/components/unary/outlet_injector/monitored{
 	chamber_id = "catstation4";
 	dir = 4
@@ -541,6 +574,7 @@
 /obj/machinery/atmospherics/components/unary/outlet_injector/monitored{
 	chamber_id = "catstation6"
 	},
+/obj/machinery/light/small/directional/west,
 /turf/open/floor/plating,
 /area/ruin/space/has_grav/powered/cat_man)
 "bQ" = (
@@ -553,7 +587,9 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/green/hidden{
 	dir = 6
 	},
-/obj/effect/decal/cleanable/cobweb,
+/obj/effect/decal/cleanable/cobweb{
+	pixel_y = 12
+	},
 /turf/open/floor/plating,
 /area/ruin/space/has_grav/powered/cat_man)
 "bS" = (
@@ -573,11 +609,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/green/hidden{
 	dir = 6
 	},
-/turf/open/floor/plating,
-/area/ruin/space/has_grav/powered/cat_man)
-"bV" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/light/small/directional/south,
 /turf/open/floor/plating,
 /area/ruin/space/has_grav/powered/cat_man)
 "bX" = (
@@ -665,8 +696,13 @@
 	dir = 5
 	},
 /obj/structure/table,
-/obj/item/storage/toolbox/mechanical,
-/obj/item/wrench,
+/obj/item/storage/toolbox/mechanical{
+	pixel_y = 10
+	},
+/obj/item/wrench{
+	pixel_x = -2;
+	pixel_y = 6
+	},
 /turf/open/floor/plating,
 /area/ruin/space/has_grav/powered/cat_man)
 "ck" = (
@@ -743,6 +779,7 @@
 /obj/item/organ/internal/ears/cat,
 /obj/item/organ/internal/ears/cat,
 /obj/item/organ/internal/ears/cat,
+/obj/machinery/light/small/directional/north,
 /turf/open/floor/iron/freezer,
 /area/ruin/space/has_grav/powered/cat_man)
 "cv" = (
@@ -783,10 +820,6 @@
 	},
 /turf/open/floor/iron/freezer,
 /area/ruin/space/has_grav/powered/cat_man)
-"cw" = (
-/obj/machinery/light/small/directional/south,
-/turf/open/floor/iron/freezer,
-/area/ruin/space/has_grav/powered/cat_man)
 "cx" = (
 /obj/structure/closet/crate/freezer{
 	name = "cat tails"
@@ -804,6 +837,13 @@
 /obj/machinery/atmospherics/components/unary/outlet_injector/monitored{
 	chamber_id = "catstation5"
 	},
+/turf/open/floor/plating,
+/area/ruin/space/has_grav/powered/cat_man)
+"kj" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/item/reagent_containers/cup/bowl,
+/obj/machinery/light/small/directional/north,
 /turf/open/floor/plating,
 /area/ruin/space/has_grav/powered/cat_man)
 "lQ" = (
@@ -838,6 +878,13 @@
 	dir = 4
 	},
 /area/ruin/space/has_grav/powered/cat_man)
+"wB" = (
+/obj/effect/turf_decal/tile/neutral/half/contrasted{
+	dir = 1
+	},
+/obj/machinery/firealarm/directional/north,
+/turf/open/floor/iron,
+/area/ruin/space/has_grav/powered/cat_man)
 "yx" = (
 /obj/machinery/light/small/directional/east,
 /turf/open/floor/carpet,
@@ -850,7 +897,6 @@
 /turf/open/floor/plating,
 /area/ruin/space/has_grav/powered/cat_man)
 "BX" = (
-/obj/machinery/firealarm/directional/east,
 /obj/machinery/computer/atmos_control/noreconnect{
 	atmos_chambers = list("catstation1"="Chamber 1","catstation2"="Chamber 2","catstation3"="Chamber 3","catstation4"="Chamber 4","catstation5"="Chamber 5","catstation6"="Chamber 6","catstationsupply"="Supply");
 	dir = 8
@@ -860,13 +906,32 @@
 	},
 /turf/open/floor/iron,
 /area/ruin/space/has_grav/powered/cat_man)
+"Mn" = (
+/obj/item/reagent_containers/cup/bucket{
+	pixel_y = 4
+	},
+/obj/item/mop,
+/turf/open/floor/plating,
+/area/ruin/space/has_grav/powered/cat_man)
+"OP" = (
+/obj/machinery/firealarm/directional/west,
+/turf/open/floor/iron,
+/area/ruin/space/has_grav/powered/cat_man)
+"QB" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/item/reagent_containers/cup/bowl,
+/obj/machinery/light/small/directional/east,
+/turf/open/floor/plating,
+/area/ruin/space/has_grav/powered/cat_man)
 "RT" = (
 /obj/machinery/door/airlock/external/ruin,
 /obj/effect/mapping_helpers/airlock/cyclelink_helper,
 /turf/open/floor/plating,
 /area/ruin/space/has_grav/powered/cat_man)
 "Sl" = (
-/obj/machinery/door/airlock/external/ruin,
+/obj/machinery/door/airlock/external/ruin{
+	dir = 4
+	},
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 8
 	},
@@ -1115,7 +1180,7 @@ bo
 bw
 ad
 bJ
-aI
+OP
 aF
 ad
 aZ
@@ -1180,7 +1245,7 @@ aS
 ad
 bL
 aI
-aH
+aG
 ad
 aZ
 ad
@@ -1203,7 +1268,7 @@ ad
 ad
 ad
 ax
-aH
+aG
 ad
 aT
 mm
@@ -1234,7 +1299,7 @@ ad
 ag
 aj
 ad
-aw
+wB
 aG
 ad
 ad
@@ -1263,14 +1328,14 @@ aa
 ab
 ab
 ad
-ah
+Mn
 ah
 ar
 aw
 aI
 aO
 aI
-bc
+aI
 bq
 aI
 aI
@@ -1347,7 +1412,7 @@ ay
 ah
 cp
 ct
-cw
+ct
 ad
 ab
 ab
@@ -1372,7 +1437,7 @@ bB
 bE
 aP
 bQ
-bV
+ay
 ad
 ca
 cf
@@ -1500,7 +1565,7 @@ bi
 aP
 ad
 aJ
-bV
+ay
 ad
 an
 ad
@@ -1531,7 +1596,7 @@ ad
 ay
 ay
 ad
-aK
+QB
 aD
 ad
 am
@@ -1560,7 +1625,7 @@ ad
 aX
 bk
 ad
-aL
+kj
 bH
 ad
 ad

--- a/code/modules/mining/equipment/survival_pod.dm
+++ b/code/modules/mining/equipment/survival_pod.dm
@@ -155,10 +155,12 @@ MAPPING_DIRECTIONAL_HELPERS_EMPTY(/obj/structure/window/reinforced/survival_pod/
 	overlays_file = 'icons/obj/doors/airlocks/survival/survival_overlays.dmi'
 	assemblytype = /obj/structure/door_assembly/door_assembly_pod
 	smoothing_groups = SMOOTH_GROUP_SURVIVAL_TITANIUM_POD
+	greyscale_colors = "#a5a7ac#a5a7ac#969696#969696#5ea52c#6d6565#777777"
 
 /obj/machinery/door/airlock/survival_pod/glass
 	opacity = FALSE
 	glass = TRUE
+	greyscale_config = /datum/greyscale_config/airlocks/window
 
 /obj/structure/door_assembly/door_assembly_pod
 	name = "pod airlock assembly"


### PR DESCRIPTION
## About The Pull Request

Hits the following maps:
Gluttony Ruin (lavaland)
Phonebooth (lavaland)
Shuttle Wreckage (Lavaland)
Survival pod (lavaland) *
Clown Planet (Space)
The Feline-Human Combination Den (Space)

* Additionally, this moves over the survival pod full-door to use a GAGS template as it looks like the airlocks for these got forgotten about. In absence of sitting down and doing another 24+ animation frames and unique artwork for this, I just threw together an acceptable color palette and used it on the GAGS template. For now anyway, it looks okay.

## Why It's Good For The Game
🐛 💥  More maps reviewed for more visual consistency across the board.