### PR TITLE
Makes Deltatation Roughly Playable

### DIFF
--- a/_maps/map_files/Deltastation/DeltaStation2.dmm
+++ b/_maps/map_files/Deltastation/DeltaStation2.dmm
@@ -15,14 +15,6 @@
 /obj/structure/lattice,
 /turf/open/space,
 /area/space/nearstation)
-"aaf" = (
-/obj/structure/sign/directions/engineering{
-	desc = "A sign that shows there are doors here. There are doors everywhere!";
-	icon_state = "doors";
-	name = "WARNING: EXTERNAL AIRLOCK"
-	},
-/turf/closed/wall/r_wall,
-/area/station/maintenance/solars/port/fore)
 "aaz" = (
 /obj/effect/landmark/start/hangover,
 /obj/structure/chair/stool/directional/east,
@@ -46,7 +38,6 @@
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/aisat/exterior)
 "aaR" = (
-/obj/machinery/computer/security/telescreen/entertainment/directional/north,
 /obj/item/kirbyplants/random,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -77,9 +68,7 @@
 /area/station/service/abandoned_gambling_den)
 "aaY" = (
 /obj/effect/landmark/start/hangover/closet,
-/obj/structure/sign/nanotrasen{
-	pixel_y = 32
-	},
+/obj/structure/sign/nanotrasen,
 /obj/machinery/status_display/evac/directional/west,
 /obj/structure/closet/emcloset,
 /obj/effect/turf_decal/delivery,
@@ -129,7 +118,6 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/trimline/blue/filled/line,
-/obj/structure/sign/warning/secure_area/directional/west,
 /obj/machinery/light/directional/west,
 /turf/open/floor/iron/white,
 /area/station/medical/medbay)
@@ -199,6 +187,7 @@
 /obj/effect/turf_decal/tile/yellow/anticorner/contrasted{
 	dir = 4
 	},
+/obj/structure/sign/warning/electric_shock/directional/north,
 /turf/open/floor/iron,
 /area/station/construction/mining/aux_base)
 "acs" = (
@@ -342,7 +331,6 @@
 /area/station/security/prison)
 "aej" = (
 /obj/structure/chair/stool/directional/east,
-/obj/structure/sign/poster/random/directional/west,
 /obj/effect/landmark/start/hangover,
 /turf/open/floor/iron/dark,
 /area/station/service/barber)
@@ -655,6 +643,7 @@
 /obj/machinery/portable_atmospherics/canister/nitrogen,
 /obj/effect/turf_decal/bot,
 /obj/machinery/light/small/directional/west,
+/obj/structure/sign/warning/radiation/directional/north,
 /turf/open/floor/iron/dark,
 /area/station/engineering/supermatter/room)
 "agZ" = (
@@ -813,6 +802,10 @@
 	},
 /turf/open/floor/iron,
 /area/station/security/checkpoint/arrivals)
+"ajf" = (
+/obj/machinery/atmospherics/pipe/smart/simple/dark/visible,
+/turf/open/floor/iron,
+/area/station/maintenance/disposal/incinerator)
 "ajq" = (
 /obj/effect/landmark/blobstart,
 /obj/structure/disposalpipe/segment{
@@ -853,9 +846,7 @@
 "akg" = (
 /obj/machinery/disposal/bin,
 /obj/effect/turf_decal/bot,
-/obj/structure/sign/nanotrasen{
-	pixel_y = 32
-	},
+/obj/structure/sign/nanotrasen,
 /obj/structure/disposalpipe/trunk,
 /obj/effect/turf_decal/tile/neutral/anticorner/contrasted,
 /turf/open/floor/iron,
@@ -928,6 +919,7 @@
 	name = "science camera";
 	network = list("ss13","rd")
 	},
+/obj/structure/sign/nanotrasen,
 /turf/open/floor/iron/white,
 /area/station/science/lobby)
 "alT" = (
@@ -1107,10 +1099,6 @@
 /obj/effect/mapping_helpers/broken_floor,
 /turf/open/floor/wood,
 /area/station/service/library/abandoned)
-"anB" = (
-/obj/structure/sign/warning/secure_area,
-/turf/closed/wall/r_wall,
-/area/station/engineering/supermatter/room)
 "anC" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/hatch{
@@ -1163,13 +1151,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/white,
 /area/station/medical/medbay)
-"anZ" = (
-/obj/structure/sign/nanotrasen{
-	pixel_y = 32
-	},
-/obj/structure/lattice,
-/turf/open/space/basic,
-/area/space/nearstation)
 "aoc" = (
 /obj/machinery/door/airlock/maintenance_hatch{
 	name = "Maintenance Hatch"
@@ -1418,6 +1399,7 @@
 	dir = 1
 	},
 /obj/item/pillow/random,
+/obj/machinery/status_display/evac/directional/south,
 /turf/open/floor/wood,
 /area/station/commons/dorms)
 "aqW" = (
@@ -1781,7 +1763,9 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/door/poddoor{
 	id = "engstorage";
-	name = "Engineering Secure Storage Lockdown"
+	name = "Engineering Secure Storage Lockdown";
+	dir = 8;
+	manual_align = 1
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/stripes/line{
@@ -1921,7 +1905,6 @@
 	dir = 8
 	},
 /obj/structure/chair/stool/bar/directional/west,
-/obj/structure/sign/poster/contraband/random/directional/south,
 /obj/machinery/light/small/directional/south,
 /turf/open/floor/wood,
 /area/station/service/electronic_marketing_den)
@@ -1965,7 +1948,6 @@
 "awi" = (
 /obj/structure/table/glass,
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/sign/poster/official/science/directional/south,
 /turf/open/floor/plating,
 /area/station/maintenance/space_hut/observatory)
 "awj" = (
@@ -1990,10 +1972,10 @@
 /turf/open/floor/iron,
 /area/station/cargo/storage)
 "awA" = (
-/obj/structure/sign/poster/random/directional/north,
 /obj/machinery/module_duplicator,
 /obj/effect/turf_decal/bot,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/structure/sign/warning/firing_range/directional/north,
 /turf/open/floor/iron/dark,
 /area/station/science/circuits)
 "awC" = (
@@ -2579,10 +2561,6 @@
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron/dark/telecomms,
 /area/station/tcommsat/server)
-"aFE" = (
-/obj/structure/sign/nanotrasen,
-/turf/closed/wall/r_wall,
-/area/station/command/teleporter)
 "aFH" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/oil,
@@ -2625,7 +2603,9 @@
 "aGo" = (
 /obj/machinery/door/poddoor{
 	id = "engstorage";
-	name = "Engineering Secure Storage Lockdown"
+	name = "Engineering Secure Storage Lockdown";
+	dir = 8;
+	manual_align = 1
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/stripes/line{
@@ -2715,6 +2695,7 @@
 /obj/item/wrench,
 /obj/item/analyzer,
 /obj/item/book/manual/wiki/atmospherics,
+/obj/structure/sign/warning/gas_mask/directional/north,
 /turf/open/floor/plating,
 /area/station/maintenance/department/electrical)
 "aGZ" = (
@@ -2851,6 +2832,9 @@
 /obj/structure/cable,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /obj/effect/landmark/event_spawn,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/open/floor/iron/dark,
 /area/station/service/library/printer)
 "aII" = (
@@ -3013,11 +2997,11 @@
 /turf/open/floor/iron,
 /area/station/maintenance/port/aft)
 "aKq" = (
-/obj/machinery/airalarm/directional/north,
 /obj/effect/turf_decal/tile/neutral/half/contrasted{
 	dir = 1
 	},
 /obj/machinery/light/directional/north,
+/obj/structure/sign/nanotrasen,
 /turf/open/floor/iron,
 /area/station/security/courtroom)
 "aKt" = (
@@ -3242,10 +3226,6 @@
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron,
 /area/station/maintenance/department/chapel)
-"aNP" = (
-/obj/structure/sign/warning/hot_temp/directional/west,
-/turf/open/floor/plating,
-/area/station/maintenance/department/science)
 "aNQ" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -3356,10 +3336,10 @@
 /area/station/service/chapel/office)
 "aOQ" = (
 /obj/structure/closet/secure_closet/courtroom,
-/obj/machinery/light_switch/directional/north,
 /obj/effect/turf_decal/tile/neutral/anticorner/contrasted{
 	dir = 4
 	},
+/obj/machinery/light_switch/directional/east,
 /turf/open/floor/iron,
 /area/station/security/courtroom)
 "aOT" = (
@@ -3473,7 +3453,8 @@
 	dir = 4
 	},
 /obj/machinery/door/airlock/external{
-	name = "MiniSat Exterior Access"
+	name = "MiniSat Exterior Access";
+	dir = 4
 	},
 /obj/effect/mapping_helpers/airlock/access/all/engineering/construction,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
@@ -3612,9 +3593,7 @@
 	},
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/sign/nanotrasen{
-	pixel_y = 32
-	},
+/obj/structure/sign/nanotrasen,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 4
 	},
@@ -3816,6 +3795,7 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/tile/yellow/opposingcorners,
+/obj/structure/sign/warning/secure_area/directional/north,
 /turf/open/floor/iron,
 /area/station/engineering/supermatter/room)
 "aWk" = (
@@ -4218,7 +4198,6 @@
 	dir = 8
 	},
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/sign/warning/secure_area/directional/west,
 /obj/machinery/light/directional/west,
 /obj/machinery/atmospherics/pipe/bridge_pipe/cyan/visible,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
@@ -4245,7 +4224,6 @@
 /obj/effect/turf_decal/stripes/corner{
 	dir = 4
 	},
-/obj/structure/sign/warning/biohazard/directional/east,
 /turf/open/floor/iron/white,
 /area/station/science/research)
 "bbo" = (
@@ -4528,14 +4506,6 @@
 /obj/structure/sink/directional/west,
 /turf/open/floor/iron,
 /area/station/maintenance/department/science)
-"bfe" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
-/obj/structure/sign/warning/pods/directional/south,
-/obj/effect/turf_decal/tile/neutral/half/contrasted,
-/turf/open/floor/iron,
-/area/station/commons/dorms)
 "bfn" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
@@ -4858,6 +4828,7 @@
 /obj/effect/turf_decal/bot,
 /obj/machinery/atmospherics/components/unary/portables_connector/visible,
 /obj/machinery/light/small/red/directional/north,
+/obj/structure/sign/warning/secure_area/directional/north,
 /turf/open/floor/iron/smooth,
 /area/station/science/xenobiology)
 "biv" = (
@@ -4933,8 +4904,8 @@
 /area/station/engineering/lobby)
 "bjp" = (
 /obj/effect/turf_decal/bot,
-/obj/machinery/light/small/directional/north,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/structure/sign/warning/test_chamber/directional/north,
 /turf/open/floor/iron,
 /area/station/science/research)
 "bjs" = (
@@ -5398,7 +5369,6 @@
 /area/station/engineering/storage/tech)
 "bpw" = (
 /obj/machinery/light/small/directional/west,
-/obj/structure/sign/poster/contraband/random/directional/west,
 /obj/structure/table/wood,
 /obj/item/newspaper,
 /obj/item/clothing/head/hats/bowler,
@@ -5433,7 +5403,6 @@
 /obj/structure/table/wood,
 /obj/item/food/baguette,
 /obj/item/toy/crayon/spraycan/mimecan,
-/obj/structure/sign/poster/random/directional/south,
 /obj/effect/turf_decal/tile/neutral/opposingcorners{
 	dir = 1
 	},
@@ -5565,9 +5534,6 @@
 /turf/open/floor/iron/dark,
 /area/station/engineering/atmos)
 "bsd" = (
-/obj/structure/sign/nanotrasen{
-	pixel_x = -32
-	},
 /obj/machinery/airalarm/directional/south,
 /obj/effect/landmark/start/hangover/closet,
 /obj/effect/spawner/random/structure/closet_private,
@@ -5887,7 +5853,6 @@
 /obj/effect/turf_decal/siding/wood/corner{
 	dir = 1
 	},
-/obj/structure/sign/poster/random/directional/south,
 /obj/machinery/power/port_gen/pacman/pre_loaded,
 /turf/open/floor/plating,
 /area/station/maintenance/port/fore)
@@ -5931,6 +5896,12 @@
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron,
 /area/station/hallway/secondary/exit)
+"bwS" = (
+/obj/structure/table/wood,
+/obj/item/flashlight/lamp,
+/obj/structure/sign/painting/library,
+/turf/open/floor/wood,
+/area/station/commons/dorms)
 "bwU" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -6165,7 +6136,6 @@
 "bAp" = (
 /obj/structure/sink/directional/west,
 /obj/item/trash/sosjerky,
-/obj/structure/sign/poster/official/cleanliness/directional/east,
 /obj/machinery/firealarm/directional/south,
 /obj/machinery/power/apc/auto_name/directional/north,
 /obj/structure/cable,
@@ -6267,10 +6237,6 @@
 /area/station/maintenance/starboard/aft)
 "bBh" = (
 /obj/machinery/disposal/bin,
-/obj/structure/sign/nanotrasen{
-	pixel_x = 32;
-	pixel_y = -32
-	},
 /obj/structure/disposalpipe/trunk{
 	dir = 1
 	},
@@ -6338,9 +6304,6 @@
 /obj/item/bedsheet/medical{
 	dir = 4
 	},
-/obj/structure/sign/nanotrasen{
-	pixel_x = -32
-	},
 /obj/effect/turf_decal/trimline/green/filled/line{
 	dir = 9
 	},
@@ -6366,7 +6329,6 @@
 /obj/item/disk/tech_disk{
 	pixel_y = 6
 	},
-/obj/structure/sign/warning/no_smoking/directional/west,
 /obj/effect/turf_decal/siding/purple{
 	dir = 4
 	},
@@ -6445,7 +6407,6 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/light/small/directional/east,
 /obj/effect/spawner/random/structure/tank_holder,
-/obj/structure/sign/poster/official/wtf_is_co2/directional/east,
 /turf/open/floor/iron,
 /area/station/maintenance/department/engine/atmos)
 "bCY" = (
@@ -6629,10 +6590,6 @@
 /obj/machinery/light/small/directional/east,
 /turf/open/floor/iron,
 /area/station/maintenance/department/eva/abandoned)
-"bET" = (
-/obj/structure/sign/warning/vacuum,
-/turf/closed/wall/r_wall,
-/area/station/maintenance/department/science/xenobiology)
 "bEU" = (
 /obj/structure/sign/poster/official/random/directional/north,
 /obj/machinery/shieldgen,
@@ -6802,7 +6759,6 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/sign/poster/official/help_others/directional/south,
 /turf/open/floor/iron,
 /area/station/hallway/primary/starboard)
 "bGn" = (
@@ -7237,6 +7193,7 @@
 	network = list("ss13","medbay")
 	},
 /obj/machinery/photocopier,
+/obj/structure/sign/warning/cold_temp/directional/north,
 /turf/open/floor/iron/white,
 /area/station/medical/medbay)
 "bLu" = (
@@ -7336,10 +7293,10 @@
 /turf/open/floor/iron/dark,
 /area/station/service/abandoned_gambling_den)
 "bMh" = (
-/obj/item/radio/intercom/directional/north,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 4
 	},
+/obj/structure/sign/nanotrasen,
 /turf/open/floor/iron/dark/corner{
 	dir = 4
 	},
@@ -7428,9 +7385,6 @@
 /turf/open/floor/iron/white,
 /area/station/science/research)
 "bOh" = (
-/obj/structure/sign/painting/library{
-	pixel_y = -32
-	},
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/light/directional/south,
@@ -7610,13 +7564,6 @@
 	},
 /turf/open/floor/iron,
 /area/station/security/checkpoint/medical/medsci)
-"bRl" = (
-/obj/structure/sign/warning/electric_shock{
-	pixel_y = -32
-	},
-/obj/effect/turf_decal/tile/neutral,
-/turf/open/floor/iron,
-/area/station/hallway/secondary/command)
 "bRm" = (
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment{
@@ -7671,10 +7618,6 @@
 /obj/machinery/atmospherics/components/unary/portables_connector/visible/layer4,
 /obj/machinery/airalarm/directional/north,
 /turf/open/floor/plating,
-/area/station/ai_monitored/turret_protected/aisat_interior)
-"bRD" = (
-/obj/structure/sign/nanotrasen,
-/turf/closed/wall/r_wall,
 /area/station/ai_monitored/turret_protected/aisat_interior)
 "bRE" = (
 /obj/structure/cable,
@@ -7773,16 +7716,6 @@
 /obj/effect/turf_decal/tile/red,
 /turf/open/floor/iron,
 /area/station/security/execution/transfer)
-"bSn" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/purple/filled/corner{
-	dir = 8
-	},
-/obj/structure/sign/poster/official/anniversary_vintage_reprint/directional/south,
-/turf/open/floor/iron/white,
-/area/station/science/research)
 "bSp" = (
 /obj/effect/landmark/start/hangover,
 /obj/structure/table/wood,
@@ -8158,7 +8091,6 @@
 /obj/effect/turf_decal/siding/wood{
 	dir = 1
 	},
-/obj/machinery/light/small/directional/south,
 /turf/open/floor/iron/dark,
 /area/station/service/chapel/office)
 "bWT" = (
@@ -8189,6 +8121,7 @@
 	name = "emergency shower"
 	},
 /obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/structure/sign/warning/secure_area/directional/north,
 /turf/open/floor/iron/dark/textured,
 /area/station/science/research)
 "bXA" = (
@@ -8258,7 +8191,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
-/obj/structure/sign/warning/no_smoking/directional/south,
 /obj/effect/turf_decal/trimline/purple/filled/line,
 /turf/open/floor/iron/white,
 /area/station/science/ordnance/storage)
@@ -8475,7 +8407,6 @@
 /turf/open/floor/iron,
 /area/station/engineering/main)
 "caW" = (
-/obj/structure/sign/poster/random/directional/west,
 /obj/structure/closet,
 /obj/effect/spawner/random/food_or_drink/donkpockets,
 /obj/effect/spawner/random/food_or_drink/condiment,
@@ -8556,11 +8487,6 @@
 /obj/effect/mapping_helpers/mail_sorting/security/hos_office,
 /turf/open/floor/iron,
 /area/station/security/office)
-"cbY" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/structure/sign/warning/vacuum,
-/turf/open/floor/plating,
-/area/station/hallway/secondary/entry)
 "ccd" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -8924,6 +8850,7 @@
 /obj/machinery/power/smes/full,
 /obj/effect/turf_decal/bot,
 /obj/item/radio/intercom/directional/west,
+/obj/structure/sign/warning/electric_shock/directional/north,
 /turf/open/floor/iron,
 /area/station/engineering/gravity_generator)
 "chF" = (
@@ -8974,13 +8901,6 @@
 /obj/item/kirbyplants/random,
 /turf/open/floor/iron/dark,
 /area/station/commons/fitness/recreation)
-"ciz" = (
-/obj/structure/sign/nanotrasen{
-	pixel_y = -32
-	},
-/obj/effect/turf_decal/tile/neutral,
-/turf/open/floor/iron,
-/area/station/hallway/secondary/entry)
 "ciB" = (
 /obj/machinery/camera/directional/west{
 	c_tag = "Engineering - Supermatter Room Port";
@@ -9089,14 +9009,6 @@
 /obj/structure/cable,
 /turf/open/floor/iron/dark/textured_large,
 /area/station/cargo/bitrunning/den)
-"ckb" = (
-/obj/structure/disposalpipe/segment,
-/obj/structure/cable,
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/sign/poster/random/directional/east,
-/obj/effect/turf_decal/tile/neutral/opposingcorners,
-/turf/open/floor/iron,
-/area/station/maintenance/port/fore)
 "ckd" = (
 /obj/structure/chair/sofa/bench/left{
 	dir = 8
@@ -9232,7 +9144,6 @@
 /obj/structure/table/wood,
 /obj/item/instrument/guitar,
 /obj/effect/decal/cleanable/cobweb/cobweb2,
-/obj/structure/sign/poster/contraband/random/directional/east,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/wood,
 /area/station/service/theater/abandoned)
@@ -9602,14 +9513,6 @@
 	},
 /turf/open/floor/iron/white,
 /area/station/medical/treatment_center)
-"coH" = (
-/obj/structure/sign/directions/engineering{
-	desc = "A sign that shows there are doors here. There are doors everywhere!";
-	icon_state = "doors";
-	name = "WARNING: EXTERNAL AIRLOCK"
-	},
-/turf/closed/wall/r_wall,
-/area/station/maintenance/solars/starboard/fore)
 "coV" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 4
@@ -9683,7 +9586,6 @@
 /turf/open/floor/iron/dark,
 /area/station/security/execution/transfer)
 "cpG" = (
-/obj/structure/sign/poster/contraband/kudzu/directional/west,
 /obj/machinery/light/small/directional/west,
 /obj/structure/table,
 /obj/machinery/reagentgrinder,
@@ -9768,7 +9670,6 @@
 /obj/effect/turf_decal/trimline/neutral/mid_joiner{
 	dir = 1
 	},
-/obj/structure/sign/poster/contraband/borg_fancy_1/directional/west,
 /obj/structure/table/reinforced,
 /obj/machinery/ecto_sniffer,
 /turf/open/floor/iron/dark/textured_half,
@@ -10028,7 +9929,6 @@
 /area/station/engineering/main)
 "cul" = (
 /obj/machinery/plate_press,
-/obj/structure/sign/warning/electric_shock/directional/east,
 /obj/structure/cable,
 /obj/machinery/power/apc/auto_name/directional/south,
 /obj/effect/turf_decal/tile/yellow,
@@ -10159,7 +10059,6 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
-/obj/structure/sign/warning/radiation/directional/south,
 /turf/open/floor/iron,
 /area/station/engineering/supermatter/room)
 "cwV" = (
@@ -10448,16 +10347,6 @@
 /obj/machinery/light/cold/directional/north,
 /turf/open/floor/iron,
 /area/station/science/robotics/mechbay)
-"cAs" = (
-/obj/structure/cable,
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/structure/sign/warning/docking/directional/south,
-/obj/machinery/duct,
-/turf/open/floor/iron,
-/area/station/maintenance/department/chapel)
 "cAw" = (
 /obj/structure/cable,
 /obj/structure/rack,
@@ -10565,6 +10454,7 @@
 	},
 /obj/structure/closet/emcloset,
 /obj/machinery/light/small/red/directional/north,
+/obj/structure/sign/nanotrasen,
 /turf/open/floor/plating,
 /area/station/security/execution/transfer)
 "cBE" = (
@@ -10593,7 +10483,9 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/structure/plasticflaps,
+/obj/structure/plasticflaps{
+	dir = 4
+	},
 /turf/open/floor/iron,
 /area/station/medical/storage)
 "cBS" = (
@@ -10737,7 +10629,9 @@
 	dir = 4
 	},
 /obj/machinery/door/airlock/external/glass{
-	name = "Supply Door Airlock"
+	name = "Supply Door Airlock";
+	dir = 4;
+	manual_align = 1
 	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -11006,11 +10900,6 @@
 	},
 /turf/open/floor/plating,
 /area/station/science/xenobiology)
-"cGI" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/sign/poster/contraband/random/directional/south,
-/turf/open/floor/plating,
-/area/station/maintenance/department/science/xenobiology)
 "cGJ" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -11185,6 +11074,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 10
 	},
+/obj/structure/sign/nanotrasen,
 /turf/open/floor/iron,
 /area/station/command/heads_quarters/captain/private)
 "cIA" = (
@@ -11395,6 +11285,13 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/command/heads_quarters/rd)
+"cLV" = (
+/obj/effect/turf_decal/tile/neutral/half/contrasted{
+	dir = 1
+	},
+/obj/structure/sign/flag/nanotrasen/directional/north,
+/turf/open/floor/iron,
+/area/station/commons/dorms)
 "cLX" = (
 /obj/effect/turf_decal/siding/dark_red{
 	dir = 1
@@ -11581,6 +11478,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/spawner/random/structure/crate,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/machinery/light/small/dim/directional/north,
 /turf/open/floor/iron/dark,
 /area/station/maintenance/department/science/xenobiology)
 "cOA" = (
@@ -11612,7 +11510,6 @@
 	name = "Brig"
 	},
 /obj/structure/disposalpipe/segment,
-/obj/structure/sign/poster/official/nanotrasen_logo/directional/west,
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -11754,7 +11651,6 @@
 /area/station/command/bridge)
 "cQw" = (
 /obj/item/kirbyplants/random,
-/obj/structure/sign/warning/no_smoking/directional/north,
 /obj/effect/turf_decal/stripes/line,
 /obj/machinery/power/terminal{
 	dir = 8
@@ -11794,7 +11690,6 @@
 /turf/open/floor/iron/large,
 /area/station/science/xenobiology)
 "cQZ" = (
-/obj/structure/sign/warning/chem_diamond/directional/west,
 /obj/machinery/chem_dispenser,
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -12200,6 +12095,12 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
 /area/station/hallway/secondary/entry)
+"cWD" = (
+/obj/structure/cable,
+/obj/effect/turf_decal/tile/red,
+/obj/structure/sign/warning/electric_shock/directional/north,
+/turf/open/floor/iron,
+/area/station/security/execution/transfer)
 "cWI" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/siding/yellow{
@@ -12372,7 +12273,6 @@
 /obj/structure/table/wood,
 /obj/item/clothing/under/costume/geisha,
 /obj/item/clothing/shoes/sandal,
-/obj/structure/sign/poster/ripped/directional/east,
 /obj/item/radio/intercom/directional/east,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron/dark,
@@ -12718,6 +12618,7 @@
 	dir = 4
 	},
 /obj/structure/cable,
+/obj/machinery/light_switch/directional/east,
 /turf/open/floor/iron/white,
 /area/station/medical/virology)
 "ddw" = (
@@ -13036,9 +12937,6 @@
 /turf/open/floor/iron,
 /area/station/hallway/secondary/exit/departure_lounge)
 "dgU" = (
-/obj/machinery/status_display/supply{
-	pixel_x = -32
-	},
 /obj/machinery/camera/directional/west{
 	c_tag = "Cargo Bay - Port";
 	name = "cargo camera"
@@ -13083,7 +12981,6 @@
 /turf/open/floor/wood,
 /area/station/service/library/abandoned)
 "dip" = (
-/obj/structure/sign/poster/contraband/hacking_guide/directional/south,
 /obj/effect/turf_decal/tile/neutral/opposingcorners,
 /turf/open/floor/iron/dark,
 /area/station/maintenance/department/science)
@@ -13123,10 +13020,6 @@
 /obj/effect/mapping_helpers/airlock/access/any/engineering/construction,
 /turf/open/floor/iron,
 /area/station/engineering/storage_shared)
-"djf" = (
-/obj/structure/sign/warning/radiation,
-/turf/closed/wall/r_wall,
-/area/station/engineering/atmos/project)
 "djn" = (
 /obj/structure/table/wood,
 /obj/item/toy/talking/codex_gigas,
@@ -13342,12 +13235,6 @@
 	},
 /turf/open/floor/engine/vacuum,
 /area/station/science/ordnance/burnchamber)
-"dlm" = (
-/obj/structure/cable,
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/sign/poster/random/directional/south,
-/turf/open/floor/plating,
-/area/station/maintenance/port/fore)
 "dlo" = (
 /obj/effect/decal/cleanable/robot_debris/down,
 /obj/effect/decal/cleanable/oil,
@@ -13374,7 +13261,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/spawner/random/trash/mess,
-/obj/structure/sign/poster/random/directional/east,
 /turf/open/floor/iron/grimy,
 /area/station/maintenance/port/fore)
 "dlC" = (
@@ -13601,7 +13487,6 @@
 "dpQ" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/box,
-/obj/structure/sign/poster/random/directional/south,
 /turf/open/floor/iron/dark,
 /area/station/maintenance/department/engine/atmos)
 "dqc" = (
@@ -13741,7 +13626,6 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 1
 	},
-/obj/structure/sign/poster/official/no_erp/directional/west,
 /turf/open/floor/iron/white,
 /area/station/security/prison/toilet)
 "drJ" = (
@@ -13808,7 +13692,6 @@
 	dir = 4
 	},
 /obj/machinery/meter/layer2,
-/obj/structure/sign/warning/no_smoking/directional/east,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /obj/structure/cable,
 /turf/open/floor/iron/dark,
@@ -13834,6 +13717,7 @@
 /obj/structure/chair/sofa/right/brown,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/computer/security/telescreen/entertainment/directional/north,
 /turf/open/floor/iron/dark,
 /area/station/service/library)
 "dso" = (
@@ -13944,8 +13828,6 @@
 "dtj" = (
 /obj/structure/table/wood,
 /obj/item/flashlight/lamp,
-/obj/structure/sign/warning/no_smoking/directional/east,
-/obj/structure/sign/poster/official/random/directional/south,
 /turf/open/floor/wood,
 /area/station/commons/vacant_room/office)
 "dtn" = (
@@ -14404,9 +14286,7 @@
 /turf/open/floor/iron/cafeteria,
 /area/station/service/kitchen)
 "dyi" = (
-/obj/structure/sign/nanotrasen{
-	pixel_y = 32
-	},
+/obj/structure/sign/nanotrasen,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
@@ -14422,10 +14302,6 @@
 /obj/machinery/light/small/directional/south,
 /turf/open/floor/wood,
 /area/station/command/heads_quarters/hop)
-"dyw" = (
-/obj/structure/sign/departments/psychology/directional/east,
-/turf/closed/wall,
-/area/station/maintenance/department/chapel)
 "dyx" = (
 /turf/open/floor/iron/white,
 /area/station/science/research)
@@ -14474,11 +14350,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/station/hallway/secondary/construction)
-"dzn" = (
-/obj/structure/sign/plaques/kiddie/library,
-/obj/effect/spawner/structure/window,
-/turf/open/floor/plating,
-/area/station/service/library/artgallery)
 "dzw" = (
 /turf/closed/wall/r_wall,
 /area/station/security/brig)
@@ -14495,11 +14366,11 @@
 /obj/effect/turf_decal/stripes/corner{
 	dir = 1
 	},
+/obj/structure/sign/nanotrasen,
 /turf/open/floor/plating,
 /area/station/ai_monitored/turret_protected/aisat_interior)
 "dAX" = (
 /obj/machinery/light/small/directional/west,
-/obj/structure/sign/poster/official/work_for_a_future/directional/south,
 /obj/machinery/atmospherics/components/tank/air{
 	dir = 1
 	},
@@ -14580,6 +14451,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 6
 	},
+/obj/machinery/light/small/directional/north,
 /turf/open/floor/iron/grimy,
 /area/station/service/chapel/office)
 "dBB" = (
@@ -14626,6 +14498,19 @@
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron,
 /area/station/hallway/primary/starboard)
+"dCg" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/cable,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/structure/sign/poster/random/directional/north,
+/turf/open/floor/iron,
+/area/station/hallway/primary/central/aft)
 "dCk" = (
 /turf/closed/wall/r_wall,
 /area/station/security/detectives_office)
@@ -14993,10 +14878,6 @@
 	},
 /turf/open/floor/iron,
 /area/station/maintenance/department/chapel)
-"dHx" = (
-/obj/structure/sign/warning/radiation/directional/north,
-/turf/open/floor/engine,
-/area/station/engineering/supermatter)
 "dHN" = (
 /obj/machinery/door/poddoor/massdriver_chapel,
 /obj/structure/fans/tiny,
@@ -15111,12 +14992,6 @@
 /obj/machinery/door/airlock/external{
 	name = "External Airlock"
 	},
-/obj/structure/sign/directions/engineering{
-	desc = "A sign that shows there are doors here. There are doors everywhere!";
-	icon_state = "doors";
-	name = "WARNING: EXTERNAL AIRLOCK";
-	pixel_x = 32
-	},
 /obj/effect/turf_decal/stripes/line,
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -15188,6 +15063,11 @@
 /obj/structure/sign/calendar/directional/south,
 /turf/open/floor/plating,
 /area/station/service/abandoned_gambling_den)
+"dKe" = (
+/obj/effect/turf_decal/stripes/line,
+/obj/structure/sign/warning/deathsposal,
+/turf/open/floor/iron,
+/area/station/engineering/atmos/hfr_room)
 "dKg" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -15215,6 +15095,7 @@
 "dKz" = (
 /obj/machinery/photocopier,
 /obj/item/radio/intercom/directional/east,
+/obj/machinery/light/small/directional/north,
 /turf/open/floor/carpet/royalblack,
 /area/station/service/chapel/office)
 "dKC" = (
@@ -15711,12 +15592,6 @@
 /obj/effect/turf_decal/tile/red/fourcorners,
 /turf/open/floor/iron,
 /area/station/security/processing)
-"dPN" = (
-/obj/structure/lattice/catwalk,
-/obj/machinery/atmospherics/pipe/smart/simple/orange/visible,
-/obj/structure/sign/warning/secure_area/directional/east,
-/turf/open/space/basic,
-/area/space/nearstation)
 "dPR" = (
 /turf/closed/wall/r_wall,
 /area/station/maintenance/solars/port/aft)
@@ -15856,6 +15731,7 @@
 /area/station/science/ordnance/testlab)
 "dRG" = (
 /obj/effect/spawner/random/structure/twelve_percent_spirit_board,
+/obj/machinery/light/small/directional/east,
 /turf/open/floor/iron/grimy,
 /area/station/service/chapel/office)
 "dRJ" = (
@@ -16253,12 +16129,9 @@
 /turf/open/floor/iron,
 /area/station/maintenance/port)
 "dXw" = (
-/obj/structure/sign/painting/large/library_private{
-	dir = 1;
-	pixel_x = -29
-	},
 /obj/structure/destructible/cult/item_dispenser/archives/library,
 /obj/item/book/codex_gigas,
+/obj/structure/sign/painting/large/library_private,
 /turf/open/floor/iron/dark,
 /area/station/service/library/printer)
 "dXD" = (
@@ -16606,7 +16479,6 @@
 /obj/structure/table,
 /obj/item/paper_bin,
 /obj/item/pen,
-/obj/structure/sign/poster/contraband/borg_fancy_2/directional/south,
 /turf/open/floor/iron,
 /area/station/science/research/abandoned)
 "ecm" = (
@@ -16676,6 +16548,10 @@
 	},
 /turf/open/floor/iron,
 /area/station/security/prison)
+"edc" = (
+/obj/structure/sign/warning/electric_shock/directional/north,
+/turf/open/floor/plating,
+/area/station/maintenance/port/aft)
 "edd" = (
 /turf/closed/wall,
 /area/station/service/chapel/storage)
@@ -16953,9 +16829,6 @@
 /turf/open/floor/plating,
 /area/station/cargo/storage)
 "ehg" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /obj/machinery/newscaster/directional/west,
 /obj/structure/table/wood,
 /obj/item/clipboard,
@@ -17013,15 +16886,11 @@
 	dir = 1
 	},
 /obj/machinery/light/small/directional/north,
+/obj/structure/sign/nanotrasen,
 /turf/open/floor/iron/dark/corner{
 	dir = 1
 	},
 /area/station/hallway/secondary/exit/departure_lounge)
-"ehJ" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/sign/poster/contraband/random/directional/south,
-/turf/open/floor/plating,
-/area/station/maintenance/department/science)
 "ehL" = (
 /obj/structure/cable,
 /obj/effect/decal/cleanable/dirt,
@@ -17079,10 +16948,6 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /turf/open/floor/iron,
 /area/station/security/prison/safe)
-"eiK" = (
-/obj/structure/sign/warning/secure_area/directional/east,
-/turf/closed/wall/r_wall,
-/area/station/maintenance/disposal/incinerator)
 "eiU" = (
 /obj/structure/cable,
 /obj/effect/decal/cleanable/dirt,
@@ -17140,7 +17005,6 @@
 /turf/open/floor/iron/white,
 /area/station/medical/virology)
 "ekF" = (
-/obj/structure/sign/poster/official/random/directional/south,
 /obj/machinery/light/directional/south,
 /obj/structure/window/reinforced/spawner/directional/west,
 /obj/structure/disposalpipe/trunk{
@@ -17233,7 +17097,6 @@
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment,
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/sign/poster/random/directional/east,
 /turf/open/floor/plating,
 /area/station/maintenance/fore)
 "elT" = (
@@ -17370,7 +17233,6 @@
 /obj/item/clothing/head/cone,
 /obj/item/clothing/head/cone,
 /obj/item/clothing/head/cone,
-/obj/structure/sign/poster/official/moth_delam/directional/south,
 /turf/open/floor/iron,
 /area/station/engineering/main)
 "eos" = (
@@ -17486,6 +17348,7 @@
 /obj/effect/turf_decal/tile/yellow{
 	dir = 8
 	},
+/obj/structure/sign/warning/radiation/rad_area/directional/north,
 /turf/open/floor/iron/dark/corner{
 	dir = 1
 	},
@@ -17866,13 +17729,6 @@
 /obj/structure/cable,
 /turf/open/floor/iron/solarpanel/airless,
 /area/station/solars/port/aft)
-"etw" = (
-/obj/structure/lattice,
-/obj/structure/sign/nanotrasen{
-	pixel_y = 32
-	},
-/turf/open/space,
-/area/space/nearstation)
 "ety" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
@@ -17894,16 +17750,6 @@
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/iron,
 /area/station/hallway/secondary/exit/departure_lounge)
-"etR" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/sign/poster/random/directional/west,
-/obj/effect/turf_decal/tile/neutral/half/contrasted{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/station/maintenance/port/fore)
 "etS" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/stripes/line{
@@ -17999,7 +17845,6 @@
 "euV" = (
 /obj/item/kirbyplants/random,
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/sign/warning/electric_shock/directional/south,
 /obj/machinery/firealarm/directional/west,
 /turf/open/floor/iron,
 /area/station/engineering/storage)
@@ -18179,7 +18024,6 @@
 /turf/open/floor/iron/dark,
 /area/station/engineering/atmos/hfr_room)
 "exS" = (
-/obj/structure/sign/poster/official/work_for_a_future/directional/west,
 /obj/machinery/firealarm/directional/south,
 /obj/machinery/vending/cigarette,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
@@ -18209,7 +18053,6 @@
 /obj/effect/turf_decal/trimline/purple/filled/corner{
 	dir = 8
 	},
-/obj/machinery/airalarm/directional/south,
 /obj/machinery/photocopier,
 /turf/open/floor/iron/white,
 /area/station/science/research)
@@ -18728,7 +18571,6 @@
 /turf/open/floor/plating,
 /area/station/service/kitchen/abandoned)
 "eGq" = (
-/obj/structure/sign/poster/official/do_not_question/directional/west,
 /obj/structure/sign/poster/official/random/directional/north,
 /turf/open/floor/carpet,
 /area/station/commons/vacant_room/office)
@@ -18824,7 +18666,6 @@
 /obj/structure/disposalpipe/junction/flip{
 	dir = 1
 	},
-/obj/structure/sign/poster/official/cleanliness/directional/east,
 /turf/open/floor/iron/white,
 /area/station/medical/medbay)
 "eHt" = (
@@ -19057,6 +18898,7 @@
 /area/station/medical/chemistry)
 "eKi" = (
 /obj/effect/turf_decal/tile/blue/half/contrasted,
+/obj/item/radio/intercom/directional/south,
 /turf/open/floor/iron/dark,
 /area/station/security/checkpoint/customs/aft)
 "eKr" = (
@@ -19078,6 +18920,7 @@
 	dir = 8
 	},
 /obj/structure/cable,
+/obj/structure/sign/warning/vacuum/directional/north,
 /turf/open/floor/iron,
 /area/station/maintenance/starboard/aft)
 "eKz" = (
@@ -19140,6 +18983,7 @@
 /obj/effect/turf_decal/tile/red/anticorner/contrasted{
 	dir = 1
 	},
+/obj/structure/sign/nanotrasen,
 /turf/open/floor/iron,
 /area/station/security/checkpoint/escape)
 "eKX" = (
@@ -19265,7 +19109,6 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/structure/sign/warning/docking/directional/south,
 /obj/machinery/duct,
 /obj/effect/spawner/random/structure/steam_vent,
 /turf/open/floor/plating,
@@ -19434,7 +19277,7 @@
 /turf/open/floor/carpet/black,
 /area/station/maintenance/port)
 "eOH" = (
-/obj/structure/sign/warning/secure_area/directional/west,
+/obj/structure/sign/warning/secure_area/directional/north,
 /turf/open/space/basic,
 /area/space/nearstation)
 "eOL" = (
@@ -19785,7 +19628,6 @@
 "eSU" = (
 /obj/machinery/computer/atmos_alert,
 /obj/effect/turf_decal/bot,
-/obj/structure/sign/warning/gas_mask/directional/north,
 /obj/machinery/light/small/directional/north,
 /obj/effect/turf_decal/tile/yellow/half/contrasted{
 	dir = 1
@@ -19803,7 +19645,6 @@
 /obj/structure/closet/crate/trashcart,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/sign/poster/official/random/directional/east,
 /turf/open/floor/iron,
 /area/station/security/prison)
 "eTy" = (
@@ -19939,7 +19780,6 @@
 "eUJ" = (
 /obj/effect/turf_decal/bot,
 /obj/structure/closet/firecloset,
-/obj/structure/sign/poster/official/random/directional/west,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron/dark,
 /area/station/hallway/primary/port)
@@ -20018,10 +19858,6 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /turf/open/floor/iron/large,
 /area/station/security/office)
-"eVp" = (
-/obj/structure/sign/warning/secure_area/directional/south,
-/turf/open/floor/glass/reinforced,
-/area/station/maintenance/department/science/xenobiology)
 "eVq" = (
 /turf/open/floor/iron/grimy,
 /area/station/service/chapel/office)
@@ -20287,6 +20123,7 @@
 /obj/effect/turf_decal/tile/yellow{
 	dir = 4
 	},
+/obj/structure/sign/warning/radiation/rad_area/directional/north,
 /turf/open/floor/iron/dark/corner,
 /area/station/engineering/supermatter/room)
 "eYJ" = (
@@ -20328,10 +20165,6 @@
 /obj/effect/turf_decal/trimline/blue/filled/corner{
 	dir = 8
 	},
-/obj/structure/sign/warning/cold_temp/directional/west{
-	desc = "A sign that notes the room within is the Cold Room. Not that it's actually cold.";
-	name = "COLD ROOM"
-	},
 /turf/open/floor/iron/white,
 /area/station/medical/medbay)
 "eYY" = (
@@ -20349,12 +20182,16 @@
 /area/station/security/checkpoint/escape)
 "eZe" = (
 /obj/machinery/vending/wardrobe/viro_wardrobe,
-/obj/structure/sign/poster/official/cleanliness/directional/west,
 /obj/effect/turf_decal/bot,
 /obj/effect/turf_decal/siding/green{
 	dir = 4
 	},
 /obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/machinery/button/door/directional/north{
+	id = "viro_private_shutters";
+	name = "Privacy Shutters";
+	pixel_y = 36
+	},
 /turf/open/floor/iron/dark,
 /area/station/medical/virology)
 "eZh" = (
@@ -20411,12 +20248,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/grimy,
 /area/station/maintenance/port/fore)
-"faF" = (
-/obj/structure/cable,
-/obj/effect/spawner/structure/window/reinforced,
-/obj/structure/sign/warning/vacuum,
-/turf/open/floor/plating,
-/area/station/security/processing)
 "faP" = (
 /obj/effect/turf_decal/tile/yellow/diagonal_edge,
 /obj/effect/turf_decal/tile/red/diagonal_centre,
@@ -20452,7 +20283,6 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
-/obj/structure/sign/poster/official/moth_piping/directional/west,
 /obj/machinery/light/small/directional/west,
 /turf/open/floor/engine,
 /area/station/engineering/supermatter/room)
@@ -20601,7 +20431,6 @@
 /turf/open/floor/iron,
 /area/station/engineering/atmos/project)
 "fdb" = (
-/obj/structure/sign/poster/official/report_crimes/directional/south,
 /obj/structure/aquarium/lawyer,
 /turf/open/floor/wood,
 /area/station/service/lawoffice)
@@ -20848,7 +20677,6 @@
 /obj/item/wrench,
 /obj/item/clothing/under/suit/waiter,
 /obj/item/clothing/accessory/waistcoat,
-/obj/structure/sign/poster/contraband/random/directional/west,
 /obj/machinery/barsign/all_access/directional/north,
 /turf/open/floor/iron/dark,
 /area/station/service/electronic_marketing_den)
@@ -20882,9 +20710,7 @@
 /obj/item/kirbyplants/random,
 /obj/machinery/power/apc/auto_name/directional/north,
 /obj/structure/cable,
-/obj/machinery/light_switch/directional/north{
-	pixel_x = -10
-	},
+/obj/machinery/light_switch/directional/north,
 /turf/open/floor/wood/tile,
 /area/station/service/library/artgallery)
 "ffQ" = (
@@ -21140,7 +20966,6 @@
 "fjQ" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/sign/flag/nanotrasen/directional/south,
 /obj/machinery/light/directional/south,
 /obj/structure/cable,
 /obj/effect/turf_decal/tile/neutral/half/contrasted,
@@ -21197,7 +21022,6 @@
 	dir = 10
 	},
 /obj/machinery/light/small/directional/south,
-/obj/structure/sign/warning/biohazard/directional/west,
 /turf/open/floor/iron,
 /area/station/medical/medbay)
 "fkB" = (
@@ -21637,15 +21461,6 @@
 	},
 /turf/open/floor/iron,
 /area/station/science/xenobiology)
-"fpu" = (
-/obj/structure/cable,
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/duct,
-/obj/machinery/firealarm/directional/west,
-/turf/open/floor/iron/white,
-/area/station/science/research)
 "fpv" = (
 /obj/effect/spawner/random/engineering/atmospherics_portable,
 /obj/effect/turf_decal/trimline/yellow/filled/line{
@@ -21952,9 +21767,6 @@
 /turf/open/floor/iron,
 /area/station/maintenance/department/crew_quarters/bar)
 "ftG" = (
-/obj/structure/sign/nanotrasen{
-	pixel_y = -32
-	},
 /obj/structure/table,
 /obj/machinery/cell_charger,
 /obj/item/gps,
@@ -22092,10 +21904,6 @@
 /obj/effect/decal/cleanable/cobweb,
 /turf/open/floor/plating,
 /area/station/maintenance/department/eva/abandoned)
-"fvZ" = (
-/obj/structure/sign/warning/no_smoking,
-/turf/closed/wall/r_wall,
-/area/station/ai_monitored/turret_protected/aisat_interior)
 "fwa" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -22138,7 +21946,6 @@
 	c_tag = "Service - Mime's Room";
 	name = "service camera"
 	},
-/obj/structure/sign/poster/random/directional/east,
 /turf/open/floor/wood,
 /area/station/service/theater)
 "fwt" = (
@@ -22316,9 +22123,6 @@
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
 "fyU" = (
-/obj/structure/sign/nanotrasen{
-	pixel_y = -32
-	},
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/tile/neutral,
 /obj/machinery/light/directional/south,
@@ -22522,8 +22326,8 @@
 "fBk" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/bot,
-/obj/machinery/airalarm/directional/north,
 /obj/effect/spawner/random/maintenance,
+/obj/structure/sign/poster/random/directional/north,
 /turf/open/floor/iron,
 /area/station/maintenance/department/engine/atmos)
 "fBp" = (
@@ -22546,7 +22350,6 @@
 "fBL" = (
 /obj/effect/turf_decal/bot,
 /obj/machinery/portable_atmospherics/pipe_scrubber,
-/obj/structure/sign/poster/official/there_is_no_gas_giant/directional/east,
 /turf/open/floor/iron/textured_large,
 /area/station/engineering/atmos/project)
 "fBQ" = (
@@ -22681,7 +22484,6 @@
 /area/station/engineering/main)
 "fEd" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/sign/warning/vacuum/directional/west,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron/dark,
 /area/station/security/execution/education)
@@ -22752,7 +22554,6 @@
 /turf/open/floor/plating,
 /area/station/service/abandoned_gambling_den)
 "fEV" = (
-/obj/structure/sign/poster/official/moth_epi/directional/west,
 /obj/effect/turf_decal/bot,
 /obj/structure/disposalpipe/trunk{
 	dir = 1
@@ -23010,6 +22811,7 @@
 /area/station/command/bridge)
 "fIn" = (
 /obj/structure/bookcase/random,
+/obj/structure/sign/nanotrasen,
 /turf/open/floor/wood,
 /area/station/command/meeting_room/council)
 "fIp" = (
@@ -23055,8 +22857,8 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/sign/warning/docking/directional/north,
 /obj/structure/cable,
+/obj/structure/sign/warning/directional/north,
 /turf/open/floor/plating,
 /area/station/maintenance/department/chapel)
 "fIQ" = (
@@ -23802,6 +23604,12 @@
 	},
 /turf/open/floor/plating/airless,
 /area/station/science/ordnance/bomb)
+"fSt" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/structure/sign/nanotrasen,
+/turf/open/floor/iron/dark,
+/area/station/ai_monitored/turret_protected/ai)
 "fSw" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable,
@@ -23993,10 +23801,6 @@
 /area/station/science/xenobiology)
 "fVd" = (
 /obj/structure/cable,
-/obj/structure/sign/warning/no_smoking/circle{
-	pixel_x = 28;
-	pixel_y = -28
-	},
 /obj/machinery/modular_computer/preset/engineering{
 	dir = 1
 	},
@@ -24525,14 +24329,6 @@
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron/dark,
 /area/station/command/heads_quarters/hos)
-"gbD" = (
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/sign/poster/random/directional/east,
-/turf/open/floor/plating,
-/area/station/maintenance/port/fore)
 "gbF" = (
 /obj/effect/turf_decal/stripes/corner{
 	dir = 8
@@ -24780,9 +24576,6 @@
 /turf/open/floor/iron/white,
 /area/station/medical/medbay)
 "gee" = (
-/obj/structure/sign/painting/library{
-	pixel_y = -32
-	},
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/light/directional/south,
@@ -24856,7 +24649,7 @@
 "geR" = (
 /obj/machinery/vending/engivend,
 /obj/effect/turf_decal/delivery,
-/obj/structure/sign/poster/official/moth_hardhat/directional/east,
+/obj/machinery/light_switch/directional/east,
 /turf/open/floor/iron,
 /area/station/engineering/main)
 "geU" = (
@@ -24942,9 +24735,6 @@
 /area/station/security/checkpoint/arrivals)
 "gfp" = (
 /obj/structure/table/wood,
-/obj/structure/sign/nanotrasen{
-	pixel_x = -32
-	},
 /obj/machinery/computer/security/telescreen/entertainment/directional/south,
 /turf/open/floor/wood,
 /area/station/commons/dorms)
@@ -24962,7 +24752,6 @@
 /turf/open/floor/iron/dark,
 /area/station/science/auxlab/firing_range)
 "gfw" = (
-/obj/structure/sign/warning/secure_area/directional/south,
 /obj/structure/table,
 /obj/item/assembly/infra,
 /obj/structure/disposalpipe/segment{
@@ -25025,7 +24814,6 @@
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/aisat/exterior)
 "ggz" = (
-/obj/machinery/firealarm/directional/south,
 /obj/effect/turf_decal/tile/blue/anticorner/contrasted{
 	dir = 8
 	},
@@ -25354,7 +25142,6 @@
 "gkW" = (
 /obj/structure/table/wood,
 /obj/item/storage/briefcase,
-/obj/structure/sign/poster/official/help_others/directional/east,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron/dark,
 /area/station/security/courtroom)
@@ -25650,12 +25437,6 @@
 /obj/effect/landmark/generic_maintenance_landmark,
 /turf/open/floor/iron,
 /area/station/maintenance/starboard/aft)
-"goj" = (
-/obj/structure/sign/painting/library{
-	pixel_y = 33
-	},
-/turf/open/floor/carpet/green,
-/area/station/commons/dorms)
 "gor" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -25760,11 +25541,14 @@
 	},
 /obj/machinery/light/directional/west,
 /obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/sign/poster/official/random/directional/west,
 /turf/open/floor/iron/half{
 	dir = 1
 	},
 /area/station/cargo/miningoffice)
+"gpG" = (
+/obj/structure/sign/nanotrasen,
+/turf/open/floor/plating,
+/area/station/maintenance/port/aft)
 "gpI" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -25891,13 +25675,6 @@
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron/dark,
 /area/station/security/brig)
-"gri" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/sign/poster/random/directional/south,
-/obj/effect/turf_decal/tile/neutral/half/contrasted,
-/turf/open/floor/iron,
-/area/station/commons/dorms)
 "grl" = (
 /obj/effect/turf_decal/bot,
 /obj/structure/rack,
@@ -25907,6 +25684,7 @@
 /obj/item/tank/internals/emergency_oxygen/engi,
 /obj/item/clothing/glasses/meson,
 /obj/item/clothing/glasses/meson,
+/obj/structure/sign/warning/secure_area/directional/north,
 /turf/open/floor/iron,
 /area/station/engineering/main)
 "grm" = (
@@ -26406,7 +26184,6 @@
 	dir = 4
 	},
 /obj/effect/spawner/random/structure/closet_private,
-/obj/structure/sign/poster/random/directional/west,
 /turf/open/floor/wood,
 /area/station/hallway/secondary/service)
 "gwx" = (
@@ -26485,7 +26262,6 @@
 "gxL" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/sign/poster/random/directional/east,
 /obj/effect/turf_decal/tile/yellow{
 	dir = 4
 	},
@@ -26785,7 +26561,6 @@
 	},
 /obj/item/reagent_containers/cup/bottle/multiver,
 /obj/item/reagent_containers/syringe,
-/obj/structure/sign/poster/official/cleanliness/directional/east,
 /obj/machinery/vending/wallmed/directional/north,
 /obj/effect/turf_decal/siding/dark_red,
 /obj/effect/turf_decal/tile/neutral/half/contrasted{
@@ -26846,7 +26621,6 @@
 /turf/open/floor/iron/dark,
 /area/station/security/mechbay)
 "gCn" = (
-/obj/structure/sign/warning/electric_shock/directional/east,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 1
 	},
@@ -26929,6 +26703,7 @@
 /obj/effect/turf_decal/tile/neutral/half/contrasted{
 	dir = 1
 	},
+/obj/structure/sign/poster/official/ion_rifle/directional/north,
 /turf/open/floor/iron,
 /area/station/maintenance/department/science)
 "gCL" = (
@@ -26950,7 +26725,6 @@
 /turf/open/floor/iron,
 /area/station/security/courtroom)
 "gCS" = (
-/obj/structure/sign/poster/official/science/directional/west,
 /obj/effect/turf_decal/stripes/line,
 /obj/machinery/status_display/ai/directional/north,
 /obj/structure/rack,
@@ -27042,10 +26816,6 @@
 "gDV" = (
 /turf/closed/wall,
 /area/station/service/library/lounge)
-"gDW" = (
-/obj/structure/sign/nanotrasen,
-/turf/closed/wall/r_wall,
-/area/station/maintenance/port/aft)
 "gDY" = (
 /obj/effect/turf_decal/tile/neutral/half/contrasted{
 	dir = 1
@@ -27299,7 +27069,6 @@
 	name = "Chapel Requests Console"
 	},
 /obj/effect/mapping_helpers/requests_console/assistance,
-/obj/machinery/light/small/directional/north,
 /turf/open/floor/carpet/royalblack,
 /area/station/service/chapel/office)
 "gHI" = (
@@ -27390,6 +27159,15 @@
 	},
 /turf/open/floor/iron,
 /area/station/security/warden)
+"gIF" = (
+/obj/machinery/atmospherics/components/unary/portables_connector/visible{
+	dir = 8
+	},
+/obj/machinery/portable_atmospherics/canister,
+/obj/effect/turf_decal/bot,
+/obj/structure/sign/warning/radiation/directional/north,
+/turf/open/floor/iron/dark,
+/area/station/engineering/supermatter/room)
 "gII" = (
 /obj/structure/cable,
 /obj/effect/turf_decal/stripes/line{
@@ -27399,6 +27177,7 @@
 /obj/effect/turf_decal/tile/neutral/half/contrasted{
 	dir = 8
 	},
+/obj/structure/sign/warning/deathsposal,
 /turf/open/floor/iron,
 /area/station/science/xenobiology)
 "gIJ" = (
@@ -27661,7 +27440,6 @@
 /turf/open/floor/iron/dark,
 /area/station/hallway/secondary/service)
 "gME" = (
-/obj/structure/sign/warning/vacuum,
 /turf/closed/wall,
 /area/station/cargo/miningoffice)
 "gMK" = (
@@ -27780,6 +27558,12 @@
 	},
 /turf/open/floor/iron,
 /area/station/security/prison)
+"gOF" = (
+/obj/item/kirbyplants/random,
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/structure/sign/nanotrasen,
+/turf/open/floor/iron/dark,
+/area/station/ai_monitored/turret_protected/aisat_interior)
 "gOR" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -27939,7 +27723,6 @@
 /turf/open/floor/iron/cafeteria,
 /area/station/service/cafeteria)
 "gQH" = (
-/obj/structure/sign/warning/secure_area/directional/west,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron/dark,
 /area/station/engineering/atmos)
@@ -28201,7 +27984,9 @@
 	dir = 4
 	},
 /obj/machinery/door/airlock/external/glass{
-	name = "Supply Door Airlock"
+	name = "Supply Door Airlock";
+	dir = 4;
+	manual_align = 1
 	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -28220,7 +28005,6 @@
 /obj/item/clothing/head/utility/chefhat,
 /obj/item/reagent_containers/condiment/flour,
 /obj/effect/turf_decal/bot,
-/obj/structure/sign/poster/contraband/random/directional/south,
 /obj/item/kitchen/rollingpin{
 	pixel_x = -4
 	},
@@ -28415,6 +28199,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/bot_white/right,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/structure/sign/nanotrasen,
 /turf/open/floor/iron/dark,
 /area/station/command/gateway)
 "gWV" = (
@@ -28616,7 +28401,6 @@
 /obj/machinery/atmospherics/pipe/smart/simple/dark/visible{
 	dir = 5
 	},
-/obj/structure/sign/warning/secure_area/directional/south,
 /obj/machinery/light/directional/south,
 /obj/effect/turf_decal/trimline/yellow/filled/line,
 /turf/open/floor/iron,
@@ -28759,6 +28543,7 @@
 /area/station/engineering/atmos/pumproom)
 "hbW" = (
 /obj/effect/spawner/random/structure/crate,
+/obj/structure/sign/departments/medbay/alt/directional/west,
 /turf/open/floor/plating,
 /area/station/maintenance/department/chapel)
 "hcb" = (
@@ -28851,11 +28636,11 @@
 /area/station/medical/morgue)
 "hcW" = (
 /obj/machinery/light/directional/north,
-/obj/structure/sign/warning/gas_mask/directional/north,
 /obj/effect/turf_decal/tile/neutral/full,
 /obj/machinery/atmospherics/components/binary/pump/on/supply/visible/layer4{
 	dir = 4
 	},
+/obj/item/radio/intercom/directional/north,
 /turf/open/floor/iron/dark/smooth_large,
 /area/station/science/ordnance)
 "hdx" = (
@@ -29057,7 +28842,6 @@
 /area/station/hallway/secondary/entry)
 "hfM" = (
 /obj/effect/decal/cleanable/glass,
-/obj/structure/sign/poster/contraband/random/directional/west,
 /turf/open/floor/plating,
 /area/station/maintenance/fore)
 "hfN" = (
@@ -29373,7 +29157,6 @@
 /area/station/maintenance/department/chapel)
 "hkJ" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/sign/warning/no_smoking/directional/east,
 /obj/structure/tank_dispenser,
 /obj/machinery/camera/directional/east{
 	c_tag = "Engineering - Gear Storage";
@@ -29588,9 +29371,6 @@
 /area/station/hallway/secondary/command)
 "hnx" = (
 /obj/structure/table,
-/obj/structure/sign/nanotrasen{
-	pixel_y = -32
-	},
 /obj/machinery/computer/records/security/laptop{
 	dir = 8;
 	pixel_y = 6
@@ -29640,9 +29420,6 @@
 /area/station/engineering/atmos)
 "hnM" = (
 /obj/machinery/pdapainter/research,
-/obj/structure/sign/nanotrasen{
-	pixel_x = -32
-	},
 /obj/effect/turf_decal/bot_red,
 /obj/effect/turf_decal/tile/purple{
 	dir = 8
@@ -30081,6 +29858,7 @@
 /obj/effect/turf_decal/tile/neutral/half/contrasted{
 	dir = 1
 	},
+/obj/machinery/light_switch/directional/north,
 /turf/open/floor/iron,
 /area/station/commons/toilet/locker)
 "huH" = (
@@ -30148,7 +29926,6 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/bot,
-/obj/structure/sign/warning/cold_temp/directional/south,
 /obj/effect/turf_decal/tile/neutral/half/contrasted{
 	dir = 8
 	},
@@ -30173,9 +29950,6 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
-/obj/structure/sign/nanotrasen{
-	pixel_x = -32
-	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 4
 	},
@@ -30197,7 +29971,6 @@
 /area/station/security/interrogation)
 "hvD" = (
 /obj/structure/chair/stool/bar/directional/north,
-/obj/structure/sign/poster/contraband/random/directional/west,
 /turf/open/floor/iron/grimy,
 /area/station/service/abandoned_gambling_den)
 "hvJ" = (
@@ -30207,6 +29980,12 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/medical/virology)
+"hvX" = (
+/obj/structure/cable,
+/obj/machinery/power/smes/engineering,
+/obj/structure/sign/warning/electric_shock/directional/north,
+/turf/open/floor/circuit/green,
+/area/station/engineering/main)
 "hwa" = (
 /obj/structure/chair{
 	dir = 1
@@ -30366,7 +30145,6 @@
 /area/station/service/chapel/office)
 "hxT" = (
 /obj/structure/table/reinforced,
-/obj/structure/sign/poster/official/random/directional/south,
 /obj/item/relic,
 /obj/effect/spawner/random/maintenance,
 /obj/effect/turf_decal/tile/neutral/half/contrasted,
@@ -30604,6 +30382,7 @@
 	},
 /obj/machinery/door/firedoor,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/structure/sign/plaques/kiddie/library,
 /turf/open/floor/iron/dark,
 /area/station/service/library)
 "hCh" = (
@@ -30684,7 +30463,9 @@
 	dir = 8
 	},
 /obj/machinery/door/airlock/external/glass{
-	name = "Supply Door Airlock"
+	name = "Supply Door Airlock";
+	dir = 4;
+	manual_align = 1
 	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -30845,7 +30626,6 @@
 /obj/item/reagent_containers/cup/beaker,
 /obj/item/reagent_containers/syringe/antiviral,
 /obj/item/reagent_containers/dropper,
-/obj/structure/sign/warning/biohazard/directional/west,
 /obj/structure/cable,
 /obj/structure/table/reinforced/rglass,
 /turf/open/floor/iron,
@@ -31213,6 +30993,7 @@
 	dir = 1
 	},
 /obj/machinery/light/small/directional/west,
+/obj/structure/sign/warning/biohazard/directional/north,
 /turf/open/floor/iron/white,
 /area/station/medical/virology)
 "hKZ" = (
@@ -31350,6 +31131,10 @@
 	},
 /turf/open/floor/iron,
 /area/station/maintenance/department/medical/morgue)
+"hNe" = (
+/obj/structure/sign/warning/electric_shock/directional/north,
+/turf/closed/wall/r_wall,
+/area/station/command/heads_quarters/hos)
 "hNg" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -31390,7 +31175,6 @@
 /turf/open/floor/iron,
 /area/station/commons/toilet/locker)
 "hNP" = (
-/obj/structure/sign/poster/contraband/random/directional/west,
 /obj/effect/turf_decal/tile/yellow/opposingcorners{
 	dir = 1
 	},
@@ -31417,7 +31201,9 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/door/poddoor{
 	id = "engstorage";
-	name = "Engineering Secure Storage Lockdown"
+	name = "Engineering Secure Storage Lockdown";
+	dir = 4;
+	manual_align = 1
 	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -31574,7 +31360,6 @@
 /area/station/security/prison/safe)
 "hPO" = (
 /obj/machinery/light/small/directional/south,
-/obj/structure/sign/warning/vacuum/directional/west,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron/dark,
 /area/station/engineering/hallway)
@@ -31592,20 +31377,14 @@
 /turf/open/floor/plating,
 /area/station/security/office)
 "hQr" = (
-/obj/machinery/light_switch/directional/north,
 /obj/machinery/disposal/bin,
 /obj/effect/turf_decal/bot,
-/obj/structure/sign/warning/deathsposal/directional/east,
 /obj/structure/disposalpipe/trunk,
 /obj/effect/turf_decal/trimline/green/filled/line{
 	dir = 5
 	},
-/obj/machinery/button/door/directional/north{
-	id = "viro_private_shutters";
-	name = "Privacy Shutters";
-	pixel_y = 36
-	},
 /obj/machinery/light/small/directional/east,
+/obj/structure/sign/warning/deathsposal/directional/north,
 /turf/open/floor/iron/white,
 /area/station/medical/virology)
 "hQs" = (
@@ -31773,6 +31552,7 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/structure/sign/warning/gas_mask/directional/north,
 /turf/open/floor/iron/dark/telecomms,
 /area/station/science/xenobiology)
 "hSl" = (
@@ -31907,7 +31687,6 @@
 /obj/structure/chair/office{
 	dir = 1
 	},
-/obj/structure/sign/poster/random/directional/south,
 /obj/machinery/light/small/directional/south,
 /turf/open/floor/iron/dark,
 /area/station/hallway/secondary/service)
@@ -31983,10 +31762,6 @@
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron/dark,
 /area/station/hallway/secondary/entry)
-"hUV" = (
-/obj/structure/sign/warning/no_smoking,
-/turf/closed/wall,
-/area/station/engineering/atmos/storage)
 "hVi" = (
 /obj/machinery/power/apc/auto_name/directional/west,
 /obj/structure/cable,
@@ -32207,6 +31982,12 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/station/science/research/abandoned)
+"hXQ" = (
+/obj/structure/lattice/catwalk,
+/obj/structure/cable,
+/obj/structure/sign/warning/secure_area/directional/north,
+/turf/open/space/basic,
+/area/space/nearstation)
 "hXZ" = (
 /obj/item/storage/box/teargas{
 	pixel_x = 3;
@@ -32691,7 +32472,6 @@
 /turf/open/floor/iron,
 /area/station/hallway/secondary/command)
 "icX" = (
-/obj/structure/sign/warning/pods/directional/west,
 /obj/effect/turf_decal/stripes/line{
 	dir = 9
 	},
@@ -32752,9 +32532,6 @@
 /turf/open/floor/plating,
 /area/station/maintenance/department/electrical)
 "idD" = (
-/obj/structure/sign/nanotrasen{
-	pixel_x = -32
-	},
 /obj/machinery/disposal/bin,
 /obj/structure/disposalpipe/trunk{
 	dir = 4
@@ -32854,6 +32631,7 @@
 	},
 /obj/structure/cable,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/machinery/light/floor,
 /turf/open/floor/iron,
 /area/station/science/research)
 "ieM" = (
@@ -32905,6 +32683,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/vending/cigarette,
 /obj/structure/sign/warning/electric_shock/directional/north,
+/obj/machinery/light/small/directional/north,
 /turf/open/floor/plating,
 /area/station/service/abandoned_gambling_den)
 "ifp" = (
@@ -32987,6 +32766,10 @@
 /obj/item/stack/rods/fifty,
 /turf/open/floor/plating,
 /area/station/maintenance/department/eva/abandoned)
+"igZ" = (
+/obj/structure/sign/warning/docking/directional/north,
+/turf/open/space/basic,
+/area/space)
 "iho" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -33193,7 +32976,6 @@
 /turf/open/floor/plating,
 /area/station/maintenance/port)
 "ikn" = (
-/obj/structure/sign/poster/party_game/directional/west,
 /obj/structure/table,
 /obj/item/storage/briefcase/secure{
 	pixel_x = 3;
@@ -33323,6 +33105,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/tile/yellow/opposingcorners,
+/obj/structure/sign/warning/secure_area/directional/north,
 /turf/open/floor/iron,
 /area/station/engineering/supermatter/room)
 "ilH" = (
@@ -33657,7 +33440,6 @@
 /turf/open/floor/plating,
 /area/station/maintenance/fore)
 "iqn" = (
-/obj/structure/mirror/directional/west,
 /obj/effect/landmark/start/hangover,
 /obj/structure/sink/directional/east,
 /obj/effect/turf_decal/bot,
@@ -33675,8 +33457,8 @@
 /obj/item/crowbar,
 /obj/item/grenade/chem_grenade/smart_metal_foam,
 /obj/item/grenade/chem_grenade/smart_metal_foam,
-/obj/structure/sign/poster/official/report_crimes/directional/north,
 /obj/effect/turf_decal/bot,
+/obj/structure/sign/poster/official/report_crimes/directional/north,
 /turf/open/floor/iron,
 /area/station/engineering/storage)
 "iqT" = (
@@ -33872,6 +33654,9 @@
 "isQ" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/reagent_dispensers/watertank,
+/obj/machinery/status_display/supply{
+	pixel_y = 32
+	},
 /turf/open/floor/iron,
 /area/station/cargo/storage)
 "isR" = (
@@ -34095,11 +33880,6 @@
 /obj/machinery/light/small/directional/east,
 /turf/open/floor/iron,
 /area/station/cargo/warehouse)
-"ivH" = (
-/obj/machinery/light/small/directional/south,
-/obj/structure/sign/warning/radiation/directional/south,
-/turf/open/floor/engine,
-/area/station/engineering/supermatter)
 "ivK" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -34160,9 +33940,6 @@
 /turf/open/floor/plating,
 /area/station/maintenance/port/fore)
 "iwW" = (
-/obj/structure/sign/painting/library{
-	pixel_y = -32
-	},
 /obj/effect/spawner/random/structure/closet_private,
 /obj/effect/landmark/start/hangover/closet,
 /obj/item/clothing/suit/toggle/lawyer,
@@ -34486,6 +34263,7 @@
 /obj/effect/turf_decal/tile/neutral/half/contrasted{
 	dir = 1
 	},
+/obj/structure/sign/warning/firing_range/directional/north,
 /turf/open/floor/iron,
 /area/station/maintenance/department/science)
 "iBx" = (
@@ -34503,7 +34281,6 @@
 /turf/open/floor/iron,
 /area/station/maintenance/port/aft)
 "iBG" = (
-/obj/structure/sign/poster/official/help_others/directional/east,
 /obj/structure/closet/secure_closet/psychology,
 /obj/item/toy/plush/beeplushie{
 	desc = "Maybe hugging this will make you feel better about yourself.";
@@ -34637,6 +34414,10 @@
 "iDq" = (
 /turf/closed/wall/r_wall,
 /area/station/security/range)
+"iDs" = (
+/obj/structure/sign/warning/deathsposal,
+/turf/open/space/basic,
+/area/space)
 "iDw" = (
 /obj/machinery/camera/directional/south{
 	c_tag = "Central Hallway - Center Starboard";
@@ -35045,12 +34826,6 @@
 /obj/structure/sign/warning/electric_shock/directional/north,
 /turf/open/floor/plating,
 /area/station/service/abandoned_gambling_den)
-"iIz" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/structure/sign/warning/electric_shock/directional/west,
-/obj/structure/cable,
-/turf/open/floor/plating,
-/area/station/security/processing)
 "iIM" = (
 /obj/effect/turf_decal/tile/red/diagonal_centre,
 /obj/effect/turf_decal/tile/blue/diagonal_edge,
@@ -35347,12 +35122,10 @@
 /area/station/science/ordnance/burnchamber)
 "iMO" = (
 /obj/structure/closet/secure_closet/personal,
-/obj/structure/sign/nanotrasen{
-	pixel_x = 32
-	},
 /obj/item/storage/wallet,
 /obj/effect/turf_decal/bot,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/structure/sign/nanotrasen,
 /turf/open/floor/iron/dark,
 /area/station/commons/locker)
 "iMV" = (
@@ -35371,7 +35144,6 @@
 "iNe" = (
 /obj/machinery/hydroponics/soil,
 /obj/item/cultivator,
-/obj/structure/sign/warning/electric_shock/directional/west,
 /turf/open/misc/sandy_dirt,
 /area/station/security/prison/garden)
 "iNg" = (
@@ -35968,7 +35740,6 @@
 /area/station/science/xenobiology)
 "iVT" = (
 /obj/machinery/photocopier,
-/obj/structure/sign/poster/official/work_for_a_future/directional/east,
 /turf/open/floor/wood,
 /area/station/command/heads_quarters/hop)
 "iVU" = (
@@ -36246,12 +36017,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/station/science/research/abandoned)
-"iYI" = (
-/obj/structure/sign/warning/secure_area/directional/west,
-/obj/machinery/atmospherics/pipe/smart/simple/yellow/visible,
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating,
-/area/station/engineering/atmos)
 "iYJ" = (
 /obj/structure/table/wood,
 /obj/item/camera,
@@ -36403,6 +36168,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable/layer3,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/structure/sign/nanotrasen,
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/turret_protected/ai)
 "jaz" = (
@@ -36418,6 +36184,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
+/obj/structure/sign/warning/secure_area/directional/north,
 /turf/open/floor/plating,
 /area/station/maintenance/port)
 "jaV" = (
@@ -36786,13 +36553,6 @@
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron/dark,
 /area/station/command/bridge)
-"jeI" = (
-/obj/structure/sign/nanotrasen{
-	pixel_x = -32;
-	pixel_y = 32
-	},
-/turf/open/floor/wood,
-/area/station/command/heads_quarters/captain)
 "jeM" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /turf/open/floor/iron/dark,
@@ -36849,15 +36609,20 @@
 /obj/machinery/status_display/evac/directional/south,
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/command/nuke_storage)
+"jff" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/station/maintenance/disposal/incinerator)
 "jfn" = (
 /obj/machinery/vending/wardrobe/bar_wardrobe,
-/obj/structure/sign/poster/random/directional/east,
+/obj/structure/sign/poster/random/directional/north,
 /turf/open/floor/iron/checker,
 /area/station/service/bar/backroom)
 "jfo" = (
 /obj/effect/turf_decal/tile/yellow/diagonal_edge,
 /obj/effect/turf_decal/tile/red/diagonal_centre,
-/obj/structure/sign/poster/official/cleanliness/directional/west,
 /obj/machinery/camera/directional/west{
 	c_tag = "Science - Break Room";
 	name = "science camera";
@@ -36902,11 +36667,6 @@
 	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/central/fore)
-"jfL" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/structure/sign/warning/secure_area/directional/west,
-/turf/open/floor/plating,
-/area/station/engineering/atmos/mix)
 "jfP" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -36952,6 +36712,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 9
 	},
+/obj/structure/sign/warning/no_smoking/circle/directional/north,
 /turf/open/floor/iron,
 /area/station/maintenance/port)
 "jgb" = (
@@ -36999,10 +36760,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
 /area/station/engineering/supermatter/room)
-"jgH" = (
-/obj/structure/sign/warning/electric_shock/directional/east,
-/turf/open/space/basic,
-/area/space/nearstation)
 "jgN" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -37189,7 +36946,6 @@
 	name = "engineering camera";
 	network = list("ss13","engine")
 	},
-/obj/structure/sign/warning/radiation/directional/east,
 /turf/open/floor/engine,
 /area/station/engineering/supermatter)
 "jjC" = (
@@ -37229,6 +36985,7 @@
 /obj/effect/turf_decal/bot,
 /obj/structure/rack,
 /obj/machinery/newscaster/directional/west,
+/obj/structure/sign/warning/electric_shock/directional/north,
 /turf/open/floor/iron/dark,
 /area/station/engineering/main)
 "jkd" = (
@@ -37443,6 +37200,7 @@
 /obj/effect/turf_decal/tile/yellow/opposingcorners{
 	dir = 1
 	},
+/obj/structure/sign/warning/no_smoking/circle/directional/north,
 /turf/open/floor/iron/dark/corner{
 	dir = 1
 	},
@@ -37550,6 +37308,7 @@
 /obj/structure/cable,
 /obj/machinery/power/apc/auto_name/directional/east,
 /obj/effect/turf_decal/tile/neutral/anticorner/contrasted,
+/obj/machinery/airalarm/directional/east,
 /turf/open/floor/iron,
 /area/station/security/courtroom)
 "jni" = (
@@ -37689,14 +37448,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/station/engineering/hallway)
-"joz" = (
-/obj/structure/lattice/catwalk,
-/obj/machinery/atmospherics/pipe/smart/simple/orange/visible{
-	dir = 8
-	},
-/obj/structure/sign/warning/secure_area/directional/south,
-/turf/open/space/basic,
-/area/space/nearstation)
 "joB" = (
 /obj/machinery/conveyor{
 	dir = 4;
@@ -37802,6 +37553,7 @@
 /obj/structure/disposalpipe/trunk{
 	dir = 8
 	},
+/obj/structure/sign/warning/secure_area/directional/north,
 /turf/open/floor/plating/airless,
 /area/space/nearstation)
 "jqr" = (
@@ -37942,7 +37694,6 @@
 /turf/open/floor/iron,
 /area/station/engineering/atmos/project)
 "jso" = (
-/obj/structure/sign/poster/random/directional/east,
 /obj/structure/chair/comfy/beige{
 	dir = 8
 	},
@@ -38065,10 +37816,6 @@
 "jtC" = (
 /turf/open/floor/plating,
 /area/station/service/abandoned_gambling_den)
-"jtV" = (
-/obj/structure/sign/warning/electric_shock,
-/turf/closed/wall/r_wall,
-/area/station/maintenance/port/aft)
 "jui" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -38346,6 +38093,7 @@
 /obj/effect/spawner/random/structure/table_or_rack,
 /obj/item/stack/rods/ten,
 /obj/effect/spawner/random/maintenance,
+/obj/machinery/light/small/dim/directional/north,
 /turf/open/floor/plating,
 /area/station/maintenance/department/science/xenobiology)
 "jyu" = (
@@ -38516,6 +38264,19 @@
 	},
 /turf/open/floor/iron,
 /area/station/maintenance/department/science)
+"jAe" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/sign/warning/secure_area/directional/north,
+/turf/open/floor/plating,
+/area/station/maintenance/starboard/fore)
 "jAf" = (
 /obj/structure/chair/pew/left,
 /turf/open/floor/iron/chapel{
@@ -38551,11 +38312,10 @@
 /obj/effect/mapping_helpers/airlock/access/all/engineering/atmos,
 /turf/open/floor/iron,
 /area/station/engineering/atmos/storage)
-"jAx" = (
-/obj/structure/lattice,
-/obj/structure/sign/warning/electric_shock/directional/east,
-/turf/open/space/basic,
-/area/space/nearstation)
+"jAC" = (
+/obj/structure/sign/painting/library,
+/turf/open/floor/carpet/green,
+/area/station/commons/dorms)
 "jAI" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -39020,9 +38780,6 @@
 	dir = 4
 	},
 /obj/item/bedsheet/medical,
-/obj/structure/sign/nanotrasen{
-	pixel_x = 32
-	},
 /obj/effect/turf_decal/trimline/green/filled/line{
 	dir = 5
 	},
@@ -39050,14 +38807,6 @@
 /obj/effect/mapping_helpers/airlock/access/all/engineering/atmos,
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
-"jGs" = (
-/obj/structure/sign/directions/engineering{
-	desc = "A sign that shows there are doors here. There are doors everywhere!";
-	icon_state = "doors";
-	name = "WARNING: EXTERNAL AIRLOCK"
-	},
-/turf/closed/wall/r_wall,
-/area/station/maintenance/port/aft)
 "jGx" = (
 /obj/structure/disposalpipe/segment{
 	dir = 10
@@ -39137,7 +38886,6 @@
 /obj/structure/chair/sofa/left/brown{
 	dir = 4
 	},
-/obj/machinery/airalarm/directional/north,
 /obj/effect/turf_decal/tile/red/opposingcorners{
 	dir = 1
 	},
@@ -39823,6 +39571,7 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/structure/sign/warning/cold_temp/directional/north,
 /turf/open/floor/iron/dark/telecomms,
 /area/station/science/xenobiology)
 "jQd" = (
@@ -40032,6 +39781,7 @@
 /obj/effect/turf_decal/tile/neutral/half/contrasted{
 	dir = 1
 	},
+/obj/structure/sign/warning/test_chamber/directional/north,
 /turf/open/floor/iron,
 /area/station/maintenance/department/science)
 "jSl" = (
@@ -40448,7 +40198,6 @@
 "jYt" = (
 /obj/structure/closet/crate/wooden/toy,
 /obj/item/toy/mecha/honk,
-/obj/structure/sign/poster/contraband/random/directional/east,
 /obj/effect/turf_decal/tile/blue/opposingcorners{
 	dir = 1
 	},
@@ -40647,11 +40396,9 @@
 /area/station/service/abandoned_gambling_den)
 "kaG" = (
 /obj/structure/closet/secure_closet/personal,
-/obj/structure/sign/nanotrasen{
-	pixel_x = -32
-	},
 /obj/effect/turf_decal/bot,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/structure/sign/nanotrasen,
 /turf/open/floor/iron/dark,
 /area/station/commons/locker)
 "kaL" = (
@@ -40755,10 +40502,7 @@
 	dir = 8
 	},
 /obj/effect/spawner/random/structure/crate,
-/obj/structure/sign/warning/secure_area/directional/west,
-/obj/structure/sign/nanotrasen{
-	pixel_y = 32
-	},
+/obj/structure/sign/nanotrasen,
 /turf/open/floor/iron,
 /area/station/maintenance/department/engine/atmos)
 "kca" = (
@@ -40829,10 +40573,6 @@
 /obj/effect/turf_decal/tile/neutral/half/contrasted,
 /turf/open/floor/iron,
 /area/station/maintenance/department/science)
-"kcR" = (
-/obj/structure/sign/warning/secure_area/directional/east,
-/turf/closed/wall/r_wall,
-/area/station/engineering/transit_tube)
 "kcT" = (
 /obj/machinery/door/morgue{
 	name = "Relic Closet";
@@ -40876,7 +40616,6 @@
 /obj/effect/turf_decal/trimline/purple/filled/line{
 	dir = 1
 	},
-/obj/structure/sign/warning/secure_area/directional/east,
 /turf/open/floor/iron/white,
 /area/station/science/research)
 "kdC" = (
@@ -40895,8 +40634,8 @@
 /turf/open/floor/iron,
 /area/station/cargo/storage)
 "kdM" = (
-/obj/structure/sign/poster/official/do_not_question/directional/south,
 /obj/effect/turf_decal/tile/blue/half/contrasted,
+/obj/machinery/firealarm/directional/south,
 /turf/open/floor/iron/dark,
 /area/station/security/checkpoint/customs/aft)
 "kdN" = (
@@ -41069,6 +40808,7 @@
 /obj/machinery/disposal/bin,
 /obj/effect/turf_decal/bot,
 /obj/structure/disposalpipe/trunk,
+/obj/structure/extinguisher_cabinet/directional/north,
 /turf/open/floor/iron/dark,
 /area/station/service/library)
 "kfI" = (
@@ -41335,7 +41075,6 @@
 /turf/open/floor/iron/checker,
 /area/station/hallway/secondary/service)
 "kiz" = (
-/obj/structure/sign/poster/random/directional/east,
 /obj/structure/table,
 /obj/item/clipboard,
 /obj/item/folder/white,
@@ -41378,7 +41117,9 @@
 /area/station/engineering/atmos/project)
 "kiR" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/plasticflaps/opaque,
+/obj/structure/plasticflaps/opaque{
+	dir = 4
+	},
 /obj/machinery/door/poddoor/preopen{
 	id = "atmoslock";
 	name = "Atmospherics Lockdown Blast Door"
@@ -41951,9 +41692,6 @@
 /obj/effect/turf_decal/stripes/corner{
 	dir = 1
 	},
-/obj/structure/sign/nanotrasen{
-	pixel_x = -32
-	},
 /obj/item/kirbyplants/random,
 /obj/effect/turf_decal/tile/purple/fourcorners,
 /turf/open/floor/iron,
@@ -42080,16 +41818,6 @@
 /obj/effect/turf_decal/tile/red/half/contrasted,
 /turf/open/floor/iron,
 /area/station/service/kitchen/abandoned)
-"ksJ" = (
-/obj/structure/sign/nanotrasen{
-	pixel_x = -32;
-	pixel_y = -32
-	},
-/obj/machinery/light/small/directional/south,
-/obj/item/kirbyplants/organic/plant22,
-/obj/effect/turf_decal/tile/blue/half/contrasted,
-/turf/open/floor/iron/dark,
-/area/station/command/bridge)
 "ksK" = (
 /turf/closed/wall/r_wall,
 /area/station/command/gateway)
@@ -42396,7 +42124,6 @@
 /turf/open/floor/wood,
 /area/station/service/electronic_marketing_den)
 "kws" = (
-/obj/structure/sign/poster/official/work_for_a_future/directional/south,
 /obj/structure/chair/sofa/bench{
 	dir = 1
 	},
@@ -42412,11 +42139,11 @@
 	dir = 4
 	},
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/sign/warning/docking/directional/north,
 /obj/machinery/duct,
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/sign/warning/directional/north,
 /turf/open/floor/plating,
 /area/station/maintenance/department/chapel)
 "kwL" = (
@@ -42430,7 +42157,6 @@
 /area/station/maintenance/port)
 "kwX" = (
 /obj/effect/mapping_helpers/burnt_floor,
-/obj/structure/sign/warning/electric_shock/directional/south,
 /turf/open/floor/plating,
 /area/station/maintenance/port)
 "kxg" = (
@@ -42514,6 +42240,10 @@
 /obj/effect/turf_decal/tile/yellow/opposingcorners,
 /turf/open/floor/iron,
 /area/station/commons/lounge)
+"kyu" = (
+/obj/structure/sign/nanotrasen,
+/turf/open/floor/iron/white,
+/area/station/science/lobby)
 "kyx" = (
 /obj/structure/cable,
 /obj/effect/turf_decal/tile/yellow/anticorner/contrasted{
@@ -42605,7 +42335,6 @@
 /area/station/service/electronic_marketing_den)
 "kzP" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/sign/poster/official/do_not_question/directional/east,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron/dark,
 /area/station/security/detectives_office/private_investigators_office)
@@ -42652,10 +42381,6 @@
 /obj/structure/reagent_dispensers/water_cooler,
 /turf/open/floor/iron/white/smooth_large,
 /area/station/medical/psychology)
-"kAD" = (
-/obj/structure/sign/warning/electric_shock,
-/turf/closed/wall/r_wall,
-/area/station/engineering/storage/tech)
 "kAE" = (
 /obj/structure/extinguisher_cabinet/directional/west,
 /obj/structure/reagent_dispensers/fueltank,
@@ -42981,7 +42706,6 @@
 /turf/open/floor/iron/dark,
 /area/station/security/prison/visit)
 "kFO" = (
-/obj/structure/sign/poster/random/directional/east,
 /obj/effect/turf_decal/tile/neutral/half/contrasted{
 	dir = 8
 	},
@@ -43119,6 +42843,9 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/open/floor/iron/dark,
 /area/station/service/library/printer)
 "kHp" = (
@@ -43147,7 +42874,6 @@
 /obj/machinery/shieldgen,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/sign/warning/no_smoking/directional/north,
 /obj/effect/turf_decal/bot,
 /obj/machinery/light/small/directional/north,
 /turf/open/floor/iron,
@@ -43263,7 +42989,6 @@
 /turf/open/floor/iron/dark,
 /area/station/service/hydroponics/garden/abandoned)
 "kJF" = (
-/obj/structure/sign/warning/secure_area/directional/south,
 /obj/structure/table/reinforced,
 /obj/machinery/computer/security/telescreen/minisat/directional/east,
 /turf/open/floor/iron/dark,
@@ -43322,9 +43047,7 @@
 /turf/open/floor/plating,
 /area/station/maintenance/department/electrical)
 "kKY" = (
-/obj/structure/sign/nanotrasen{
-	pixel_y = 32
-	},
+/obj/structure/sign/nanotrasen,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 4
 	},
@@ -43457,7 +43180,6 @@
 /area/station/security/brig)
 "kMt" = (
 /obj/machinery/light/small/directional/west,
-/obj/structure/sign/warning/radiation/directional/west,
 /turf/open/floor/engine,
 /area/station/engineering/supermatter)
 "kMu" = (
@@ -43484,10 +43206,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/service/chapel)
-"kMQ" = (
-/obj/structure/sign/warning/electric_shock/directional/west,
-/turf/open/space/basic,
-/area/space/nearstation)
 "kMS" = (
 /turf/open/floor/iron/white/side,
 /area/station/commons/fitness/recreation)
@@ -43571,16 +43289,6 @@
 /obj/effect/turf_decal/tile/yellow/opposingcorners,
 /turf/open/floor/iron,
 /area/station/engineering/atmos/project)
-"kNG" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/door/poddoor/preopen{
-	id = "xenosecure";
-	name = "Secure Pen Shutters"
-	},
-/obj/structure/cable,
-/obj/structure/sign/warning/electric_shock/directional/west,
-/turf/open/floor/plating,
-/area/station/science/xenobiology)
 "kNH" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /turf/open/floor/iron/white/smooth_large,
@@ -43672,6 +43380,10 @@
 /obj/effect/turf_decal/bot,
 /turf/open/floor/iron,
 /area/station/science/xenobiology)
+"kPH" = (
+/obj/structure/sign/warning/secure_area/directional/north,
+/turf/open/space/basic,
+/area/space)
 "kPI" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -43859,7 +43571,6 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 5
 	},
-/obj/structure/sign/warning/pods/directional/east,
 /turf/open/floor/iron,
 /area/station/hallway/secondary/entry)
 "kSc" = (
@@ -43906,6 +43617,13 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/dark,
 /area/station/maintenance/department/engine/atmos)
+"kSC" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/structure/sign/warning/electric_shock/directional/north,
+/turf/open/floor/iron,
+/area/station/maintenance/port)
 "kSR" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -43979,10 +43697,6 @@
 	},
 /turf/open/floor/iron/grimy,
 /area/station/command/heads_quarters/hos)
-"kTV" = (
-/obj/structure/sign/warning/radiation,
-/turf/closed/wall/r_wall,
-/area/station/engineering/gravity_generator)
 "kTX" = (
 /obj/machinery/photocopier,
 /obj/item/radio/intercom/directional/south,
@@ -44143,7 +43857,6 @@
 "kVZ" = (
 /obj/structure/closet/secure_closet/freezer/fridge/open,
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/sign/poster/contraband/random/directional/south,
 /turf/open/floor/plating,
 /area/station/service/kitchen/abandoned)
 "kWi" = (
@@ -44321,9 +44034,6 @@
 /turf/open/space/basic,
 /area/space/nearstation)
 "kYb" = (
-/obj/structure/sign/nanotrasen{
-	pixel_x = -32
-	},
 /obj/structure/closet/emcloset,
 /obj/effect/turf_decal/delivery,
 /obj/machinery/camera/directional/west{
@@ -44484,9 +44194,6 @@
 /turf/open/floor/plating,
 /area/station/science/research/abandoned)
 "laJ" = (
-/obj/structure/sign/nanotrasen{
-	pixel_x = 32
-	},
 /obj/effect/turf_decal/tile/blue/half/contrasted,
 /turf/open/floor/iron,
 /area/station/security/courtroom)
@@ -44528,7 +44235,6 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
-/obj/structure/sign/warning/radiation/directional/south,
 /turf/open/floor/iron,
 /area/station/engineering/supermatter/room)
 "lbo" = (
@@ -44786,7 +44492,6 @@
 "led" = (
 /obj/item/restraints/handcuffs,
 /obj/item/assembly/flash/handheld,
-/obj/structure/sign/poster/official/report_crimes/directional/south,
 /obj/structure/cable,
 /obj/structure/rack,
 /obj/effect/turf_decal/bot,
@@ -44845,9 +44550,6 @@
 /turf/open/floor/iron,
 /area/station/hallway/primary/port)
 "lfs" = (
-/obj/structure/sign/nanotrasen{
-	pixel_y = -32
-	},
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
@@ -45301,20 +45003,11 @@
 /area/station/cargo/office)
 "lks" = (
 /obj/machinery/chem_dispenser,
-/obj/structure/sign/warning/chem_diamond/directional/south,
 /obj/effect/turf_decal/stripes/line,
 /obj/effect/turf_decal/tile/yellow/opposingcorners,
 /obj/machinery/light/small/directional/south,
 /turf/open/floor/iron/dark,
 /area/station/medical/pharmacy)
-"lkx" = (
-/obj/structure/sign/directions/engineering{
-	desc = "A sign that shows there are doors here. There are doors everywhere!";
-	icon_state = "doors";
-	name = "WARNING: EXTERNAL AIRLOCK"
-	},
-/turf/closed/wall/r_wall,
-/area/station/maintenance/starboard/aft)
 "lky" = (
 /obj/structure/filingcabinet/filingcabinet,
 /obj/machinery/airalarm/directional/north,
@@ -45482,6 +45175,7 @@
 /obj/effect/turf_decal/tile/neutral/anticorner/contrasted{
 	dir = 1
 	},
+/obj/structure/sign/warning/electric_shock/directional/north,
 /turf/open/floor/iron,
 /area/station/maintenance/port)
 "lmL" = (
@@ -45692,9 +45386,6 @@
 /area/station/hallway/secondary/construction)
 "lpA" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/status_display/supply{
-	pixel_y = 32
-	},
 /obj/structure/reagent_dispensers/fueltank,
 /obj/structure/window/reinforced/spawner/directional/west,
 /obj/item/weldingtool,
@@ -46005,13 +45696,6 @@
 /obj/effect/mapping_helpers/airlock/access/any/service/maintenance,
 /turf/open/floor/iron,
 /area/station/service/kitchen/abandoned)
-"ltY" = (
-/obj/structure/sign/warning/secure_area/directional/west,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/turf/open/floor/iron,
-/area/station/hallway/primary/central/fore)
 "ltZ" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/table/glass,
@@ -46049,6 +45733,7 @@
 /obj/effect/turf_decal/tile/red/anticorner/contrasted{
 	dir = 1
 	},
+/obj/structure/sign/warning/electric_shock/directional/north,
 /turf/open/floor/iron/dark,
 /area/station/security/brig)
 "luE" = (
@@ -46066,7 +45751,6 @@
 "luG" = (
 /obj/structure/easel,
 /obj/item/canvas/twentythree_twentythree,
-/obj/structure/sign/poster/random/directional/south,
 /turf/open/floor/iron/grimy,
 /area/station/maintenance/port/fore)
 "luX" = (
@@ -46087,7 +45771,6 @@
 /area/station/cargo/storage)
 "lvi" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/sign/poster/official/foam_force_ad/directional/west,
 /obj/structure/cable,
 /obj/effect/turf_decal/tile/neutral/half/contrasted{
 	dir = 8
@@ -46103,6 +45786,7 @@
 /obj/effect/turf_decal/tile/red/anticorner/contrasted{
 	dir = 1
 	},
+/obj/structure/sign/warning/electric_shock/directional/north,
 /turf/open/floor/iron/dark,
 /area/station/security/brig)
 "lvl" = (
@@ -46307,7 +45991,6 @@
 /obj/effect/turf_decal/tile/brown/half/contrasted{
 	dir = 8
 	},
-/obj/structure/sign/poster/contraband/random/directional/west,
 /turf/open/floor/iron,
 /area/station/cargo/warehouse)
 "lxS" = (
@@ -46637,10 +46320,6 @@
 	},
 /turf/open/floor/iron,
 /area/station/medical/virology)
-"lBR" = (
-/obj/structure/sign/nanotrasen,
-/turf/closed/wall/r_wall,
-/area/station/ai_monitored/command/storage/eva)
 "lBV" = (
 /obj/structure/window/reinforced/spawner/directional/west,
 /obj/effect/decal/cleanable/dirt,
@@ -46706,6 +46385,7 @@
 	},
 /obj/item/clothing/glasses/sunglasses,
 /obj/structure/extinguisher_cabinet/directional/west,
+/obj/structure/sign/nanotrasen,
 /turf/open/floor/wood,
 /area/station/service/lawoffice)
 "lCM" = (
@@ -46778,7 +46458,6 @@
 	pixel_x = -3;
 	pixel_y = 5
 	},
-/obj/structure/sign/poster/official/random/directional/west,
 /turf/open/floor/iron,
 /area/station/cargo/miningoffice)
 "lDI" = (
@@ -46786,6 +46465,9 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/open/floor/iron/dark,
 /area/station/service/library/printer)
 "lDV" = (
@@ -46859,7 +46541,6 @@
 /obj/effect/turf_decal/loading_area{
 	dir = 4
 	},
-/obj/structure/sign/poster/random/directional/west,
 /obj/effect/mapping_helpers/mail_sorting/service/kitchen,
 /obj/effect/turf_decal/tile/neutral/opposingcorners,
 /turf/open/floor/iron,
@@ -46936,6 +46617,7 @@
 	dir = 5
 	},
 /obj/effect/turf_decal/tile/yellow/opposingcorners,
+/obj/structure/sign/warning/no_smoking/circle/directional/north,
 /turf/open/floor/iron/dark/corner{
 	dir = 4
 	},
@@ -46998,7 +46680,6 @@
 /obj/effect/turf_decal/trimline/blue/filled/corner{
 	dir = 1
 	},
-/obj/structure/sign/poster/official/report_crimes/directional/west,
 /turf/open/floor/iron/white,
 /area/station/medical/medbay)
 "lGf" = (
@@ -47106,6 +46787,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/bot_white/left,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/structure/sign/nanotrasen,
 /turf/open/floor/iron/dark,
 /area/station/command/gateway)
 "lHx" = (
@@ -47234,9 +46916,6 @@
 /turf/open/floor/plating,
 /area/station/maintenance/department/science)
 "lIy" = (
-/obj/structure/sign/nanotrasen{
-	pixel_x = 32
-	},
 /obj/structure/table/reinforced,
 /obj/item/storage/lockbox/loyalty,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
@@ -47733,7 +47412,6 @@
 /turf/open/floor/iron/dark,
 /area/station/service/library)
 "lOf" = (
-/obj/structure/sign/poster/official/report_crimes/directional/south,
 /obj/machinery/light/directional/south,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
@@ -47784,6 +47462,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/turf_decal/bot_white,
+/obj/machinery/light/small/directional/west,
 /turf/open/floor/iron/grimy,
 /area/station/service/chapel/office)
 "lPf" = (
@@ -48127,7 +47806,6 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 10
 	},
-/obj/structure/sign/warning/no_smoking/circle/directional/south,
 /turf/open/floor/iron,
 /area/station/maintenance/department/science)
 "lUI" = (
@@ -48252,7 +47930,6 @@
 /obj/item/crowbar,
 /obj/item/wrench,
 /obj/item/radio,
-/obj/structure/sign/poster/official/space_cops/directional/west,
 /obj/effect/turf_decal/tile/red/fourcorners,
 /turf/open/floor/iron,
 /area/station/security/checkpoint/escape)
@@ -48379,13 +48056,13 @@
 /area/station/maintenance/department/medical/morgue)
 "lYW" = (
 /obj/effect/turf_decal/trimline/blue/end,
-/obj/structure/sign/warning/secure_area/directional/west,
 /obj/effect/turf_decal/stripes/line{
 	dir = 9
 	},
 /obj/machinery/shower/directional/south{
 	name = "emergency shower"
 	},
+/obj/structure/sign/warning/biohazard/directional/north,
 /turf/open/floor/iron/textured,
 /area/station/medical/medbay)
 "lYY" = (
@@ -48734,7 +48411,6 @@
 	dir = 1
 	},
 /obj/machinery/light/small/directional/south,
-/obj/structure/sign/poster/official/random/directional/south,
 /obj/effect/turf_decal/tile/blue/half/contrasted,
 /turf/open/floor/iron/dark,
 /area/station/security/checkpoint/customs/fore)
@@ -48858,13 +48534,6 @@
 	},
 /turf/open/floor/iron/white,
 /area/station/science/lobby)
-"mfO" = (
-/obj/structure/sign/nanotrasen{
-	pixel_x = -32
-	},
-/obj/structure/lattice,
-/turf/open/space/basic,
-/area/space/nearstation)
 "mfP" = (
 /obj/machinery/door/firedoor,
 /obj/effect/turf_decal/stripes/line{
@@ -49196,12 +48865,12 @@
 /obj/effect/turf_decal/bot,
 /obj/machinery/light_switch/directional/east,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/structure/sign/poster/random/directional/north,
 /turf/open/floor/iron/dark,
 /area/station/science/circuits)
 "mkj" = (
 /obj/effect/turf_decal/trimline/neutral/warning,
 /obj/effect/turf_decal/trimline/neutral/mid_joiner,
-/obj/structure/sign/warning/no_smoking/directional/west,
 /obj/structure/table/reinforced,
 /obj/item/stack/sheet/glass/fifty,
 /obj/item/stack/sheet/iron/fifty,
@@ -49260,6 +48929,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 5
 	},
+/obj/structure/sign/nanotrasen,
 /turf/open/floor/iron,
 /area/station/ai_monitored/command/storage/eva)
 "mly" = (
@@ -49287,15 +48957,13 @@
 /turf/closed/wall/r_wall,
 /area/station/ai_monitored/command/storage/eva)
 "mlW" = (
-/obj/structure/sign/nanotrasen{
-	pixel_y = 32
-	},
 /obj/structure/railing{
 	dir = 1
 	},
 /obj/effect/turf_decal/tile/neutral{
 	dir = 4
 	},
+/obj/structure/sign/nanotrasen,
 /turf/open/floor/iron,
 /area/station/hallway/primary/central/aft)
 "mmf" = (
@@ -49547,6 +49215,7 @@
 /obj/effect/turf_decal/tile/blue/anticorner/contrasted{
 	dir = 1
 	},
+/obj/structure/sign/nanotrasen,
 /turf/open/floor/iron/dark,
 /area/station/security/checkpoint/customs/aft)
 "mqP" = (
@@ -49571,7 +49240,6 @@
 /area/station/security/office)
 "mqV" = (
 /obj/structure/dresser,
-/obj/structure/mirror/directional/south,
 /turf/open/floor/wood,
 /area/station/hallway/secondary/service)
 "mra" = (
@@ -49661,11 +49329,6 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/department/eva/abandoned)
-"msx" = (
-/obj/item/kirbyplants/random,
-/obj/structure/sign/poster/contraband/random/directional/south,
-/turf/open/floor/wood,
-/area/station/service/electronic_marketing_den)
 "msB" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4,
 /turf/open/floor/engine,
@@ -50153,7 +49816,6 @@
 	},
 /area/station/engineering/lobby)
 "mxn" = (
-/obj/structure/sign/warning/secure_area/directional/south,
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/iron/half{
 	dir = 8
@@ -50500,7 +50162,6 @@
 /obj/structure/table/glass,
 /obj/item/paper_bin,
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/sign/poster/official/safety_eye_protection/directional/south,
 /turf/open/floor/plating,
 /area/station/maintenance/space_hut/observatory)
 "mCf" = (
@@ -50846,6 +50507,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/structure/sign/warning/electric_shock/directional/north,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/aft)
 "mGm" = (
@@ -51161,14 +50823,11 @@
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/aisat/exterior)
 "mJi" = (
-/obj/structure/sign/departments/science{
-	name = "ROBOTICS";
-	pixel_y = 32
-	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 5
 	},
 /obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/machinery/light/cold/directional/north,
 /turf/open/floor/iron/dark,
 /area/station/science/robotics/lab)
 "mJm" = (
@@ -51186,11 +50845,6 @@
 /obj/effect/mapping_helpers/airlock/access/all/science/ordnance_storage,
 /turf/open/floor/iron/white,
 /area/station/science/ordnance/storage)
-"mJn" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/sign/poster/contraband/random/directional/south,
-/turf/open/floor/plating,
-/area/station/maintenance/port)
 "mJq" = (
 /obj/effect/turf_decal/tile/red,
 /turf/open/floor/iron,
@@ -51259,9 +50913,7 @@
 /area/station/engineering/atmos/pumproom)
 "mJS" = (
 /obj/structure/dresser,
-/obj/structure/sign/nanotrasen{
-	pixel_x = 32
-	},
+/obj/structure/sign/painting/library,
 /turf/open/floor/wood,
 /area/station/commons/dorms)
 "mJW" = (
@@ -51597,9 +51249,6 @@
 "mPo" = (
 /obj/structure/table/wood,
 /obj/item/food/grown/poppy/lily,
-/obj/structure/sign/painting/library{
-	pixel_y = -32
-	},
 /obj/item/radio/intercom/directional/west,
 /turf/open/floor/wood,
 /area/station/commons/dorms)
@@ -51670,15 +51319,6 @@
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron/dark,
 /area/station/hallway/primary/fore)
-"mQz" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/sign/poster/official/work_for_a_future/directional/south,
-/obj/effect/turf_decal/tile/red/half/contrasted{
-	dir = 8
-	},
-/turf/open/floor/iron,
-/area/station/security/prison/safe)
 "mQA" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/chair/stool/bar/directional/west,
@@ -51716,12 +51356,10 @@
 /turf/open/floor/plating,
 /area/station/science/xenobiology)
 "mQY" = (
-/obj/machinery/camera/directional/east{
-	c_tag = "Departures Lounge - Fore Starboard";
-	dir = 6;
-	name = "departures camera"
-	},
 /obj/effect/turf_decal/tile/neutral,
+/obj/machinery/camera/directional/south_east{
+	c_tag = "Departures Lounge - Fore Starboard"
+	},
 /turf/open/floor/iron/dark/corner,
 /area/station/hallway/secondary/exit/departure_lounge)
 "mQZ" = (
@@ -51759,6 +51397,7 @@
 	name = "Research Division Fax Machine";
 	pixel_x = 1
 	},
+/obj/structure/sign/warning/test_chamber/directional/north,
 /turf/open/floor/iron,
 /area/station/science/research)
 "mRs" = (
@@ -51861,13 +51500,13 @@
 /turf/open/floor/iron,
 /area/station/medical/treatment_center)
 "mTc" = (
-/obj/item/radio/intercom/directional/north,
 /obj/machinery/disposal/bin,
 /obj/effect/turf_decal/bot,
 /obj/structure/disposalpipe/trunk,
 /obj/effect/turf_decal/tile/blue/anticorner/contrasted{
 	dir = 4
 	},
+/obj/structure/sign/nanotrasen,
 /turf/open/floor/iron/dark,
 /area/station/security/checkpoint/customs/aft)
 "mTe" = (
@@ -52059,6 +51698,12 @@
 /obj/effect/turf_decal/tile/neutral/full,
 /turf/open/floor/iron/large,
 /area/station/medical/paramedic)
+"mWi" = (
+/obj/structure/cable,
+/obj/effect/turf_decal/tile/red,
+/obj/structure/sign/warning/pods/directional/north,
+/turf/open/floor/iron,
+/area/station/security/execution/transfer)
 "mWq" = (
 /obj/effect/spawner/structure/window/reinforced/plasma,
 /turf/open/floor/plating,
@@ -52189,7 +51834,6 @@
 /turf/open/floor/iron/dark,
 /area/station/science/robotics/lab)
 "mYr" = (
-/obj/structure/sign/warning/secure_area/directional/west,
 /obj/machinery/camera/directional/west{
 	c_tag = "Atmospherics - Fore Tanks";
 	name = "atmospherics camera"
@@ -52520,6 +52164,7 @@
 /obj/effect/turf_decal/trimline/purple/filled/corner{
 	dir = 1
 	},
+/obj/structure/sign/departments/science/alt/directional/north,
 /turf/open/floor/iron/white,
 /area/station/science/research)
 "ndh" = (
@@ -52946,10 +52591,6 @@
 /obj/effect/turf_decal/tile/neutral/half/contrasted,
 /turf/open/floor/iron,
 /area/station/maintenance/department/medical/morgue)
-"njz" = (
-/obj/structure/sign/warning/vacuum/external,
-/turf/closed/wall,
-/area/station/maintenance/starboard/aft)
 "njI" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/airalarm/directional/east,
@@ -53131,7 +52772,6 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 5
 	},
-/obj/structure/sign/departments/science/alt/directional/east,
 /obj/machinery/digital_clock/directional/north,
 /turf/open/floor/iron,
 /area/station/science/lab)
@@ -53147,6 +52787,7 @@
 /obj/machinery/light/small/directional/north,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/sign/nanotrasen,
 /turf/open/floor/iron/dark/textured_edge{
 	dir = 4
 	},
@@ -53378,6 +53019,9 @@
 /obj/structure/closet/secure_closet/personal/cabinet{
 	name = "mime's closet"
 	},
+/obj/machinery/light_switch/directional/west{
+	pixel_y = -6
+	},
 /turf/open/floor/wood,
 /area/station/service/theater)
 "npm" = (
@@ -53507,7 +53151,6 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/sink/directional/east,
-/obj/structure/mirror/directional/west,
 /obj/effect/turf_decal/bot,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron,
@@ -53856,15 +53499,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/station/security/prison)
-"nwV" = (
-/obj/structure/sign/warning/secure_area/directional/west,
-/obj/effect/turf_decal/tile/neutral/fourcorners,
-/turf/open/floor/iron/dark,
-/area/station/science/xenobiology)
 "nwW" = (
-/obj/structure/sign/nanotrasen{
-	pixel_x = -32
-	},
 /obj/machinery/status_display/ai/directional/north,
 /obj/structure/table/wood/fancy/red,
 /obj/machinery/door/window/brigdoor/left/directional/east{
@@ -54010,6 +53645,7 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/structure/sign/plaques/kiddie/library,
 /turf/open/floor/iron/dark,
 /area/station/service/library)
 "nyE" = (
@@ -54360,7 +53996,7 @@
 "nCg" = (
 /obj/structure/lattice,
 /obj/structure/window/reinforced/plasma/spawner/directional/west,
-/obj/structure/sign/warning/hot_temp/directional/north,
+/obj/structure/sign/warning/fire/directional/north,
 /turf/open/space/basic,
 /area/space/nearstation)
 "nCi" = (
@@ -54477,7 +54113,6 @@
 /obj/structure/table/wood,
 /obj/item/toy/crayon/spraycan/lubecan,
 /obj/item/bikehorn,
-/obj/structure/sign/poster/contraband/random/directional/south,
 /obj/effect/turf_decal/tile/blue/opposingcorners{
 	dir = 1
 	},
@@ -54671,7 +54306,6 @@
 /turf/open/floor/iron,
 /area/station/hallway/primary/fore)
 "nGZ" = (
-/obj/structure/mirror/directional/east,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 8
 	},
@@ -54766,7 +54400,6 @@
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/bluespace_vendor/directional/north,
 /obj/effect/turf_decal/tile/yellow{
 	dir = 1
 	},
@@ -55307,9 +54940,6 @@
 /area/station/hallway/primary/central/aft)
 "nOT" = (
 /obj/item/kirbyplants/random,
-/obj/structure/sign/warning/electric_shock{
-	pixel_y = -30
-	},
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 8
 	},
@@ -55367,8 +54997,8 @@
 /turf/open/floor/plating,
 /area/station/cargo/sorting)
 "nPp" = (
-/obj/structure/sign/warning/secure_area/directional/north,
 /obj/structure/lattice,
+/obj/structure/sign/warning/biohazard/directional/north,
 /turf/open/space/basic,
 /area/space/nearstation)
 "nPz" = (
@@ -55533,7 +55163,6 @@
 /turf/open/floor/iron/dark,
 /area/station/security/evidence)
 "nRi" = (
-/obj/structure/sign/warning/secure_area/directional/south,
 /obj/structure/table,
 /obj/item/stack/sheet/iron/fifty,
 /obj/item/stack/sheet/glass/fifty,
@@ -55593,10 +55222,6 @@
 /obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/station/medical/virology)
-"nSv" = (
-/obj/structure/sign/nanotrasen,
-/turf/closed/wall/r_wall,
-/area/station/command/heads_quarters/captain/private)
 "nSA" = (
 /obj/effect/spawner/structure/window/reinforced/tinted,
 /turf/open/floor/plating,
@@ -56155,12 +55780,6 @@
 /turf/open/floor/plating,
 /area/station/maintenance/department/chapel)
 "oaZ" = (
-/obj/structure/sign/painting/library_private{
-	pixel_y = -32
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /obj/machinery/modular_computer/preset/curator{
 	dir = 1
 	},
@@ -56564,9 +56183,6 @@
 /obj/machinery/atmospherics/components/binary/pump{
 	dir = 4;
 	name = "Mix Outlet Pump"
-	},
-/obj/structure/sign/warning/secure_area/directional/west{
-	pixel_y = -32
 	},
 /obj/machinery/power/apc/auto_name/directional/south,
 /obj/structure/cable,
@@ -57026,7 +56642,6 @@
 /area/station/service/library/artgallery)
 "olD" = (
 /obj/item/kirbyplants/random,
-/obj/structure/sign/poster/official/ian/directional/south,
 /obj/structure/extinguisher_cabinet/directional/east,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron/dark,
@@ -57163,7 +56778,6 @@
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /obj/machinery/status_display/ai/directional/north,
-/obj/structure/sign/poster/official/obey/directional/east,
 /turf/open/floor/plating,
 /area/station/security/prison/safe)
 "omY" = (
@@ -57277,6 +56891,7 @@
 /obj/machinery/firealarm/directional/east,
 /obj/item/grenade/chem_grenade/smart_metal_foam,
 /obj/item/crowbar/red,
+/obj/structure/sign/warning/directional/north,
 /turf/open/floor/iron,
 /area/station/engineering/gravity_generator)
 "ooC" = (
@@ -57399,7 +57014,6 @@
 "oqx" = (
 /obj/machinery/deepfryer,
 /obj/effect/turf_decal/bot,
-/obj/structure/sign/poster/official/random/directional/south,
 /turf/open/floor/iron/cafeteria,
 /area/station/service/kitchen)
 "oqz" = (
@@ -57587,9 +57201,6 @@
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/security/armory)
 "ouc" = (
-/obj/structure/sign/warning/electric_shock{
-	pixel_y = -30
-	},
 /obj/machinery/camera/directional/south{
 	c_tag = "Permabrig - Fitness";
 	network = list("ss13","prison")
@@ -57635,9 +57246,6 @@
 "ouT" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
-	},
-/obj/structure/sign/nanotrasen{
-	pixel_x = 32
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 8
@@ -57886,7 +57494,6 @@
 /obj/item/stack/sheet/glass/fifty,
 /obj/item/stack/sheet/iron/fifty,
 /obj/effect/turf_decal/bot,
-/obj/structure/sign/poster/contraband/free_drone/directional/south,
 /obj/effect/turf_decal/tile/neutral/anticorner/contrasted,
 /turf/open/floor/iron/dark,
 /area/station/maintenance/port)
@@ -58188,10 +57795,6 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/iron,
 /area/station/medical/virology)
-"oCG" = (
-/obj/structure/sign/warning/electric_shock,
-/turf/closed/wall/r_wall,
-/area/station/maintenance/starboard/aft)
 "oCJ" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/tile/neutral/opposingcorners,
@@ -58465,9 +58068,6 @@
 /turf/closed/wall,
 /area/station/service/chapel)
 "oGM" = (
-/obj/structure/sign/nanotrasen{
-	pixel_x = 32
-	},
 /obj/structure/closet/secure_closet/armory2,
 /obj/effect/turf_decal/bot,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
@@ -58952,7 +58552,9 @@
 /turf/open/floor/iron,
 /area/station/engineering/storage/tech)
 "oNc" = (
-/obj/structure/plasticflaps/opaque,
+/obj/structure/plasticflaps/opaque{
+	dir = 4
+	},
 /obj/machinery/navbeacon{
 	codes_txt = "delivery;dir=1";
 	location = "Robotics"
@@ -59335,12 +58937,6 @@
 /turf/open/floor/iron,
 /area/station/cargo/storage)
 "oSx" = (
-/obj/structure/sign/directions/engineering{
-	desc = "A sign that shows there are doors here. There are doors everywhere!";
-	icon_state = "doors";
-	name = "WARNING: BLAST DOORS";
-	pixel_y = -32
-	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
@@ -59395,7 +58991,7 @@
 /area/station/science/xenobiology)
 "oSN" = (
 /obj/structure/lattice,
-/obj/structure/sign/warning/secure_area/directional/east,
+/obj/structure/sign/warning/deathsposal,
 /turf/open/space/basic,
 /area/space/nearstation)
 "oSV" = (
@@ -59408,6 +59004,16 @@
 	},
 /turf/open/floor/iron,
 /area/station/maintenance/department/chapel)
+"oSZ" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/tile/yellow{
+	dir = 1
+	},
+/obj/structure/sign/warning/secure_area/directional/north,
+/turf/open/floor/iron,
+/area/station/hallway/primary/port)
 "oTg" = (
 /obj/structure/sink/directional/west,
 /obj/machinery/light_switch/directional/east,
@@ -59485,7 +59091,6 @@
 "oTY" = (
 /obj/structure/cable,
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/sign/poster/random/directional/west,
 /turf/open/floor/plating,
 /area/station/maintenance/port/fore)
 "oUc" = (
@@ -59540,12 +59145,6 @@
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron/dark,
 /area/station/science/server)
-"oUy" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/sign/warning/electric_shock/directional/south,
-/obj/effect/turf_decal/tile/neutral/half/contrasted,
-/turf/open/floor/iron,
-/area/station/maintenance/port)
 "oUz" = (
 /obj/structure/chair/sofa/left/brown{
 	dir = 8
@@ -59793,7 +59392,6 @@
 	c_tag = "Service - Clown's Room";
 	name = "service camera"
 	},
-/obj/structure/sign/poster/contraband/random/directional/east,
 /turf/open/floor/wood,
 /area/station/service/theater)
 "oZz" = (
@@ -59893,11 +59491,6 @@
 	},
 /turf/open/floor/iron,
 /area/station/maintenance/department/chapel)
-"pbv" = (
-/obj/structure/sign/warning/radiation/directional/south,
-/obj/effect/turf_decal/tile/neutral/fourcorners,
-/turf/open/floor/iron/dark,
-/area/station/engineering/gravity_generator)
 "pbF" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable,
@@ -59942,6 +59535,7 @@
 /obj/effect/turf_decal/trimline/purple/filled/corner{
 	dir = 4
 	},
+/obj/machinery/airalarm/directional/north,
 /turf/open/floor/iron/white,
 /area/station/science/research)
 "pca" = (
@@ -60021,6 +59615,12 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
 /area/station/science/robotics/mechbay)
+"pcU" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/sign/warning/secure_area/directional/north,
+/turf/open/floor/plating,
+/area/station/maintenance/port)
 "pdb" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /obj/effect/turf_decal/stripes/line,
@@ -60157,7 +59757,6 @@
 /obj/structure/disposalpipe/trunk{
 	dir = 1
 	},
-/obj/structure/sign/warning/deathsposal/directional/east,
 /obj/effect/turf_decal/tile/neutral/anticorner/contrasted{
 	dir = 1
 	},
@@ -60353,10 +59952,6 @@
 	},
 /turf/open/floor/glass,
 /area/station/maintenance/space_hut/observatory)
-"pgA" = (
-/obj/structure/sign/warning/secure_area,
-/turf/closed/wall/r_wall,
-/area/station/engineering/main)
 "pgE" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -60387,7 +59982,6 @@
 /obj/item/radio/intercom/directional/north,
 /obj/machinery/disposal/bin,
 /obj/effect/turf_decal/bot,
-/obj/structure/sign/poster/random/directional/east,
 /obj/effect/turf_decal/tile/yellow/opposingcorners,
 /obj/effect/turf_decal/tile/red/opposingcorners{
 	dir = 1
@@ -60585,7 +60179,6 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 6
 	},
-/obj/structure/sign/warning/secure_area/directional/east,
 /obj/structure/sink/directional/north,
 /turf/open/floor/iron,
 /area/station/medical/medbay)
@@ -60674,7 +60267,6 @@
 /turf/open/floor/iron,
 /area/station/medical/storage)
 "pkb" = (
-/obj/item/radio/intercom/directional/north,
 /obj/machinery/button/door/directional/north{
 	id = "chemisttop";
 	name = "Pharmacy Shutters";
@@ -60692,15 +60284,6 @@
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron,
 /area/station/medical/pharmacy)
-"pkd" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/structure/sign/directions/engineering{
-	desc = "A sign that shows there are doors here. There are doors everywhere!";
-	icon_state = "doors";
-	name = "WARNING: EXTERNAL AIRLOCK"
-	},
-/turf/open/floor/plating,
-/area/station/hallway/secondary/entry)
 "pke" = (
 /obj/structure/cable,
 /obj/effect/turf_decal/siding/green{
@@ -60719,7 +60302,6 @@
 /turf/open/floor/iron/dark,
 /area/station/medical/break_room)
 "pkk" = (
-/obj/structure/sign/warning/test_chamber/directional/south,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /obj/machinery/light/directional/south,
 /turf/open/floor/iron/dark,
@@ -60745,6 +60327,7 @@
 /obj/structure/cable,
 /obj/machinery/power/smes/engineering,
 /obj/machinery/light_switch/directional/east,
+/obj/structure/sign/warning/electric_shock/directional/north,
 /turf/open/floor/circuit/green,
 /area/station/engineering/main)
 "pkA" = (
@@ -60956,6 +60539,7 @@
 /obj/machinery/vending/coffee,
 /obj/effect/turf_decal/bot,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/structure/sign/nanotrasen,
 /turf/open/floor/iron/dark,
 /area/station/hallway/secondary/entry)
 "pmY" = (
@@ -61206,6 +60790,7 @@
 /area/station/service/theater/abandoned)
 "prt" = (
 /obj/item/kirbyplants/random,
+/obj/machinery/firealarm/directional/north,
 /turf/open/floor/wood,
 /area/station/command/heads_quarters/captain)
 "pru" = (
@@ -61214,7 +60799,6 @@
 	dir = 9;
 	name = "library camera"
 	},
-/obj/machinery/computer/security/telescreen/entertainment/directional/north,
 /obj/machinery/vending/wardrobe/curator_wardrobe,
 /obj/effect/turf_decal/bot_white,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
@@ -61317,6 +60901,11 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/tile/yellow/opposingcorners,
+/obj/machinery/button/door/directional/north{
+	id = "chemisttop";
+	name = "Pharmacy Shutters";
+	pixel_y = 40
+	},
 /turf/open/floor/iron/dark,
 /area/station/medical/pharmacy)
 "ptk" = (
@@ -61355,6 +60944,7 @@
 /area/station/maintenance/department/crew_quarters/bar)
 "ptI" = (
 /obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/structure/sign/painting/library_private,
 /turf/open/floor/iron/dark,
 /area/station/service/library/printer)
 "ptM" = (
@@ -61364,11 +60954,6 @@
 	},
 /turf/open/floor/plating,
 /area/station/engineering/supermatter/room)
-"ptN" = (
-/obj/structure/sign/warning/directional/west,
-/obj/structure/lattice,
-/turf/open/space/basic,
-/area/space/nearstation)
 "ptO" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/item/kirbyplants/random,
@@ -61396,9 +60981,6 @@
 	dir = 1
 	},
 /obj/machinery/firealarm/directional/north,
-/obj/machinery/light_switch/directional/north{
-	pixel_x = -8
-	},
 /turf/open/floor/iron,
 /area/station/engineering/main)
 "put" = (
@@ -61426,7 +61008,6 @@
 	dir = 4
 	},
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/sign/warning/docking/directional/south,
 /obj/machinery/duct,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron,
@@ -62284,20 +61865,6 @@
 /obj/effect/turf_decal/tile/neutral/opposingcorners,
 /turf/open/floor/iron/dark,
 /area/station/maintenance/department/science)
-"pEH" = (
-/obj/machinery/door/poddoor/preopen{
-	id = "brigprison";
-	name = "Prison Blast Door"
-	},
-/obj/effect/turf_decal/delivery,
-/obj/structure/sign/directions/engineering{
-	desc = "A sign that shows there are doors here. There are doors everywhere!";
-	icon_state = "doors";
-	name = "WARNING: BLAST DOORS";
-	pixel_x = 32
-	},
-/turf/open/floor/iron/dark/textured_large,
-/area/station/security/execution/transfer)
 "pEL" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -62331,6 +61898,7 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/tile/yellow/opposingcorners,
+/obj/machinery/airalarm/directional/north,
 /turf/open/floor/iron,
 /area/station/commons/lounge)
 "pEU" = (
@@ -62391,7 +61959,6 @@
 /turf/open/floor/iron/grimy,
 /area/station/ai_monitored/turret_protected/aisat_interior)
 "pFq" = (
-/obj/structure/sign/warning/no_smoking/directional/west,
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
@@ -62431,6 +61998,7 @@
 	},
 /obj/effect/turf_decal/delivery,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/structure/sign/nanotrasen,
 /turf/open/floor/iron/dark,
 /area/station/hallway/secondary/entry)
 "pFO" = (
@@ -62506,7 +62074,6 @@
 /area/station/maintenance/disposal/incinerator)
 "pGw" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/sign/poster/random/directional/east,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /obj/effect/spawner/random/engineering/atmospherics_portable,
 /turf/open/floor/iron,
@@ -62545,11 +62112,6 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/iron/herringbone,
 /area/station/cargo/miningoffice)
-"pHa" = (
-/obj/structure/lattice,
-/obj/structure/sign/warning/directional/west,
-/turf/open/space,
-/area/space/nearstation)
 "pHd" = (
 /obj/machinery/atmospherics/components/unary/portables_connector/visible{
 	dir = 4
@@ -62584,10 +62146,6 @@
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron,
 /area/station/hallway/primary/central/aft)
-"pHy" = (
-/obj/structure/sign/nanotrasen,
-/turf/closed/wall,
-/area/station/service/chapel)
 "pHz" = (
 /obj/structure/disposalpipe/segment{
 	dir = 10
@@ -62889,7 +62447,6 @@
 /area/station/commons/dorms)
 "pLq" = (
 /obj/structure/cable,
-/obj/structure/sign/poster/contraband/random/directional/east,
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
 	},
@@ -63009,6 +62566,11 @@
 /obj/effect/turf_decal/tile/blue/opposingcorners,
 /turf/open/floor/iron/white,
 /area/station/command/heads_quarters/cmo)
+"pMH" = (
+/obj/item/kirbyplants/random,
+/obj/structure/sign/nanotrasen,
+/turf/open/floor/iron/grimy,
+/area/station/tcommsat/computer)
 "pMK" = (
 /obj/structure/disposalpipe/trunk,
 /obj/structure/cable,
@@ -63198,9 +62760,7 @@
 /area/station/commons/dorms)
 "pOQ" = (
 /obj/structure/lattice,
-/obj/structure/sign/nanotrasen{
-	pixel_y = 32
-	},
+/obj/structure/sign/nanotrasen,
 /turf/open/space/basic,
 /area/space/nearstation)
 "pOT" = (
@@ -63240,6 +62800,7 @@
 	},
 /obj/machinery/disposal/bin,
 /obj/effect/turf_decal/bot,
+/obj/machinery/light_switch/directional/north,
 /turf/open/floor/iron,
 /area/station/commons/toilet/restrooms)
 "pPf" = (
@@ -63281,7 +62842,6 @@
 /obj/effect/spawner/random/maintenance/two,
 /obj/effect/turf_decal/bot,
 /obj/effect/spawner/random/trash/janitor_supplies,
-/obj/structure/sign/poster/random/directional/west,
 /obj/effect/turf_decal/tile/neutral/half/contrasted{
 	dir = 8
 	},
@@ -63317,6 +62877,13 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
 /area/station/engineering/atmos/project)
+"pPS" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/obj/structure/sign/warning/secure_area/directional/north,
+/turf/open/floor/plating,
+/area/station/maintenance/port/fore)
 "pQd" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 1
@@ -63331,13 +62898,6 @@
 	},
 /turf/open/floor/iron,
 /area/station/service/kitchen/abandoned)
-"pQn" = (
-/obj/structure/sign/poster/official/safety_eye_protection/directional/west,
-/obj/effect/turf_decal/tile/yellow/half/contrasted{
-	dir = 8
-	},
-/turf/open/floor/iron/white,
-/area/station/medical/chemistry)
 "pQo" = (
 /obj/machinery/modular_computer/preset/cargochat/engineering{
 	dir = 1
@@ -63640,16 +63200,6 @@
 /obj/structure/lattice,
 /turf/open/space,
 /area/space/nearstation)
-"pTT" = (
-/obj/structure/sign/directions/engineering{
-	desc = "A sign that shows there are doors here. There are doors everywhere!";
-	icon_state = "doors";
-	name = "WARNING: EXTERNAL AIRLOCK";
-	pixel_x = 32
-	},
-/obj/effect/turf_decal/tile/neutral/fourcorners,
-/turf/open/floor/iron/dark,
-/area/station/security/execution/education)
 "pTV" = (
 /obj/structure/sign/poster/official/random/directional/north,
 /obj/structure/cable,
@@ -64272,6 +63822,9 @@
 	dir = 8
 	},
 /obj/structure/cable,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/open/floor/iron/dark,
 /area/station/service/library/printer)
 "qaF" = (
@@ -64678,6 +64231,7 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/structure/sign/warning/deathsposal,
 /turf/open/floor/iron/dark,
 /area/station/maintenance/disposal/incinerator)
 "qfP" = (
@@ -65226,6 +64780,7 @@
 "qoo" = (
 /obj/structure/table/wood,
 /obj/item/pai_card,
+/obj/structure/sign/nanotrasen,
 /turf/open/floor/wood,
 /area/station/command/meeting_room/council)
 "qoA" = (
@@ -65257,12 +64812,6 @@
 	},
 /turf/open/floor/iron,
 /area/station/engineering/supermatter/room)
-"qoD" = (
-/obj/structure/sign/warning/electric_shock/directional/south,
-/obj/structure/cable,
-/obj/effect/turf_decal/tile/neutral/fourcorners,
-/turf/open/floor/iron/dark/telecomms,
-/area/station/tcommsat/server)
 "qoE" = (
 /obj/machinery/recharge_station,
 /obj/effect/decal/cleanable/dirt,
@@ -65311,7 +64860,6 @@
 /obj/effect/turf_decal/trimline/blue/end{
 	dir = 8
 	},
-/obj/structure/sign/warning/secure_area/directional/east,
 /obj/machinery/shower/directional/west{
 	name = "emergency shower"
 	},
@@ -65618,7 +65166,6 @@
 /turf/open/floor/iron,
 /area/station/maintenance/port/aft)
 "qub" = (
-/obj/structure/sign/warning/firing_range/directional/west,
 /obj/machinery/bci_implanter,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron/dark,
@@ -65693,10 +65240,6 @@
 	},
 /turf/open/floor/iron,
 /area/station/commons/toilet/locker)
-"qvn" = (
-/obj/structure/sign/warning/secure_area,
-/turf/closed/wall/r_wall,
-/area/station/maintenance/port/fore)
 "qvo" = (
 /obj/machinery/door/airlock/maintenance_hatch{
 	name = "Maintenance Hatch"
@@ -66064,7 +65607,6 @@
 	dir = 5
 	},
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/sign/warning/electric_shock/directional/east,
 /turf/open/floor/iron,
 /area/station/engineering/gravity_generator)
 "qzX" = (
@@ -66254,6 +65796,7 @@
 	},
 /obj/structure/extinguisher_cabinet/directional/east,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/structure/sign/poster/random/directional/north,
 /turf/open/floor/iron/dark,
 /area/station/science/auxlab/firing_range)
 "qCe" = (
@@ -66312,7 +65855,6 @@
 /turf/open/floor/iron,
 /area/station/maintenance/disposal)
 "qCs" = (
-/obj/machinery/light/small/directional/north,
 /obj/machinery/vending/assist,
 /obj/structure/sign/poster/contraband/random/directional/north,
 /turf/open/floor/plating,
@@ -66420,6 +65962,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/structure/sign/warning/biohazard/directional/north,
 /turf/open/floor/iron,
 /area/station/medical/virology)
 "qDZ" = (
@@ -66446,9 +65989,6 @@
 /turf/open/floor/iron/white,
 /area/station/medical/medbay)
 "qEj" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /obj/machinery/light/small/directional/south,
 /obj/structure/table/wood,
 /obj/item/paper_bin{
@@ -66854,6 +66394,7 @@
 "qJl" = (
 /obj/structure/closet/emcloset/anchored,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/structure/sign/warning/vacuum/external/directional/north,
 /turf/open/floor/iron/dark,
 /area/station/engineering/hallway)
 "qJs" = (
@@ -67129,6 +66670,7 @@
 /obj/effect/turf_decal/box/corners{
 	dir = 1
 	},
+/obj/structure/sign/warning/secure_area/directional/north,
 /turf/open/floor/plating/airless,
 /area/space/nearstation)
 "qLS" = (
@@ -67184,7 +66726,6 @@
 "qMB" = (
 /obj/effect/turf_decal/bot,
 /obj/machinery/firealarm/directional/north,
-/obj/machinery/light/small/directional/north,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron,
 /area/station/science/research)
@@ -67530,15 +67071,6 @@
 /obj/item/storage/bag/tray/cafeteria,
 /turf/open/floor/plating,
 /area/station/security/prison/mess)
-"qSa" = (
-/obj/item/reagent_containers/cup/beaker,
-/obj/item/reagent_containers/syringe/antiviral,
-/obj/item/reagent_containers/dropper,
-/obj/structure/sign/warning/biohazard/directional/east,
-/obj/structure/cable,
-/obj/structure/table/reinforced/rglass,
-/turf/open/floor/iron,
-/area/station/medical/virology)
 "qSd" = (
 /obj/machinery/door/firedoor,
 /obj/effect/turf_decal/stripes/line,
@@ -67612,17 +67144,6 @@
 /obj/machinery/light/directional/east,
 /turf/open/floor/iron,
 /area/station/security/execution/transfer)
-"qTb" = (
-/obj/structure/cable,
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/structure/sign/warning/electric_shock/directional/south,
-/obj/machinery/duct,
-/obj/effect/turf_decal/tile/neutral/half/contrasted,
-/turf/open/floor/iron,
-/area/station/maintenance/department/chapel)
 "qTs" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -67775,7 +67296,6 @@
 /obj/machinery/light/small/directional/south,
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/vending/boozeomat/all_access,
-/obj/structure/sign/poster/contraband/random/directional/south,
 /turf/open/floor/plating,
 /area/station/service/abandoned_gambling_den)
 "qVr" = (
@@ -67972,7 +67492,6 @@
 /obj/structure/bodycontainer/morgue{
 	dir = 1
 	},
-/obj/structure/sign/poster/official/random/directional/south,
 /turf/open/floor/iron/dark/textured_half{
 	dir = 1
 	},
@@ -68000,7 +67519,9 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/structure/plasticflaps/opaque,
+/obj/structure/plasticflaps/opaque{
+	dir = 4
+	},
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/delivery,
 /obj/machinery/navbeacon{
@@ -68118,10 +67639,6 @@
 /obj/effect/mapping_helpers/requests_console/announcement,
 /obj/effect/mapping_helpers/requests_console/information,
 /obj/effect/mapping_helpers/requests_console/assistance,
-/obj/structure/sign/nanotrasen{
-	pixel_x = 32;
-	pixel_y = 32
-	},
 /obj/effect/turf_decal/bot_white,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron/dark,
@@ -68300,7 +67817,7 @@
 /turf/open/floor/iron,
 /area/station/hallway/primary/starboard)
 "rdR" = (
-/obj/machinery/firealarm/directional/north,
+/obj/structure/plaque/static_plaque/golden/captain,
 /turf/open/floor/wood,
 /area/station/command/heads_quarters/captain)
 "rdS" = (
@@ -68315,12 +67832,11 @@
 /area/station/engineering/lobby)
 "rem" = (
 /obj/effect/turf_decal/stripes/line,
-/obj/structure/sign/poster/random/directional/west,
+/obj/machinery/airalarm/directional/west,
 /turf/open/floor/plating,
 /area/station/maintenance/department/engine/atmos)
 "rep" = (
 /obj/structure/closet/firecloset,
-/obj/structure/sign/warning/biohazard/directional/east,
 /obj/effect/turf_decal/bot,
 /obj/effect/turf_decal/stripes/line{
 	dir = 5
@@ -68331,7 +67847,7 @@
 	name = "medbay camera";
 	network = list("ss13","medbay")
 	},
-/obj/machinery/firealarm/directional/north,
+/obj/structure/sign/warning/biohazard/directional/north,
 /turf/open/floor/iron,
 /area/station/medical/medbay)
 "req" = (
@@ -68496,16 +68012,6 @@
 	},
 /turf/open/floor/iron,
 /area/station/science/robotics/lab)
-"rgw" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/brown/visible,
-/obj/structure/sign/directions/engineering{
-	desc = "A sign that shows there are doors here. There are doors everywhere!";
-	icon_state = "doors";
-	name = "WARNING: PRESSURIZED DOORS";
-	pixel_y = -32
-	},
-/turf/open/floor/iron,
-/area/station/engineering/supermatter/room)
 "rgA" = (
 /obj/structure/chair,
 /obj/effect/turf_decal/trimline/blue/filled/line{
@@ -68524,7 +68030,6 @@
 	},
 /obj/effect/mapping_helpers/requests_console/supplies,
 /obj/effect/mapping_helpers/requests_console/assistance,
-/obj/structure/sign/poster/official/do_not_question/directional/east,
 /obj/effect/turf_decal/delivery,
 /turf/open/floor/iron,
 /area/station/engineering/main)
@@ -68647,7 +68152,6 @@
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/sign/warning/biohazard/directional/south,
 /obj/machinery/duct,
 /obj/machinery/light/small/directional/south,
 /obj/structure/disposalpipe/segment{
@@ -68786,9 +68290,6 @@
 /area/station/service/theater)
 "rju" = (
 /obj/structure/closet/crate/preopen,
-/obj/structure/sign/nanotrasen{
-	pixel_x = 32
-	},
 /obj/item/tank/internals/oxygen/red{
 	pixel_x = 3
 	},
@@ -68800,10 +68301,6 @@
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron/dark,
 /area/station/security/execution/education)
-"rjz" = (
-/obj/structure/sign/warning/secure_area/directional/east,
-/turf/open/floor/glass/reinforced,
-/area/station/maintenance/department/science/xenobiology)
 "rjG" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -68845,15 +68342,6 @@
 /obj/effect/turf_decal/siding/white,
 /turf/open/floor/iron/cafeteria,
 /area/station/service/kitchen)
-"rjT" = (
-/obj/structure/sign/poster/official/ion_rifle/directional/east,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/turf_decal/tile/neutral/half/contrasted{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/station/maintenance/department/science)
 "rjZ" = (
 /obj/machinery/door/firedoor,
 /obj/effect/turf_decal/stripes/line{
@@ -68940,12 +68428,6 @@
 /obj/effect/landmark/start/hangover,
 /turf/open/floor/iron/white,
 /area/station/science/lobby)
-"rle" = (
-/obj/structure/lattice,
-/obj/structure/window/reinforced/plasma/spawner/directional/west,
-/obj/structure/sign/warning/fire/directional/south,
-/turf/open/space/basic,
-/area/space/nearstation)
 "rlj" = (
 /obj/structure/cable,
 /obj/effect/turf_decal/trimline/purple/filled/line{
@@ -69163,7 +68645,6 @@
 	pixel_y = 3
 	},
 /obj/item/stack/cable_coil,
-/obj/structure/sign/poster/official/build/directional/east,
 /turf/open/floor/plating,
 /area/station/maintenance/department/electrical)
 "rmP" = (
@@ -69244,6 +68725,7 @@
 	},
 /obj/item/camera_film,
 /obj/machinery/light_switch/directional/east,
+/obj/structure/sign/warning/no_smoking/directional/north,
 /turf/open/floor/wood,
 /area/station/commons/vacant_room/office)
 "rnr" = (
@@ -69382,10 +68864,10 @@
 /turf/open/floor/carpet/green,
 /area/station/commons/lounge)
 "rqa" = (
-/obj/machinery/status_display/evac/directional/north,
 /obj/structure/table/wood,
 /obj/item/folder/red,
 /obj/item/pen/red,
+/obj/structure/sign/painting/library,
 /turf/open/floor/wood,
 /area/station/commons/dorms)
 "rqi" = (
@@ -69676,7 +69158,6 @@
 /obj/item/instrument/violin,
 /obj/structure/table/wood,
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/sign/poster/contraband/random/directional/east,
 /obj/machinery/airalarm/directional/south,
 /turf/open/floor/plating,
 /area/station/service/theater/abandoned)
@@ -69787,7 +69268,6 @@
 /area/station/commons/fitness/recreation)
 "rwk" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/sign/poster/contraband/random/directional/west,
 /turf/open/floor/iron/grimy,
 /area/station/service/abandoned_gambling_den)
 "rwl" = (
@@ -70409,15 +69889,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/cafeteria,
 /area/station/service/kitchen)
-"rEN" = (
-/obj/structure/sign/warning/electric_shock{
-	pixel_y = -32
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/turf/open/floor/iron,
-/area/station/hallway/secondary/command)
 "rEO" = (
 /turf/closed/wall/r_wall,
 /area/station/medical/coldroom)
@@ -70543,6 +70014,11 @@
 	},
 /turf/open/floor/iron,
 /area/station/maintenance/port/fore)
+"rGA" = (
+/obj/structure/lattice,
+/obj/structure/sign/warning/directional/north,
+/turf/open/space/basic,
+/area/space/nearstation)
 "rGI" = (
 /obj/structure/disposalpipe/trunk{
 	dir = 4
@@ -70693,13 +70169,6 @@
 	dir = 1
 	},
 /area/station/commons/fitness/recreation)
-"rIv" = (
-/obj/structure/sign/poster/official/moth_meth/directional/west,
-/obj/effect/turf_decal/tile/yellow/half/contrasted{
-	dir = 8
-	},
-/turf/open/floor/iron/white,
-/area/station/medical/chemistry)
 "rID" = (
 /obj/effect/turf_decal/tile/green{
 	dir = 8
@@ -70751,11 +70220,6 @@
 /obj/effect/turf_decal/tile/neutral/full,
 /turf/open/floor/iron/large,
 /area/station/medical/virology)
-"rIP" = (
-/obj/structure/lattice/catwalk,
-/obj/structure/sign/warning/secure_area/directional/east,
-/turf/open/space/basic,
-/area/space/nearstation)
 "rIU" = (
 /obj/machinery/door/airlock/maintenance_hatch{
 	name = "Maintenance Hatch"
@@ -71176,12 +70640,6 @@
 	},
 /turf/open/floor/iron,
 /area/station/science/robotics/lab)
-"rOa" = (
-/obj/structure/sign/warning/secure_area{
-	pixel_y = -14
-	},
-/turf/closed/wall/r_wall,
-/area/station/engineering/atmos/storage/gas)
 "rOc" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /turf/open/floor/iron/large,
@@ -71723,6 +71181,9 @@
 /turf/open/floor/iron,
 /area/station/cargo/lobby)
 "rTB" = (
+/obj/machinery/status_display/supply{
+	pixel_y = 32
+	},
 /turf/open/floor/iron,
 /area/station/cargo/storage)
 "rTG" = (
@@ -71850,9 +71311,6 @@
 /turf/open/floor/iron,
 /area/station/hallway/secondary/entry)
 "rUX" = (
-/obj/structure/sign/nanotrasen{
-	pixel_x = 32
-	},
 /obj/item/kirbyplants/random,
 /obj/machinery/digital_clock/directional/north,
 /turf/open/floor/wood,
@@ -72045,7 +71503,6 @@
 /obj/machinery/atmospherics/components/unary/passive_vent{
 	dir = 4
 	},
-/obj/structure/sign/warning/secure_area/directional/south,
 /obj/effect/turf_decal/box/corners{
 	dir = 8
 	},
@@ -72155,6 +71612,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/closet/emcloset,
 /obj/effect/turf_decal/delivery,
+/obj/structure/sign/warning/vacuum/directional/north,
 /turf/open/floor/iron,
 /area/station/cargo/miningoffice)
 "rZe" = (
@@ -72372,6 +71830,7 @@
 	},
 /obj/item/gps/engineering,
 /obj/effect/turf_decal/bot,
+/obj/structure/sign/warning/secure_area/directional/north,
 /turf/open/floor/iron,
 /area/station/engineering/main)
 "saT" = (
@@ -72451,6 +71910,7 @@
 	dir = 1
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
+/obj/machinery/firealarm/directional/north,
 /turf/open/floor/iron/large,
 /area/station/medical/medbay)
 "sch" = (
@@ -72473,9 +71933,6 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/bot/left,
-/obj/structure/sign/nanotrasen{
-	pixel_x = -32
-	},
 /obj/machinery/modular_computer/preset/cargochat/science{
 	dir = 4
 	},
@@ -72544,6 +72001,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/structure/sign/nanotrasen,
 /turf/open/floor/iron,
 /area/station/medical/virology)
 "sdB" = (
@@ -72658,9 +72116,7 @@
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/sign/nanotrasen{
-	pixel_y = 32
-	},
+/obj/structure/sign/nanotrasen,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 4
 	},
@@ -72699,12 +72155,6 @@
 "sfy" = (
 /obj/effect/turf_decal/delivery,
 /obj/machinery/computer/shuttle/mining/common,
-/obj/structure/sign/directions/engineering{
-	desc = "A sign that shows there are doors here. There are doors everywhere!";
-	icon_state = "doors";
-	name = "WARNING: EXTERNAL AIRLOCK";
-	pixel_y = 32
-	},
 /obj/machinery/light/small/directional/north,
 /turf/open/floor/iron/smooth_large,
 /area/station/hallway/secondary/entry)
@@ -73017,6 +72467,12 @@
 	},
 /turf/open/floor/iron,
 /area/station/maintenance/port)
+"sjX" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/sign/warning/electric_shock/directional/north,
+/turf/open/floor/plating,
+/area/station/maintenance/port)
 "ske" = (
 /obj/effect/spawner/random/entertainment/arcade,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
@@ -73101,7 +72557,6 @@
 /obj/machinery/portable_atmospherics/canister/nitrous_oxide,
 /obj/machinery/atmospherics/components/unary/portables_connector/visible,
 /obj/effect/turf_decal/box/red,
-/obj/structure/sign/poster/official/help_others/directional/east,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron/dark,
 /area/station/security/execution/education)
@@ -73165,7 +72620,6 @@
 	dir = 9
 	},
 /obj/machinery/status_display/ai/directional/north,
-/obj/structure/sign/poster/official/random/directional/west,
 /turf/open/floor/engine,
 /area/station/science/explab)
 "slE" = (
@@ -73246,10 +72700,6 @@
 	},
 /turf/open/floor/iron,
 /area/station/maintenance/starboard/lesser)
-"smO" = (
-/obj/structure/sign/warning/electric_shock,
-/turf/closed/wall/r_wall,
-/area/station/maintenance/solars/starboard/fore)
 "smR" = (
 /obj/machinery/portable_atmospherics/canister/nitrogen,
 /turf/open/floor/engine/n2,
@@ -73373,7 +72823,6 @@
 	dir = 1
 	},
 /obj/structure/table/wood/poker,
-/obj/structure/sign/poster/contraband/random/directional/south,
 /turf/open/floor/plating,
 /area/station/service/abandoned_gambling_den)
 "spd" = (
@@ -73397,7 +72846,6 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 1
 	},
-/obj/structure/sign/warning/fire/directional/east,
 /turf/open/floor/iron,
 /area/station/engineering/main)
 "spq" = (
@@ -73451,14 +72899,11 @@
 /area/station/hallway/primary/central/aft)
 "sqj" = (
 /obj/structure/closet/crate/freezer/surplus_limbs,
-/obj/machinery/camera/directional/north{
-	c_tag = "Medbay - Coldroom";
-	dir = 9;
-	name = "medbay camera";
-	network = list("ss13","medbay")
-	},
 /obj/effect/turf_decal/bot_white{
 	color = "#435a88"
+	},
+/obj/machinery/camera/directional/north{
+	c_tag = "Medbay - Coldroom"
 	},
 /turf/open/floor/iron/freezer,
 /area/station/medical/coldroom)
@@ -73484,7 +72929,6 @@
 "sqD" = (
 /obj/structure/table/wood,
 /obj/item/flashlight/lamp,
-/obj/structure/sign/poster/official/work_for_a_future/directional/south,
 /turf/open/floor/carpet,
 /area/station/commons/vacant_room/office)
 "sqI" = (
@@ -73528,7 +72972,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/disposal/bin,
-/obj/structure/sign/warning/deathsposal/directional/south,
 /obj/effect/turf_decal/tile/yellow{
 	dir = 8
 	},
@@ -73572,6 +73015,18 @@
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron/dark,
 /area/station/service/abandoned_gambling_den)
+"srQ" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/structure/sign/nanotrasen,
+/turf/open/floor/iron,
+/area/station/hallway/secondary/command)
 "ssb" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -73763,19 +73218,16 @@
 	pixel_x = -4;
 	pixel_y = 4
 	},
-/obj/structure/sign/warning/no_smoking/directional/west,
 /turf/open/floor/iron,
 /area/station/maintenance/department/engine/atmos)
 "suB" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/item/kirbyplants/random,
 /obj/machinery/firealarm/directional/north,
-/obj/machinery/light_switch/directional/west{
-	pixel_x = -24
-	},
 /obj/effect/turf_decal/tile/neutral/anticorner/contrasted{
 	dir = 1
 	},
+/obj/structure/mirror/directional/north,
 /turf/open/floor/iron,
 /area/station/commons/toilet/locker)
 "suE" = (
@@ -73826,14 +73278,6 @@
 	},
 /turf/open/floor/iron/cafeteria,
 /area/station/engineering/atmos)
-"sva" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/structure/sign/warning/engine_safety/directional/south,
-/obj/effect/turf_decal/tile/yellow/half/contrasted,
-/turf/open/floor/iron,
-/area/station/engineering/lobby)
 "svc" = (
 /obj/structure/table/reinforced,
 /obj/machinery/button/door{
@@ -73885,13 +73329,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/plating,
 /area/station/service/abandoned_gambling_den)
-"svz" = (
-/obj/structure/disposalpipe/segment,
-/obj/structure/cable,
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/sign/poster/random/directional/east,
-/turf/open/floor/plating,
-/area/station/maintenance/port/fore)
 "svO" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 9
@@ -73939,6 +73376,7 @@
 	fax_name = "Captain's Office";
 	name = "Captain's Fax Machine"
 	},
+/obj/structure/sign/nanotrasen,
 /turf/open/floor/wood,
 /area/station/command/heads_quarters/captain)
 "swn" = (
@@ -73961,6 +73399,7 @@
 	},
 /obj/structure/closet/emcloset,
 /obj/machinery/light/small/directional/north,
+/obj/structure/sign/nanotrasen,
 /turf/open/floor/plating,
 /area/station/commons/fitness/recreation)
 "swY" = (
@@ -73971,6 +73410,13 @@
 	},
 /turf/open/floor/plating,
 /area/station/maintenance/port/aft)
+"sxe" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 9
+	},
+/obj/structure/sign/nanotrasen,
+/turf/open/floor/iron,
+/area/station/ai_monitored/command/storage/eva)
 "sxk" = (
 /obj/structure/barricade/wooden,
 /obj/structure/cable,
@@ -74239,8 +73685,8 @@
 "sAi" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/xenoblood,
-/obj/structure/sign/warning/xeno_mining/directional/north,
 /obj/effect/decal/cleanable/cobweb/cobweb2,
+/obj/structure/sign/warning/xeno_mining/directional/north,
 /turf/open/floor/iron/smooth,
 /area/station/maintenance/department/science/xenobiology)
 "sAm" = (
@@ -74463,6 +73909,7 @@
 	name = "science camera";
 	network = list("ss13","rd")
 	},
+/obj/machinery/firealarm/directional/west,
 /turf/open/floor/iron/white,
 /area/station/science/research)
 "sDe" = (
@@ -74480,12 +73927,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/spawner/random/trash/caution_sign,
-/obj/structure/sign/directions/engineering{
-	desc = "A sign that shows there are doors here. There are doors everywhere!";
-	icon_state = "doors";
-	name = "WARNING: PRESSURIZED DOORS";
-	pixel_x = -32
-	},
 /turf/open/floor/plating,
 /area/station/maintenance/port/fore)
 "sDJ" = (
@@ -74675,6 +74116,7 @@
 /obj/machinery/disposal/bin,
 /obj/structure/disposalpipe/trunk,
 /obj/effect/turf_decal/bot,
+/obj/structure/sign/painting/library_private,
 /turf/open/floor/iron/dark,
 /area/station/service/library/printer)
 "sGI" = (
@@ -74861,6 +74303,7 @@
 /obj/effect/turf_decal/tile/blue/half/contrasted{
 	dir = 1
 	},
+/obj/machinery/light_switch/directional/north,
 /turf/open/floor/iron/dark,
 /area/station/security/checkpoint/customs/aft)
 "sIR" = (
@@ -74871,11 +74314,6 @@
 "sIX" = (
 /turf/closed/wall/r_wall,
 /area/station/command/heads_quarters/rd)
-"sIY" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/sign/poster/random/directional/south,
-/turf/open/floor/plating,
-/area/station/maintenance/department/security)
 "sIZ" = (
 /obj/machinery/door/firedoor,
 /obj/effect/turf_decal/stripes/line,
@@ -74915,8 +74353,11 @@
 	dir = 4;
 	id = "cargoload"
 	},
-/obj/structure/plasticflaps,
 /obj/effect/decal/cleanable/dirt,
+/obj/structure/plasticflaps{
+	dir = 8;
+	manual_align = 1
+	},
 /turf/open/floor/plating,
 /area/station/cargo/storage)
 "sJj" = (
@@ -75197,16 +74638,6 @@
 /obj/effect/turf_decal/tile/yellow/opposingcorners,
 /turf/open/floor/iron,
 /area/station/engineering/supermatter/room)
-"sMx" = (
-/obj/structure/sign/nanotrasen{
-	pixel_y = -32
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/turf/open/floor/iron,
-/area/station/hallway/secondary/entry)
 "sMG" = (
 /obj/machinery/flasher/directional/south{
 	id = "Isolation_Cell"
@@ -75261,13 +74692,6 @@
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron,
 /area/station/maintenance/port)
-"sNe" = (
-/obj/structure/cable,
-/obj/machinery/duct,
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/sign/poster/random/directional/south,
-/turf/open/floor/plating,
-/area/station/maintenance/port/fore)
 "sNC" = (
 /obj/structure/easel,
 /obj/item/canvas/twentythree_twentythree,
@@ -75380,6 +74804,12 @@
 	},
 /turf/open/floor/iron,
 /area/station/security/checkpoint/escape)
+"sPS" = (
+/obj/structure/closet/secure_closet/engineering_personal,
+/obj/effect/turf_decal/delivery,
+/obj/structure/sign/warning/electric_shock/directional/north,
+/turf/open/floor/iron/dark,
+/area/station/engineering/main)
 "sPT" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -75509,7 +74939,6 @@
 /turf/open/floor/iron,
 /area/station/hallway/primary/fore)
 "sQO" = (
-/obj/structure/sign/poster/random/directional/north,
 /obj/structure/table,
 /obj/item/radio/intercom/directional/west,
 /obj/effect/decal/cleanable/dirt,
@@ -75525,6 +74954,7 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
+/obj/structure/mirror/directional/north,
 /turf/open/floor/iron,
 /area/station/commons/vacant_room/commissary)
 "sQS" = (
@@ -75542,7 +74972,6 @@
 /turf/open/floor/iron,
 /area/station/maintenance/department/science)
 "sQU" = (
-/obj/structure/sign/poster/random/directional/east,
 /obj/effect/turf_decal/tile/brown/half/contrasted{
 	dir = 4
 	},
@@ -75562,13 +74991,13 @@
 /obj/item/wrench,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/bot,
-/obj/structure/sign/poster/random/directional/south,
 /obj/effect/turf_decal/tile/neutral/opposingcorners,
 /turf/open/floor/iron,
 /area/station/maintenance/department/security)
 "sRC" = (
 /obj/machinery/door/morgue{
-	name = "Confession Booth"
+	name = "Confession Booth";
+	dir = 4
 	},
 /obj/effect/turf_decal/siding/wood{
 	dir = 8
@@ -75625,7 +75054,9 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/door/poddoor{
 	id = "cargoload";
-	name = "Supply Dock Loading Door"
+	name = "Supply Dock Loading Door";
+	dir = 4;
+	manual_align = 1
 	},
 /turf/open/floor/plating,
 /area/station/cargo/storage)
@@ -75728,7 +75159,7 @@
 /obj/structure/table,
 /obj/item/clothing/gloves/latex,
 /obj/item/clothing/glasses/science,
-/obj/structure/sign/poster/official/science/directional/west,
+/obj/structure/sign/departments/science/directional/west,
 /turf/open/floor/iron/white,
 /area/station/science/lobby)
 "sTR" = (
@@ -75861,7 +75292,6 @@
 /turf/open/floor/iron/dark,
 /area/station/security/prison/visit)
 "sVi" = (
-/obj/structure/sign/warning/test_chamber/directional/south,
 /obj/structure/disposalpipe/segment{
 	dir = 5
 	},
@@ -76026,14 +75456,6 @@
 /obj/machinery/igniter/incinerator_ordmix,
 /turf/open/floor/engine/vacuum,
 /area/station/science/ordnance/burnchamber)
-"sXE" = (
-/obj/machinery/atmospherics/pipe/smart/simple/orange/visible,
-/obj/structure/lattice/catwalk,
-/obj/structure/sign/nanotrasen{
-	pixel_x = 32
-	},
-/turf/open/space/basic,
-/area/space/nearstation)
 "sXI" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 4
@@ -76836,6 +76258,13 @@
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron/dark,
 /area/station/engineering/atmos)
+"tiL" = (
+/obj/machinery/field/generator,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/bot,
+/obj/structure/sign/warning/secure_area/directional/north,
+/turf/open/floor/iron,
+/area/station/engineering/main)
 "tiP" = (
 /obj/structure/table/wood,
 /obj/item/paper_bin,
@@ -76859,6 +76288,10 @@
 /obj/effect/turf_decal/trimline/blue/filled/corner,
 /turf/open/floor/iron/white,
 /area/station/medical/medbay)
+"tjk" = (
+/obj/structure/sign/nanotrasen,
+/turf/open/space/basic,
+/area/space)
 "tjl" = (
 /obj/structure/disposalpipe/segment{
 	dir = 5
@@ -77110,9 +76543,6 @@
 /turf/open/floor/iron,
 /area/station/science/xenobiology)
 "tnR" = (
-/obj/structure/sign/painting/library{
-	pixel_y = -32
-	},
 /obj/effect/landmark/start/hangover,
 /turf/open/floor/carpet/purple,
 /area/station/commons/dorms)
@@ -77257,10 +76687,6 @@
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron/dark,
 /area/station/service/abandoned_gambling_den/gaming)
-"tpJ" = (
-/obj/structure/sign/nanotrasen,
-/turf/closed/wall,
-/area/station/security/courtroom)
 "tpP" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -77411,9 +76837,6 @@
 /turf/open/floor/engine,
 /area/station/engineering/supermatter)
 "tsc" = (
-/obj/structure/sign/painting/library{
-	pixel_y = -32
-	},
 /turf/open/floor/carpet/blue,
 /area/station/commons/dorms)
 "tse" = (
@@ -77546,13 +76969,9 @@
 /obj/effect/spawner/random/structure/tank_holder,
 /obj/effect/decal/cleanable/cobweb,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
-/obj/machinery/light/small/dim/directional/north,
+/obj/structure/sign/warning/vacuum/directional/north,
 /turf/open/floor/iron/dark,
 /area/station/maintenance/department/science/xenobiology)
-"ttE" = (
-/obj/structure/sign/warning/electric_shock,
-/turf/closed/wall/r_wall,
-/area/station/command/heads_quarters/ce)
 "ttF" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -77726,7 +77145,6 @@
 /obj/machinery/power/terminal{
 	dir = 4
 	},
-/obj/structure/sign/warning/electric_shock/directional/south,
 /turf/open/floor/plating,
 /area/station/maintenance/department/electrical)
 "tuN" = (
@@ -77901,17 +77319,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
 /area/station/maintenance/department/eva/abandoned)
-"txJ" = (
-/obj/structure/sign/directions/engineering{
-	desc = "A sign that shows there are doors here. There are doors everywhere!";
-	icon_state = "doors";
-	name = "WARNING: PRESSURIZED DOORS";
-	pixel_x = 32
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/tile/yellow/opposingcorners,
-/turf/open/floor/iron,
-/area/station/engineering/atmos/project)
 "txK" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -77991,7 +77398,6 @@
 /obj/structure/disposalpipe/trunk{
 	dir = 1
 	},
-/obj/structure/sign/warning/deathsposal/directional/south,
 /obj/machinery/disposal/bin,
 /obj/effect/turf_decal/bot,
 /turf/open/floor/iron/dark,
@@ -78002,7 +77408,6 @@
 "tzn" = (
 /obj/structure/table/reinforced,
 /obj/structure/window/reinforced/spawner/directional/east,
-/obj/structure/sign/poster/official/random/directional/south,
 /obj/item/clothing/suit/jacket/straight_jacket,
 /obj/item/clothing/mask/muzzle,
 /obj/item/clothing/mask/muzzle,
@@ -78052,6 +77457,10 @@
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron,
 /area/station/hallway/primary/port)
+"tAi" = (
+/obj/structure/sign/warning/electric_shock/directional/north,
+/turf/open/space/basic,
+/area/space)
 "tAj" = (
 /obj/machinery/newscaster/directional/east,
 /obj/machinery/photocopier,
@@ -78080,19 +77489,16 @@
 /obj/machinery/camera/directional/east{
 	c_tag = "Garden"
 	},
-/obj/structure/sign/poster/contraband/random/directional/east,
 /turf/open/floor/iron,
 /area/station/service/hydroponics/garden)
 "tAL" = (
-/obj/structure/sign/nanotrasen{
-	pixel_y = 32
-	},
 /obj/structure/railing{
 	dir = 1
 	},
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
+/obj/structure/sign/nanotrasen,
 /turf/open/floor/iron,
 /area/station/hallway/primary/central/aft)
 "tAM" = (
@@ -78536,7 +77942,6 @@
 /obj/effect/turf_decal/siding/wood/corner{
 	dir = 8
 	},
-/obj/structure/sign/poster/official/random/directional/west,
 /turf/open/floor/wood,
 /area/station/maintenance/port/fore)
 "tFG" = (
@@ -78990,10 +78395,6 @@
 /obj/effect/turf_decal/tile/neutral/full,
 /turf/open/floor/iron/half,
 /area/station/security/range)
-"tLC" = (
-/obj/structure/sign/warning/radiation,
-/turf/closed/wall/r_wall,
-/area/station/engineering/supermatter/room)
 "tLW" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/turf_decal/tile/red/fourcorners,
@@ -79239,6 +78640,7 @@
 /obj/machinery/light_switch/directional/west{
 	pixel_y = -6
 	},
+/obj/structure/sign/poster/contraband/random/directional/north,
 /turf/open/floor/wood,
 /area/station/service/theater)
 "tOv" = (
@@ -79539,13 +78941,11 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/table/wood,
 /obj/effect/spawner/random/maintenance,
-/obj/machinery/light/small/directional/north,
 /obj/machinery/status_display/evac/directional/north,
 /turf/open/floor/iron/dark,
 /area/station/service/abandoned_gambling_den)
 "tRO" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/sign/poster/contraband/random/directional/south,
 /obj/effect/turf_decal/tile/brown/opposingcorners{
 	dir = 1
 	},
@@ -79562,7 +78962,6 @@
 /turf/open/floor/iron/white,
 /area/station/medical/virology)
 "tSa" = (
-/obj/structure/sign/poster/random/directional/south,
 /obj/effect/turf_decal/tile/red/opposingcorners{
 	dir = 1
 	},
@@ -79629,12 +79028,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
 /area/station/maintenance/port/aft)
-"tTj" = (
-/obj/structure/plaque/static_plaque/golden/captain{
-	pixel_x = 32
-	},
-/turf/open/floor/wood,
-/area/station/command/heads_quarters/captain)
 "tTn" = (
 /obj/structure/cable,
 /obj/effect/decal/cleanable/dirt,
@@ -79682,7 +79075,6 @@
 /turf/open/floor/iron,
 /area/station/commons/toilet/locker)
 "tTQ" = (
-/obj/structure/sign/poster/ripped/directional/south,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/turf_decal/tile/red/half/contrasted{
@@ -79968,6 +79360,13 @@
 	},
 /turf/open/floor/iron/cafeteria,
 /area/station/security/prison/mess)
+"tXN" = (
+/obj/effect/turf_decal/tile/neutral/half/contrasted{
+	dir = 1
+	},
+/obj/structure/sign/warning/pods/directional/north,
+/turf/open/floor/iron,
+/area/station/commons/dorms)
 "tXO" = (
 /obj/effect/turf_decal/tile/purple/fourcorners,
 /turf/open/floor/iron,
@@ -80036,6 +79435,21 @@
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron,
 /area/station/command/teleporter)
+"tYn" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/machinery/door/poddoor/shutters{
+	dir = 4;
+	id = "mechbay";
+	name = "Mech Bay Shutters"
+	},
+/obj/structure/sign/nanotrasen,
+/turf/open/floor/iron,
+/area/station/science/robotics/mechbay)
 "tYo" = (
 /obj/structure/window/spawner/directional/south,
 /obj/effect/decal/cleanable/dirt,
@@ -80201,7 +79615,6 @@
 "uaS" = (
 /obj/item/rack_parts,
 /obj/effect/spawner/random/engineering/tool,
-/obj/structure/sign/poster/random/directional/east,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
@@ -80623,11 +80036,10 @@
 /area/station/commons/toilet/locker)
 "ufz" = (
 /obj/machinery/firealarm/directional/south,
-/obj/structure/disposalpipe/segment{
-	dir = 9
-	},
 /obj/effect/turf_decal/bot_white,
 /obj/structure/filingcabinet,
+/obj/machinery/power/apc/auto_name/directional/east,
+/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/station/service/library/printer)
 "ufE" = (
@@ -80642,7 +80054,7 @@
 /area/station/security/warden)
 "ugc" = (
 /obj/effect/spawner/random/engineering/atmospherics_portable,
-/obj/structure/sign/poster/random/directional/north,
+/obj/structure/sign/warning/no_smoking/directional/north,
 /turf/open/floor/plating,
 /area/station/maintenance/department/engine/atmos)
 "ugd" = (
@@ -80716,10 +80128,6 @@
 /obj/machinery/newscaster/directional/west,
 /turf/open/floor/iron/dark,
 /area/station/engineering/atmos/hfr_room)
-"ugP" = (
-/obj/structure/sign/warning/radiation,
-/turf/closed/wall/r_wall,
-/area/station/maintenance/port)
 "uhb" = (
 /turf/closed/wall/r_wall,
 /area/station/science/xenobiology)
@@ -80738,7 +80146,6 @@
 /area/station/maintenance/starboard/aft)
 "uhC" = (
 /obj/effect/spawner/random/vending/colavend,
-/obj/structure/sign/poster/official/ian/directional/south,
 /obj/effect/turf_decal/bot,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron/dark,
@@ -81271,13 +80678,9 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
+/obj/structure/sign/warning/pods/directional/north,
 /turf/open/floor/iron,
 /area/station/hallway/secondary/entry)
-"uow" = (
-/obj/effect/spawner/structure/window,
-/obj/structure/sign/plaques/kiddie/library,
-/turf/open/floor/plating,
-/area/station/service/library)
 "uoz" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -81293,9 +80696,6 @@
 "uoI" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 1
-	},
-/obj/structure/sign/nanotrasen{
-	pixel_y = -32
 	},
 /obj/machinery/light/small/directional/south,
 /obj/effect/turf_decal/tile/red/half/contrasted,
@@ -81417,10 +80817,10 @@
 /area/station/hallway/secondary/entry)
 "uqq" = (
 /obj/item/kirbyplants/random,
-/obj/structure/sign/poster/random/directional/north,
 /obj/effect/turf_decal/tile/neutral/anticorner/contrasted{
 	dir = 4
 	},
+/obj/structure/mirror/directional/north,
 /turf/open/floor/iron,
 /area/station/commons/toilet/locker)
 "uqJ" = (
@@ -81823,6 +81223,7 @@
 /obj/item/radio/intercom/directional/east,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /obj/machinery/light/small/directional/north,
+/obj/structure/sign/nanotrasen,
 /turf/open/floor/iron/dark,
 /area/station/security/checkpoint/arrivals)
 "uvt" = (
@@ -81859,6 +81260,14 @@
 	},
 /turf/open/floor/iron,
 /area/station/commons/locker)
+"uwb" = (
+/obj/structure/lattice/catwalk,
+/obj/machinery/atmospherics/pipe/smart/simple/orange/visible{
+	dir = 8
+	},
+/obj/structure/sign/warning/secure_area/directional/north,
+/turf/open/space/basic,
+/area/space/nearstation)
 "uwc" = (
 /obj/machinery/vending/autodrobe,
 /obj/effect/turf_decal/bot,
@@ -81981,7 +81390,6 @@
 "uxF" = (
 /obj/machinery/hydroponics/soil,
 /obj/machinery/light/small/directional/west,
-/obj/structure/sign/poster/contraband/ambrosia_vulgaris/directional/west,
 /turf/open/misc/sandy_dirt,
 /area/station/security/prison/garden)
 "uxG" = (
@@ -82054,11 +81462,6 @@
 /obj/machinery/vending/dinnerware,
 /turf/open/floor/iron/dark,
 /area/station/service/kitchen)
-"uyy" = (
-/obj/structure/sign/warning/secure_area/directional/east,
-/obj/effect/turf_decal/tile/neutral/fourcorners,
-/turf/open/floor/iron/dark,
-/area/station/science/xenobiology)
 "uyA" = (
 /obj/structure/window/reinforced/spawner/directional/south,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -82202,13 +81605,6 @@
 	},
 /turf/open/floor/wood/large,
 /area/station/service/library)
-"uzZ" = (
-/obj/structure/sign/nanotrasen{
-	pixel_x = 32
-	},
-/obj/structure/lattice,
-/turf/open/space/basic,
-/area/space/nearstation)
 "uAc" = (
 /obj/structure/closet/crate,
 /obj/item/target/alien,
@@ -82258,9 +81654,6 @@
 /turf/open/floor/iron/dark,
 /area/station/engineering/atmos/hfr_room)
 "uAL" = (
-/obj/structure/sign/nanotrasen{
-	pixel_y = -32
-	},
 /obj/structure/table/reinforced,
 /obj/machinery/recharger{
 	pixel_x = -6;
@@ -82438,19 +81831,6 @@
 	},
 /turf/open/floor/iron,
 /area/station/engineering/lobby)
-"uDj" = (
-/obj/structure/cable,
-/obj/structure/sign/nanotrasen{
-	pixel_y = -32
-	},
-/obj/effect/turf_decal/siding/wood{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/blue/half/contrasted{
-	dir = 8
-	},
-/turf/open/floor/iron/dark,
-/area/station/command/corporate_showroom)
 "uDk" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -82497,10 +81877,6 @@
 /obj/structure/chair/stool/bar/directional/north,
 /turf/open/floor/carpet/green,
 /area/station/commons/lounge)
-"uDI" = (
-/obj/structure/sign/nanotrasen,
-/turf/closed/wall,
-/area/station/service/chapel/funeral)
 "uDQ" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -82556,7 +81932,6 @@
 	id = "warehouse_shutters";
 	name = "warehouse shutters control"
 	},
-/obj/structure/sign/poster/contraband/random/directional/south,
 /obj/effect/turf_decal/tile/brown/anticorner/contrasted,
 /turf/open/floor/iron,
 /area/station/cargo/warehouse)
@@ -82575,9 +81950,6 @@
 /turf/open/floor/iron/white/side,
 /area/station/science/research)
 "uFa" = (
-/obj/structure/sign/nanotrasen{
-	pixel_y = -32
-	},
 /obj/machinery/camera/directional/south{
 	c_tag = "Security - Brig Desk"
 	},
@@ -83044,6 +82416,18 @@
 /obj/effect/spawner/random/trash/cigbutt,
 /turf/open/floor/plating,
 /area/station/medical/abandoned)
+"uKN" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/structure/sign/nanotrasen,
+/turf/open/floor/iron,
+/area/station/hallway/secondary/command)
 "uKQ" = (
 /obj/structure/chair{
 	dir = 1;
@@ -83073,7 +82457,6 @@
 /turf/open/floor/iron/dark,
 /area/station/service/chapel)
 "uLf" = (
-/obj/structure/sign/warning/electric_shock/directional/east,
 /obj/effect/turf_decal/tile/red{
 	dir = 4
 	},
@@ -83278,6 +82661,13 @@
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/turret_protected/aisat_interior)
+"uNq" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 9
+	},
+/obj/structure/sign/warning/electric_shock/directional/north,
+/turf/open/floor/iron,
+/area/station/engineering/atmos/hfr_room)
 "uNy" = (
 /obj/machinery/computer/accounting{
 	dir = 4
@@ -83310,10 +82700,6 @@
 	},
 /turf/open/floor/iron,
 /area/station/maintenance/port)
-"uNU" = (
-/obj/structure/sign/nanotrasen,
-/turf/closed/wall/r_wall,
-/area/station/command/heads_quarters/hop)
 "uNY" = (
 /turf/closed/wall,
 /area/station/medical/medbay/lobby)
@@ -83361,13 +82747,6 @@
 /obj/machinery/status_display/ai/directional/north,
 /turf/open/floor/plating,
 /area/station/service/abandoned_gambling_den)
-"uOC" = (
-/obj/structure/lattice,
-/obj/structure/sign/nanotrasen{
-	pixel_y = -32
-	},
-/turf/open/space,
-/area/space/nearstation)
 "uOE" = (
 /obj/structure/table/wood,
 /obj/effect/decal/cleanable/dirt,
@@ -83512,17 +82891,6 @@
 	},
 /turf/open/floor/iron/dark/corner,
 /area/station/maintenance/port)
-"uPM" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/lattice/catwalk,
-/obj/machinery/atmospherics/pipe/smart/simple/orange/visible,
-/obj/structure/sign/nanotrasen{
-	pixel_x = 32
-	},
-/turf/open/space/basic,
-/area/space/nearstation)
 "uPS" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/table/wood,
@@ -83582,20 +82950,11 @@
 /area/station/commons/storage/primary)
 "uQD" = (
 /obj/machinery/light/small/directional/north,
-/obj/structure/sign/nanotrasen{
-	pixel_x = 32;
-	pixel_y = 32
-	},
-/obj/structure/sign/directions/engineering{
-	desc = "A sign that shows there are doors here. There are doors everywhere!";
-	icon_state = "doors";
-	name = "WARNING: BLAST DOORS";
-	pixel_y = 32
-	},
 /obj/item/kirbyplants/organic/plant22,
 /obj/effect/turf_decal/tile/blue/half/contrasted{
 	dir = 1
 	},
+/obj/structure/sign/nanotrasen,
 /turf/open/floor/iron/dark,
 /area/station/command/bridge)
 "uQF" = (
@@ -83659,11 +83018,6 @@
 /obj/effect/spawner/random/engineering/tracking_beacon,
 /turf/open/floor/iron/edge,
 /area/station/hallway/primary/central/aft)
-"uRt" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/sign/poster/contraband/random/directional/east,
-/turf/open/floor/plating,
-/area/station/maintenance/fore)
 "uRx" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/green/visible,
 /obj/effect/turf_decal/stripes/line{
@@ -83803,9 +83157,9 @@
 "uSX" = (
 /obj/structure/closet/firecloset,
 /obj/effect/turf_decal/bot,
-/obj/item/radio/intercom/directional/north,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/sign/warning/gas_mask/directional/north,
 /turf/open/floor/iron/dark,
 /area/station/science/ordnance)
 "uSY" = (
@@ -83817,12 +83171,6 @@
 /obj/effect/turf_decal/tile/neutral/full,
 /turf/open/floor/iron/dark/smooth_large,
 /area/station/security/checkpoint/customs/aft)
-"uTd" = (
-/obj/structure/sign/nanotrasen{
-	pixel_y = -32
-	},
-/turf/open/space/basic,
-/area/space/nearstation)
 "uTe" = (
 /obj/structure/cable,
 /obj/effect/turf_decal/tile/neutral/half/contrasted{
@@ -84298,13 +83646,6 @@
 /obj/effect/turf_decal/bot,
 /turf/open/floor/iron/dark,
 /area/station/engineering/atmos/storage)
-"uZM" = (
-/obj/structure/sign/warning/electric_shock/directional/east,
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/station/hallway/primary/starboard)
 "uZQ" = (
 /obj/structure/rack,
 /obj/item/stack/medical/gauze,
@@ -84749,6 +84090,11 @@
 	},
 /turf/open/floor/iron,
 /area/station/security/prison/garden)
+"vfR" = (
+/obj/structure/lattice,
+/obj/structure/sign/warning/directional/north,
+/turf/open/space,
+/area/space/nearstation)
 "vfS" = (
 /obj/machinery/power/apc/auto_name/directional/west,
 /obj/structure/cable,
@@ -85100,9 +84446,6 @@
 "vkX" = (
 /obj/effect/turf_decal/bot,
 /obj/machinery/vending/cigarette,
-/obj/structure/sign/nanotrasen{
-	pixel_x = -32
-	},
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /obj/machinery/light/small/directional/west,
 /turf/open/floor/iron/dark,
@@ -85413,10 +84756,8 @@
 /turf/open/floor/iron,
 /area/station/engineering/storage_shared)
 "vqg" = (
-/obj/structure/sign/nanotrasen{
-	pixel_x = -32
-	},
 /obj/effect/landmark/start/hangover,
+/obj/machinery/airalarm/directional/south,
 /turf/open/floor/wood,
 /area/station/commons/dorms)
 "vqt" = (
@@ -85491,6 +84832,11 @@
 /obj/item/paint_palette,
 /turf/open/floor/carpet/blue,
 /area/station/service/library/lounge)
+"vqS" = (
+/obj/structure/lattice,
+/obj/structure/sign/nanotrasen,
+/turf/open/space,
+/area/space/nearstation)
 "vqY" = (
 /obj/effect/landmark/start/hangover,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
@@ -85761,7 +85107,6 @@
 /obj/item/cultivator,
 /obj/item/reagent_containers/cup/watering_can,
 /obj/item/plant_analyzer,
-/obj/structure/sign/poster/contraband/kudzu/directional/south,
 /obj/machinery/power/apc/auto_name/directional/south,
 /obj/effect/turf_decal/bot,
 /obj/effect/turf_decal/siding/green{
@@ -85779,6 +85124,7 @@
 	name = "engineering camera";
 	network = list("ss13","engine")
 	},
+/obj/structure/sign/warning/engine_safety/directional/north,
 /turf/open/floor/iron,
 /area/station/engineering/supermatter/room)
 "vuJ" = (
@@ -85838,6 +85184,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
+/obj/structure/sign/warning/no_smoking/directional/north,
 /turf/open/floor/iron/white/smooth_half{
 	dir = 1
 	},
@@ -85852,7 +85199,6 @@
 /area/station/security/prison/work)
 "vvD" = (
 /obj/structure/cable,
-/obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/visible,
 /turf/open/floor/iron,
 /area/station/maintenance/disposal/incinerator)
@@ -86273,13 +85619,6 @@
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron,
 /area/station/hallway/primary/fore)
-"vAl" = (
-/obj/structure/sign/nanotrasen{
-	pixel_x = 32;
-	pixel_y = 32
-	},
-/turf/open/floor/wood,
-/area/station/command/meeting_room/council)
 "vAs" = (
 /obj/structure/cable,
 /obj/machinery/holopad/secure,
@@ -86411,7 +85750,7 @@
 /area/station/science/research)
 "vBt" = (
 /obj/structure/closet/l3closet/janitor,
-/obj/structure/sign/poster/random/directional/east,
+/obj/structure/sign/poster/random/directional/north,
 /turf/open/floor/iron/dark,
 /area/station/service/janitor)
 "vBu" = (
@@ -86475,12 +85814,10 @@
 /turf/open/floor/iron,
 /area/station/hallway/primary/fore)
 "vCk" = (
-/obj/structure/sign/departments/medbay/alt{
-	pixel_x = 32
-	},
 /obj/effect/turf_decal/tile/red/half/contrasted{
 	dir = 4
 	},
+/obj/structure/sign/departments/medbay/alt/directional/east,
 /turf/open/floor/iron,
 /area/station/security/brig)
 "vCn" = (
@@ -86592,6 +85929,7 @@
 "vDJ" = (
 /obj/machinery/teleport/hub,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/structure/sign/nanotrasen,
 /turf/open/floor/iron/dark,
 /area/station/command/teleporter)
 "vDL" = (
@@ -86649,6 +85987,14 @@
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron,
 /area/station/engineering/main)
+"vEw" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/tile/neutral/half/contrasted{
+	dir = 1
+	},
+/obj/structure/sign/nanotrasen,
+/turf/open/floor/iron,
+/area/station/maintenance/port/aft)
 "vEV" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -86752,7 +86098,6 @@
 	},
 /area/station/commons/fitness/recreation)
 "vFw" = (
-/obj/structure/sign/warning/electric_shock/directional/east,
 /obj/machinery/status_display/ai/directional/north,
 /obj/structure/table/wood/fancy/blue,
 /obj/machinery/door/window/right/directional/west{
@@ -86888,6 +86233,7 @@
 /obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 1
 	},
+/obj/structure/sign/warning/no_smoking/directional/north,
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
 "vHq" = (
@@ -86956,7 +86302,7 @@
 /turf/open/floor/iron/white,
 /area/station/medical/medbay)
 "vIz" = (
-/obj/structure/sign/warning/secure_area/directional/east,
+/obj/structure/sign/warning/electric_shock/directional/north,
 /turf/open/space/basic,
 /area/space/nearstation)
 "vIB" = (
@@ -87092,6 +86438,7 @@
 	dir = 9
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
+/obj/structure/sign/warning/biohazard/directional/north,
 /turf/open/floor/iron/white,
 /area/station/medical/virology)
 "vKK" = (
@@ -87155,7 +86502,6 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/rack,
 /obj/item/stack/ducts/fifty,
-/obj/structure/sign/poster/random/directional/south,
 /obj/effect/turf_decal/tile/neutral/half/contrasted,
 /turf/open/floor/iron,
 /area/station/maintenance/port/fore)
@@ -87358,12 +86704,6 @@
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/turret_protected/ai)
-"vPe" = (
-/obj/structure/cable,
-/obj/effect/spawner/structure/window/reinforced,
-/obj/structure/sign/warning/electric_shock,
-/turf/open/floor/plating,
-/area/station/engineering/lobby)
 "vPf" = (
 /obj/structure/sign/painting/library{
 	pixel_y = -32
@@ -87884,7 +87224,6 @@
 /turf/open/floor/iron/dark,
 /area/station/hallway/secondary/exit/departure_lounge)
 "vWm" = (
-/obj/structure/sign/warning/vacuum/external/directional/west,
 /obj/item/kirbyplants/random,
 /obj/machinery/airalarm/directional/north,
 /obj/effect/turf_decal/tile/blue{
@@ -87921,6 +87260,7 @@
 "vWU" = (
 /obj/item/kirbyplants/random,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/structure/sign/nanotrasen,
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/turret_protected/ai_upload)
 "vWV" = (
@@ -87931,7 +87271,6 @@
 	},
 /obj/effect/mapping_helpers/requests_console/ore_update,
 /obj/effect/mapping_helpers/requests_console/supplies,
-/obj/machinery/light/cold/directional/north,
 /obj/structure/closet/crate/mod,
 /turf/open/floor/iron,
 /area/station/science/robotics/lab)
@@ -88608,6 +87947,7 @@
 	},
 /obj/structure/table/wood,
 /obj/item/flashlight/lamp,
+/obj/structure/sign/poster/random/directional/north,
 /turf/open/floor/wood,
 /area/station/hallway/secondary/service)
 "wgC" = (
@@ -88673,7 +88013,6 @@
 /turf/open/floor/iron/large,
 /area/station/security/checkpoint/medical/medsci)
 "whc" = (
-/obj/structure/sign/poster/official/fruit_bowl/directional/west,
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
@@ -88837,7 +88176,6 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/sign/poster/official/plasma_effects/directional/east,
 /turf/open/floor/iron/white,
 /area/station/medical/virology)
 "wjF" = (
@@ -88876,7 +88214,6 @@
 /turf/open/floor/iron,
 /area/station/maintenance/department/chapel)
 "wjS" = (
-/obj/structure/extinguisher_cabinet/directional/north,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
@@ -88887,6 +88224,7 @@
 	},
 /obj/structure/chair/comfy/teal,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/structure/sign/painting/library,
 /turf/open/floor/iron/dark,
 /area/station/service/library)
 "wjV" = (
@@ -89185,7 +88523,8 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/door/airlock/external{
-	name = "MiniSat Exterior Access"
+	name = "MiniSat Exterior Access";
+	dir = 4
 	},
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 4
@@ -89314,7 +88653,6 @@
 /obj/structure/reagent_dispensers/wall/peppertank/directional/east,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/mapping_helpers/burnt_floor,
-/obj/structure/sign/poster/official/space_cops/directional/south,
 /obj/effect/turf_decal/tile/red/fourcorners,
 /turf/open/floor/iron/dark,
 /area/station/maintenance/department/security)
@@ -89389,6 +88727,7 @@
 	dir = 4
 	},
 /obj/machinery/light/small/directional/east,
+/obj/item/radio/intercom/directional/east,
 /turf/open/floor/iron/dark/corner{
 	dir = 4
 	},
@@ -89612,9 +88951,6 @@
 "wrM" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/visible,
-/obj/structure/sign/warning/no_smoking{
-	pixel_x = -32
-	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 10
 	},
@@ -89721,7 +89057,6 @@
 "wsT" = (
 /obj/structure/table/reinforced,
 /obj/machinery/microwave/engineering/cell_included,
-/obj/structure/sign/poster/random/directional/west,
 /turf/open/floor/wood,
 /area/station/engineering/break_room)
 "wsU" = (
@@ -89788,10 +89123,12 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/machinery/light/floor,
 /turf/open/floor/iron,
 /area/station/science/research)
 "wtU" = (
 /obj/structure/cable,
+/obj/structure/sign/plaques/kiddie/library,
 /turf/open/floor/wood/tile,
 /area/station/service/library/artgallery)
 "wtV" = (
@@ -90001,10 +89338,12 @@
 /turf/open/floor/iron,
 /area/station/engineering/break_room)
 "wwN" = (
-/obj/machinery/power/apc/auto_name/directional/east,
 /obj/structure/cable,
-/obj/structure/disposalpipe/segment,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/machinery/computer/security/telescreen/entertainment/directional/east,
+/obj/structure/disposalpipe/segment{
+	dir = 9
+	},
 /turf/open/floor/iron/dark,
 /area/station/service/library/printer)
 "wwP" = (
@@ -90057,7 +89396,6 @@
 "wxl" = (
 /obj/machinery/power/apc/auto_name/directional/north,
 /obj/structure/cable,
-/obj/structure/sign/poster/official/safety_report/directional/west,
 /obj/item/kirbyplants/random,
 /obj/effect/turf_decal/tile/red/anticorner/contrasted{
 	dir = 1
@@ -90069,6 +89407,7 @@
 /obj/machinery/vending/coffee,
 /obj/machinery/firealarm/directional/west,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/structure/sign/nanotrasen,
 /turf/open/floor/iron/dark,
 /area/station/hallway/primary/central/fore)
 "wxv" = (
@@ -90100,9 +89439,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
-/obj/structure/sign/nanotrasen{
-	pixel_y = 32
-	},
+/obj/structure/sign/nanotrasen,
 /turf/open/floor/iron,
 /area/station/hallway/primary/central/fore)
 "wxX" = (
@@ -90336,11 +89673,11 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/sign/warning/docking/directional/north,
 /obj/structure/cable,
 /obj/effect/turf_decal/tile/neutral/half/contrasted{
 	dir = 1
 	},
+/obj/structure/sign/warning/directional/north,
 /turf/open/floor/iron,
 /area/station/maintenance/department/chapel)
 "wAT" = (
@@ -90349,9 +89686,6 @@
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/aft)
 "wAZ" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /obj/structure/table/wood,
 /obj/item/taperecorder,
 /obj/item/camera,
@@ -90626,7 +89960,6 @@
 /obj/item/wrench,
 /obj/item/storage/box/lights/mixed,
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/sign/poster/official/random/directional/south,
 /obj/machinery/light/small/directional/south,
 /turf/open/floor/iron,
 /area/station/maintenance/port)
@@ -90670,7 +90003,6 @@
 	dir = 1
 	},
 /obj/item/stack/sheet/glass,
-/obj/structure/sign/poster/contraband/borg_fancy_1/directional/south,
 /turf/open/floor/plating,
 /area/station/science/research/abandoned)
 "wEX" = (
@@ -90871,6 +90203,7 @@
 	},
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /obj/machinery/light/small/directional/north,
+/obj/structure/sign/nanotrasen,
 /turf/open/floor/iron/dark,
 /area/station/hallway/secondary/entry)
 "wGV" = (
@@ -90942,7 +90275,6 @@
 "wHW" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/table/wood,
-/obj/structure/sign/poster/contraband/random/directional/east,
 /obj/effect/spawner/random/maintenance,
 /turf/open/floor/plating,
 /area/station/service/abandoned_gambling_den)
@@ -91032,7 +90364,6 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 6
 	},
-/obj/structure/sign/warning/explosives/alt/directional/east,
 /obj/machinery/light/small/directional/south,
 /turf/open/floor/iron,
 /area/station/maintenance/department/science)
@@ -91084,9 +90415,6 @@
 /turf/open/floor/iron/chapel,
 /area/station/service/chapel)
 "wKm" = (
-/obj/structure/sign/nanotrasen{
-	pixel_x = 32
-	},
 /obj/item/kirbyplants/random,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /obj/effect/turf_decal/tile/blue/half/contrasted{
@@ -91318,20 +90646,6 @@
 /obj/effect/turf_decal/tile/yellow/opposingcorners,
 /turf/open/floor/iron,
 /area/station/engineering/atmos/project)
-"wNP" = (
-/obj/machinery/portable_atmospherics/pump,
-/obj/machinery/atmospherics/components/unary/portables_connector/visible{
-	dir = 4
-	},
-/obj/effect/turf_decal/box,
-/obj/structure/sign/poster/official/random/directional/west,
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/turf/open/floor/iron/white/corner{
-	dir = 1
-	},
-/area/station/engineering/atmos/storage/gas)
 "wNV" = (
 /obj/structure/table,
 /obj/item/paper_bin,
@@ -91420,7 +90734,6 @@
 /obj/effect/turf_decal/stripes/corner{
 	dir = 8
 	},
-/obj/structure/sign/warning/biohazard/directional/west,
 /obj/effect/turf_decal/trimline/yellow/filled/corner{
 	dir = 4
 	},
@@ -91430,6 +90743,7 @@
 	name = "medbay camera";
 	network = list("ss13","medbay")
 	},
+/obj/structure/sign/warning/chem_diamond/directional/north,
 /turf/open/floor/iron/white,
 /area/station/medical/medbay)
 "wPT" = (
@@ -91577,7 +90891,6 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/tile/neutral/fourcorners,
-/obj/structure/sign/poster/official/here_for_your_safety/directional/east,
 /turf/open/floor/iron/dark,
 /area/station/security/prison/visit)
 "wSv" = (
@@ -91909,13 +91222,12 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 5
 	},
-/obj/structure/sign/warning/docking/directional/east,
-/obj/structure/sign/warning/no_smoking/circle/directional/north,
 /obj/machinery/camera/directional/north{
 	c_tag = "Science - Ordnance Launch Access";
 	name = "science camera";
 	network = list("ss13","rd")
 	},
+/obj/structure/sign/warning/explosives/alt/directional/north,
 /turf/open/floor/iron,
 /area/station/maintenance/department/science)
 "wXU" = (
@@ -92042,13 +91354,10 @@
 /turf/open/floor/iron,
 /area/station/commons/storage/tools)
 "xaF" = (
-/obj/structure/sign/nanotrasen{
-	pixel_x = 32;
-	pixel_y = -32
-	},
 /obj/machinery/light/small/directional/south,
 /obj/item/kirbyplants/organic/plant22,
 /obj/effect/turf_decal/tile/blue/half/contrasted,
+/obj/machinery/firealarm/directional/south,
 /turf/open/floor/iron/dark,
 /area/station/command/bridge)
 "xaK" = (
@@ -92502,13 +91811,6 @@
 /obj/machinery/airalarm/directional/east,
 /turf/open/floor/iron,
 /area/station/hallway/primary/port)
-"xfE" = (
-/obj/structure/lattice/catwalk,
-/obj/structure/sign/nanotrasen{
-	pixel_x = 32
-	},
-/turf/open/space/basic,
-/area/space/nearstation)
 "xfR" = (
 /obj/machinery/camera/directional/east{
 	c_tag = "Security - Interrogation Monitoring"
@@ -92596,10 +91898,6 @@
 	},
 /turf/open/floor/iron,
 /area/station/cargo/storage)
-"xgZ" = (
-/obj/structure/sign/warning/secure_area/directional/south,
-/turf/open/space/basic,
-/area/space/nearstation)
 "xhi" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/button/door/directional/east{
@@ -93163,11 +92461,6 @@
 /obj/machinery/computer/security/wooden_tv,
 /turf/open/floor/carpet,
 /area/station/command/heads_quarters/captain)
-"xny" = (
-/obj/structure/sign/poster/official/do_not_question/directional/south,
-/obj/effect/turf_decal/tile/neutral,
-/turf/open/floor/iron,
-/area/station/hallway/primary/central/fore)
 "xnF" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 8
@@ -93267,6 +92560,7 @@
 /obj/effect/turf_decal/tile/yellow{
 	dir = 4
 	},
+/obj/structure/sign/warning/secure_area/directional/north,
 /turf/open/floor/iron/dark/corner{
 	dir = 1
 	},
@@ -93387,6 +92681,7 @@
 	dir = 8
 	},
 /obj/item/clothing/gloves/color/yellow,
+/obj/structure/sign/warning/radiation/rad_area/directional/north,
 /turf/open/floor/iron,
 /area/station/engineering/main)
 "xrd" = (
@@ -94031,16 +93326,11 @@
 	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/fore)
-"xyu" = (
-/obj/structure/sign/nanotrasen,
-/turf/closed/wall/r_wall,
-/area/station/maintenance/department/medical/morgue)
 "xyK" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/item/kirbyplants/random,
 /obj/structure/cable,
-/obj/structure/sign/poster/random/directional/east,
 /obj/machinery/camera/directional/north{
 	c_tag = "Dormitories - Fore Hall";
 	name = "dormitories camera"
@@ -94150,7 +93440,6 @@
 /obj/structure/table/reinforced,
 /obj/item/paper_bin,
 /obj/item/pen,
-/obj/structure/sign/poster/official/enlist/directional/south,
 /obj/effect/turf_decal/tile/red/anticorner/contrasted{
 	dir = 8
 	},
@@ -94273,7 +93562,6 @@
 /obj/structure/table/wood,
 /obj/item/paper_bin,
 /obj/item/pen,
-/obj/structure/sign/poster/official/random/directional/east,
 /obj/machinery/newscaster/directional/north,
 /obj/machinery/light/small/directional/east,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
@@ -94389,9 +93677,7 @@
 /turf/open/floor/iron,
 /area/station/science/xenobiology)
 "xCf" = (
-/obj/structure/sign/nanotrasen{
-	pixel_y = 32
-	},
+/obj/structure/sign/nanotrasen,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
@@ -94447,6 +93733,7 @@
 /obj/effect/turf_decal/stripes/line,
 /obj/effect/turf_decal/caution/stand_clear,
 /obj/machinery/light/small/directional/north,
+/obj/structure/sign/warning/directional/north,
 /turf/open/floor/iron/half,
 /area/station/engineering/atmos)
 "xDq" = (
@@ -94489,7 +93776,9 @@
 	},
 /obj/machinery/door/poddoor{
 	id = "cargounload";
-	name = "Supply Dock Unloading Door"
+	name = "Supply Dock Unloading Door";
+	dir = 4;
+	manual_align = 1
 	},
 /turf/open/floor/plating,
 /area/station/cargo/storage)
@@ -94579,7 +93868,10 @@
 	dir = 8;
 	id = "cargounload"
 	},
-/obj/structure/plasticflaps,
+/obj/structure/plasticflaps{
+	dir = 8;
+	manual_align = 1
+	},
 /turf/open/floor/plating,
 /area/station/cargo/storage)
 "xES" = (
@@ -95205,7 +94497,6 @@
 /obj/machinery/atmospherics/pipe/smart/simple/dark/visible{
 	dir = 5
 	},
-/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
 /area/station/maintenance/disposal/incinerator)
 "xMo" = (
@@ -95307,6 +94598,7 @@
 /obj/structure/closet/emcloset,
 /obj/effect/turf_decal/bot,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/structure/sign/warning/secure_area/directional/north,
 /turf/open/floor/iron/dark,
 /area/station/science/research)
 "xNR" = (
@@ -95484,13 +94776,13 @@
 /turf/open/floor/iron/large,
 /area/station/medical/storage)
 "xQZ" = (
-/obj/machinery/airalarm/directional/north,
 /obj/effect/landmark/start/hangover/closet,
 /obj/effect/spawner/random/structure/closet_private,
 /obj/item/clothing/head/costume/kitty,
 /obj/item/clothing/under/costume/maid,
 /obj/item/clothing/head/costume/rabbitears,
 /obj/item/clothing/under/dress/eveninggown,
+/obj/structure/sign/painting/library,
 /turf/open/floor/wood,
 /area/station/commons/dorms)
 "xRa" = (
@@ -95503,9 +94795,6 @@
 "xRk" = (
 /obj/machinery/computer/robotics{
 	dir = 8
-	},
-/obj/structure/sign/nanotrasen{
-	pixel_x = 32
 	},
 /obj/machinery/keycard_auth/wall_mounted/directional/south,
 /obj/effect/turf_decal/tile/purple,
@@ -95556,7 +94845,7 @@
 /obj/structure/bed,
 /obj/item/bedsheet/clown,
 /obj/machinery/newscaster/directional/east,
-/obj/structure/sign/poster/random/directional/north,
+/obj/structure/mirror/directional/north,
 /turf/open/floor/wood,
 /area/station/hallway/secondary/service)
 "xSx" = (
@@ -95623,13 +94912,6 @@
 	dir = 1
 	},
 /area/station/maintenance/department/electrical)
-"xTk" = (
-/obj/structure/closet/secure_closet/security/sec,
-/obj/structure/sign/poster/official/do_not_question/directional/south,
-/obj/effect/turf_decal/bot,
-/obj/effect/turf_decal/tile/red/fourcorners,
-/turf/open/floor/iron/dark,
-/area/station/security/lockers)
 "xTm" = (
 /obj/machinery/hydroponics/constructable,
 /obj/effect/turf_decal/tile/blue{
@@ -95845,7 +95127,6 @@
 /area/station/science/research)
 "xWi" = (
 /obj/effect/turf_decal/siding/green,
-/obj/structure/sign/warning/biohazard/directional/north,
 /obj/structure/window/reinforced/spawner/directional/south,
 /obj/structure/flora/bush/ferny,
 /obj/structure/flora/bush/lavendergrass,
@@ -95933,15 +95214,6 @@
 /obj/machinery/status_display/evac/directional/east,
 /turf/open/floor/carpet,
 /area/station/security/detectives_office)
-"xXd" = (
-/obj/machinery/hydroponics/constructable,
-/obj/structure/sign/poster/random/directional/south,
-/obj/effect/turf_decal/tile/blue/opposingcorners,
-/obj/effect/turf_decal/tile/green{
-	dir = 8
-	},
-/turf/open/floor/iron,
-/area/station/service/hydroponics)
 "xXj" = (
 /obj/structure/table/wood,
 /obj/item/clipboard,
@@ -96183,10 +95455,6 @@
 	dir = 1
 	},
 /area/station/commons/fitness/recreation)
-"yaG" = (
-/obj/structure/sign/warning/biohazard,
-/turf/closed/wall/r_wall,
-/area/station/medical/virology)
 "yaI" = (
 /turf/closed/wall,
 /area/station/commons/dorms)
@@ -96204,7 +95472,6 @@
 	name = "Prison Blast Door"
 	},
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/sign/warning/pods/directional/west,
 /obj/structure/cable,
 /obj/effect/turf_decal/delivery,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -96413,6 +95680,10 @@
 "ydW" = (
 /turf/closed/wall/r_wall,
 /area/station/maintenance/department/eva/abandoned)
+"yeh" = (
+/obj/structure/sign/plaques/kiddie/library,
+/turf/open/floor/wood/tile,
+/area/station/service/library/artgallery)
 "yei" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -96435,6 +95706,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/structure/sign/painting/library,
 /turf/open/floor/iron/dark,
 /area/station/service/library)
 "yeF" = (
@@ -96547,7 +95819,6 @@
 /area/station/commons/storage/primary)
 "ygC" = (
 /obj/machinery/atmospherics/pipe/smart/simple/cyan/visible,
-/obj/structure/sign/warning/secure_area/directional/west,
 /obj/machinery/camera/directional/west{
 	c_tag = "Atmospherics - Aft Tanks";
 	name = "atmospherics camera"
@@ -96625,18 +95896,6 @@
 /obj/machinery/light/floor,
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/aisat/exterior)
-"ygY" = (
-/obj/structure/sign/directions/engineering{
-	desc = "A sign that shows there are doors here. There are doors everywhere!";
-	icon_state = "doors";
-	name = "WARNING: BLAST DOORS";
-	pixel_x = -32
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/station/security/execution/transfer)
 "yhh" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -96660,7 +95919,6 @@
 	pixel_x = -1;
 	pixel_y = 5
 	},
-/obj/structure/sign/poster/official/random/directional/west,
 /obj/structure/sign/calendar/directional/south,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron/dark,
@@ -96796,13 +96054,6 @@
 	},
 /turf/open/floor/stone,
 /area/station/command/corporate_showroom)
-"yjF" = (
-/obj/structure/sign/poster/random/directional/west,
-/obj/effect/turf_decal/tile/neutral/half/contrasted{
-	dir = 8
-	},
-/turf/open/floor/iron,
-/area/station/commons/dorms)
 "yjG" = (
 /obj/structure/cable,
 /obj/effect/spawner/random/engineering/tracking_beacon,
@@ -102767,7 +102018,7 @@ bPC
 bPC
 bPC
 iGI
-fvZ
+bPC
 bPC
 bPC
 idU
@@ -104306,7 +103557,7 @@ jPe
 kXJ
 cQh
 bPC
-bRD
+bPC
 bPC
 tnG
 bPC
@@ -104568,7 +103819,7 @@ ikT
 uQY
 ikT
 qTF
-bRD
+bPC
 ruN
 aRr
 csk
@@ -104809,7 +104060,7 @@ eXM
 sSb
 sSb
 sSb
-lMy
+fSt
 aBN
 yga
 lMy
@@ -104820,7 +104071,7 @@ lMy
 abJ
 tHQ
 bPC
-uNh
+gOF
 bTu
 tfl
 bYe
@@ -106362,7 +105613,7 @@ xMX
 kXJ
 cQh
 bPC
-bRD
+bPC
 bPC
 dNg
 bPC
@@ -106619,7 +105870,7 @@ lyf
 lMA
 btH
 bPC
-uNh
+gOF
 jQv
 hzJ
 rKC
@@ -114361,7 +113612,7 @@ aaa
 uHd
 aaa
 qYo
-jgH
+sHt
 qYo
 aaa
 qYo
@@ -114369,7 +113620,7 @@ qYo
 aaa
 qYo
 aaa
-jgH
+sHt
 qYo
 aaa
 uHd
@@ -114616,7 +113867,7 @@ vVc
 aad
 aad
 aad
-vIz
+sHt
 nCi
 nCi
 fqm
@@ -114877,11 +114128,11 @@ nCi
 nCi
 fbp
 gZb
-rjz
+vPU
 vPU
 hzj
 vPU
-rjz
+vPU
 pvx
 jDc
 nCi
@@ -115091,11 +114342,11 @@ efQ
 qYo
 wes
 gnH
-sXE
+gnH
 gnH
 wFJ
 wFJ
-uPM
+wFJ
 wFJ
 wFJ
 wFJ
@@ -115356,7 +114607,7 @@ wGy
 vVc
 vVc
 vVc
-jAx
+qYo
 abj
 abj
 lbi
@@ -115381,10 +114632,10 @@ frC
 kvX
 tGf
 vVc
-rIP
 vVc
 vVc
-xfE
+vVc
+vVc
 vVc
 vVc
 fqm
@@ -115624,7 +114875,7 @@ qYo
 qYo
 qYo
 vVc
-rIP
+vVc
 vVc
 vVc
 ksq
@@ -115642,7 +114893,7 @@ nCi
 nCi
 hCt
 nCi
-chp
+hXQ
 chp
 fqm
 vPU
@@ -115657,9 +114908,9 @@ iyO
 nCi
 vPU
 fqm
-aaa
+iDs
 oSN
-aaa
+iDs
 aaa
 uHd
 aaa
@@ -115860,7 +115111,7 @@ aaa
 aaa
 xNe
 aaa
-joz
+nUT
 wGy
 wGy
 wGy
@@ -115875,22 +115126,22 @@ phy
 iyc
 kNA
 cmq
-kcR
-nUT
+vmt
+uwb
 aaa
 qYo
 aaa
 vVc
 gAw
-uzZ
+hrs
 qYo
 ksq
 vVc
 vVc
-rIP
 vVc
 vVc
-rIP
+vVc
+vVc
 vVc
 vVc
 ksq
@@ -115902,7 +115153,7 @@ nCi
 lMc
 rXu
 nCi
-eVp
+mFq
 nCi
 iyO
 kiP
@@ -115916,7 +115167,7 @@ mFq
 nCi
 nCi
 nCi
-aaa
+kPH
 aaa
 qYo
 aaa
@@ -116153,7 +115404,7 @@ cCY
 qmJ
 xKv
 nCi
-bET
+nCi
 hVB
 nCi
 iUF
@@ -116392,7 +115643,7 @@ vmt
 vmt
 hSa
 fgB
-dPN
+fgB
 fgB
 fgB
 azR
@@ -116597,7 +115848,7 @@ edx
 pEP
 edx
 edx
-qYo
+hrs
 efQ
 efQ
 efQ
@@ -116680,7 +115931,7 @@ imx
 imx
 xsH
 umb
-kNG
+imx
 lZF
 uhb
 nCi
@@ -117150,7 +116401,7 @@ xUy
 xqR
 qzc
 kUx
-kTV
+nUp
 chv
 dQl
 oIE
@@ -117183,7 +116434,7 @@ xQm
 nCi
 kmS
 fCk
-cGI
+wlI
 nCi
 cTO
 uOn
@@ -117428,11 +116679,11 @@ gAw
 jPd
 ehD
 sHT
-dHx
+rVM
 fNc
-ivH
+bPI
 sHT
-vrs
+gIF
 vrs
 qJI
 iQV
@@ -117673,7 +116924,7 @@ rpK
 yks
 haI
 imV
-pbv
+aCy
 gAw
 wqU
 ntd
@@ -117938,7 +117189,7 @@ hWY
 heZ
 bpr
 bpr
-anB
+gAw
 ilG
 cwI
 sHT
@@ -117950,7 +117201,7 @@ kMt
 chY
 vUV
 sst
-rgw
+nbZ
 nCi
 nCi
 nCi
@@ -118130,15 +117381,15 @@ qYo
 qYo
 qYo
 hNg
-rIP
+vVc
 edx
 vDw
 dtS
-snK
+ajf
 snK
 xMi
 dvA
-eiK
+edx
 kXV
 pxN
 dlj
@@ -118178,7 +117429,7 @@ xUy
 xqR
 vTc
 oMh
-kTV
+nUp
 oow
 qzT
 nAF
@@ -118208,14 +117459,14 @@ jcL
 vUV
 ugr
 xil
-tLC
+gAw
 epC
-qZb
+pTC
 jaI
 kwX
 pTC
 nzt
-nwV
+sfN
 lYw
 ncJ
 rYE
@@ -118225,7 +117476,7 @@ taA
 dco
 gZx
 ddW
-nwV
+sfN
 fOp
 mAt
 ifk
@@ -118390,9 +117641,9 @@ kvq
 edx
 edx
 cDK
+jff
 vPZ
-vPZ
-vPZ
+jff
 kGI
 sog
 edx
@@ -118452,7 +117703,7 @@ ntd
 bzY
 cMA
 vog
-anB
+gAw
 aVW
 lbl
 sHT
@@ -118722,10 +117973,10 @@ sHT
 qqQ
 sLe
 nzs
-tLC
+gAw
 eYG
-qZb
-uKY
+pTC
+pcU
 gcr
 pTC
 kWi
@@ -118924,7 +118175,7 @@ oOh
 gvk
 rMi
 kCN
-iYI
+jXN
 mmN
 udG
 jxJ
@@ -118938,7 +118189,7 @@ unO
 jxJ
 avX
 tiC
-jfL
+hhM
 mtm
 guU
 nNz
@@ -119493,10 +118744,10 @@ qJI
 nCl
 gAw
 dtX
-ugP
 pTC
 pTC
-uKY
+pTC
+sjX
 iQF
 pTC
 dLh
@@ -120524,7 +119775,7 @@ pjN
 pjN
 qdP
 pTC
-rZw
+kSC
 rrU
 pTC
 uFO
@@ -120702,8 +119953,8 @@ uZY
 aYK
 nBO
 mPV
-aaf
-sHl
+vlA
+uNq
 dEP
 mWP
 dYj
@@ -120753,25 +120004,25 @@ bAR
 ggB
 jko
 dEL
-ttE
+iBR
 rex
 ovS
 rex
-ttE
+iBR
 gAw
 mwW
-anB
+gAw
 cCY
 cCY
 cCY
 gAw
 gAw
 gAw
-tLC
+gAw
 cCY
 rAd
 cCY
-tLC
+gAw
 gAw
 gAw
 gAw
@@ -121039,10 +120290,10 @@ nRy
 xsb
 pTC
 rZw
-oUy
+iQF
 pTC
 fwt
-uyy
+sfN
 duq
 gED
 bJt
@@ -121052,7 +120303,7 @@ taA
 buY
 kYq
 xsN
-uyy
+sfN
 uLh
 mAt
 iIn
@@ -121241,7 +120492,7 @@ cwY
 wIf
 cwY
 wIf
-hUV
+cwY
 wIf
 cwY
 cwY
@@ -121520,7 +120771,7 @@ uCa
 gQk
 nEJ
 oGb
-vPe
+oGb
 oGb
 nvO
 blj
@@ -121781,12 +121032,12 @@ aaa
 oGb
 lGF
 mxj
-ttE
+iBR
 xzQ
 hIf
 mPh
-ttE
-kTn
+iBR
+sPS
 sBy
 vvH
 vaw
@@ -121795,11 +121046,11 @@ jkK
 fbn
 gTr
 rRD
-pgA
+rRD
 aYU
 pzA
 aYU
-pgA
+rRD
 rRD
 dOr
 mKv
@@ -122037,7 +121288,7 @@ oGb
 qYo
 oGb
 lGF
-sva
+qOL
 iBR
 iBR
 wxd
@@ -122805,7 +122056,7 @@ aiS
 lEi
 mez
 oGb
-vPe
+oGb
 oGb
 uDb
 jmj
@@ -123057,7 +122308,7 @@ gvj
 rNf
 xLZ
 xLZ
-rOa
+xLZ
 xLZ
 iVV
 cZY
@@ -123112,7 +122363,7 @@ qOr
 pra
 nuM
 gFP
-ehJ
+aBV
 wEI
 fxj
 dip
@@ -123275,7 +122526,7 @@ grV
 uAK
 sHl
 jvT
-lEr
+dKe
 epV
 vSE
 rGb
@@ -123337,11 +122588,11 @@ vvH
 hcQ
 dsj
 rRD
-pgA
+rRD
 hOa
 aGo
 auD
-pgA
+rRD
 fii
 pUf
 bID
@@ -124100,7 +123351,7 @@ uAI
 lWx
 fti
 wGA
-aJu
+hvX
 uxG
 pkZ
 xDi
@@ -124306,7 +123557,7 @@ ewY
 xxp
 mDa
 wZv
-txJ
+vSE
 jQl
 kND
 qyj
@@ -124564,9 +123815,9 @@ hwM
 hwM
 hwM
 hwM
-djf
+hwM
 bGC
-djf
+hwM
 hwM
 oXU
 vjF
@@ -124574,11 +123825,11 @@ hNp
 iaJ
 vUt
 nmw
-lHZ
+pPS
 dge
 sPT
 vOI
-etR
+vOI
 xcU
 nmw
 eOH
@@ -124590,7 +123841,7 @@ aaa
 qYo
 cut
 qYo
-eOH
+sHt
 aaa
 xLZ
 nNK
@@ -124622,7 +123873,7 @@ pTC
 goD
 sjH
 pTC
-xDV
+tiL
 xgE
 spe
 wxf
@@ -124857,7 +124108,7 @@ cES
 rHd
 sef
 kol
-wNP
+eJq
 eJq
 pPy
 xsc
@@ -125078,9 +124329,9 @@ oYs
 oYs
 azA
 nmw
-qvn
+nmw
 pfQ
-qvn
+nmw
 nmw
 nmw
 nmw
@@ -125174,7 +124425,7 @@ gFM
 pMA
 lNg
 iLq
-rjT
+lNg
 gcP
 khq
 aHI
@@ -125333,7 +124584,7 @@ oYs
 vzK
 vbP
 tEX
-gbD
+uMH
 hWF
 uMH
 cdg
@@ -125718,9 +124969,9 @@ uHc
 qQM
 qQM
 kzc
-jGs
+kzc
 kyA
-jtV
+kzc
 kzc
 qQM
 qQM
@@ -125922,7 +125173,7 @@ uPI
 ibL
 vcB
 jto
-mJn
+qcM
 vcB
 vcB
 cdN
@@ -126230,7 +125481,7 @@ bAz
 vLq
 anz
 qQM
-uYH
+edc
 frM
 avb
 hPh
@@ -126394,8 +125645,8 @@ dvn
 oYs
 vnD
 oYs
-aad
-kAD
+kvt
+aJU
 wVU
 aJU
 aJU
@@ -126666,7 +125917,7 @@ oNb
 biS
 vYG
 dGS
-iCO
+oSZ
 uED
 nXK
 vcB
@@ -126746,7 +125997,7 @@ fjx
 qQM
 jzp
 pJr
-jtV
+kzc
 fvY
 gBh
 qVv
@@ -126891,7 +126142,7 @@ bmP
 xUq
 tti
 vVe
-ckb
+ofg
 cLt
 xJf
 vVe
@@ -126900,7 +126151,7 @@ ofg
 iNH
 xJf
 iEI
-svz
+cLt
 ofg
 vVe
 itn
@@ -127001,7 +126252,7 @@ woc
 edw
 pLQ
 qQM
-dnV
+vEw
 ijm
 uRy
 txm
@@ -127127,7 +126378,7 @@ kwg
 dEe
 oLz
 dEe
-msx
+kwg
 oYs
 llW
 oYs
@@ -127180,7 +126431,7 @@ rCx
 biS
 eIo
 dGS
-iCO
+oSZ
 uED
 gdq
 vcB
@@ -127235,7 +126486,7 @@ duo
 bLL
 aBV
 eHt
-aNP
+jUx
 nGq
 wEI
 mxY
@@ -127403,7 +126654,7 @@ oYs
 oUm
 uVZ
 xeh
-sNe
+oUm
 oYs
 kcb
 eFs
@@ -127422,8 +126673,8 @@ aMH
 oYs
 owb
 oYs
-aad
-kAD
+kvt
+aJU
 wVU
 aJU
 aJU
@@ -127655,7 +126906,7 @@ kQR
 iPc
 tZN
 rID
-xXd
+nlc
 oYs
 vCn
 oYs
@@ -128007,7 +127258,7 @@ jDd
 jDd
 nCg
 juG
-rle
+juG
 jDd
 jDd
 cHb
@@ -128385,7 +127636,7 @@ sjt
 qld
 qld
 sjt
-cbY
+qld
 qld
 rAC
 qld
@@ -128396,7 +127647,7 @@ fZV
 qld
 xyL
 qld
-pkd
+qld
 sjt
 qld
 qld
@@ -128543,7 +127794,7 @@ pUd
 wnc
 dMs
 qQM
-uYH
+gpG
 pJr
 uRy
 jeo
@@ -128802,7 +128053,7 @@ qQM
 qQM
 uBt
 uXy
-gDW
+kzc
 lpY
 tsJ
 wbP
@@ -129217,7 +128468,7 @@ uRf
 oYs
 uoV
 vNI
-dlm
+oTY
 oYs
 dWf
 jcC
@@ -129275,7 +128526,7 @@ oRh
 oHq
 wNV
 eyl
-dNN
+nKA
 uMV
 sEF
 sVi
@@ -129413,7 +128664,7 @@ sjt
 qld
 qld
 sjt
-pkd
+qld
 qld
 thf
 qld
@@ -129424,7 +128675,7 @@ hIQ
 qld
 thf
 qld
-cbY
+qld
 sjt
 qld
 qld
@@ -129518,7 +128769,7 @@ khb
 dUm
 khb
 khb
-wIa
+kyu
 nlF
 dNS
 dNS
@@ -130297,7 +129548,7 @@ srb
 pRG
 mCZ
 lmC
-oEb
+dNN
 ugs
 jky
 hBb
@@ -130529,7 +129780,7 @@ fcl
 xpI
 qAQ
 dvG
-pMw
+tYn
 pMw
 cpf
 sJo
@@ -131077,7 +130328,7 @@ fvi
 fvi
 jmA
 dCx
-bSn
+oxP
 fDF
 fDF
 fDF
@@ -131114,7 +130365,7 @@ tgT
 hMI
 tgT
 tgT
-aaa
+kPH
 aaa
 gqm
 gqm
@@ -131637,7 +130888,7 @@ kSX
 hGJ
 sKQ
 tgT
-aaa
+tjk
 aaa
 qYo
 aaa
@@ -131819,14 +131070,14 @@ pRS
 pRS
 pRS
 pRS
-uNU
+pRS
 jaV
 tPc
 mlE
 mlE
 mlE
 mlE
-lBR
+mlE
 mlE
 mlE
 mlE
@@ -131872,7 +131123,7 @@ tbd
 doe
 qya
 lEj
-rIv
+qya
 xIz
 swY
 qpq
@@ -132002,7 +131253,7 @@ aaa
 qld
 rJf
 kJd
-sMx
+fNv
 sjt
 pmV
 tht
@@ -132077,7 +131328,7 @@ gqq
 tMo
 rjd
 pRS
-oHJ
+uKN
 kxs
 mlE
 xWP
@@ -132121,7 +131372,7 @@ kzc
 vmK
 wWL
 vfS
-pQn
+qya
 jvQ
 eKe
 eKe
@@ -132337,7 +131588,7 @@ pRS
 oHJ
 qdA
 mlE
-dZW
+sxe
 rKF
 gAr
 jOo
@@ -132649,7 +131900,7 @@ kzc
 aOD
 qQM
 qQM
-xgZ
+sHt
 tgT
 xPc
 xPc
@@ -132664,7 +131915,7 @@ xPc
 sTV
 xPc
 tgT
-pOQ
+qYo
 aaa
 eqU
 qYo
@@ -133011,7 +132262,7 @@ sjt
 qld
 qld
 sjt
-cbY
+qld
 qld
 xyL
 qld
@@ -133022,12 +132273,12 @@ eUf
 qld
 rAC
 qld
-pkd
+qld
 sjt
 qld
 qld
 sjt
-kKm
+sjt
 uot
 xYB
 urY
@@ -133075,7 +132326,7 @@ xzC
 rjt
 iDP
 eem
-xny
+dOZ
 kOj
 aad
 aad
@@ -133644,7 +132895,7 @@ gem
 vBk
 wil
 sDd
-fpu
+wil
 wil
 erT
 iqj
@@ -133677,7 +132928,7 @@ kzc
 ecm
 uYH
 qQM
-xgZ
+sHt
 tgT
 riB
 tgT
@@ -133692,7 +132943,7 @@ xPc
 xPc
 xPc
 tgT
-hrs
+qYo
 aaa
 qYo
 aaa
@@ -134039,7 +133290,7 @@ sjt
 qld
 qld
 sjt
-pkd
+qld
 qld
 pch
 qld
@@ -134050,7 +133301,7 @@ oYE
 qld
 pch
 qld
-cbY
+qld
 sjt
 qld
 qld
@@ -134115,7 +133366,7 @@ yil
 obc
 sQA
 qoo
-vAl
+mGw
 mGw
 qHx
 awc
@@ -134315,7 +133566,7 @@ aaa
 sjt
 fQg
 kJd
-ciz
+pOC
 sjt
 pFF
 jAi
@@ -134391,7 +133642,7 @@ aaa
 aaa
 vpK
 jHY
-rEN
+xaP
 mlE
 mlE
 szn
@@ -134463,7 +133714,7 @@ xPc
 xPc
 xPc
 tgT
-anZ
+nPp
 qYo
 efQ
 aaa
@@ -134899,7 +134150,7 @@ xCa
 ilI
 dRh
 dBl
-qoD
+hup
 xkw
 aaa
 aaa
@@ -134975,7 +134226,7 @@ ovW
 gqm
 jFJ
 skg
-qSa
+hFZ
 gqm
 qYo
 qYo
@@ -135082,7 +134333,7 @@ aaa
 aaa
 aaa
 aad
-pkd
+qld
 yiK
 oMr
 cDT
@@ -135234,7 +134485,7 @@ tgT
 tgT
 tgT
 tgT
-nPp
+pOQ
 aaa
 aaa
 aaa
@@ -135400,7 +134651,7 @@ dTp
 hEI
 sxr
 eVl
-xDU
+pMH
 gnA
 jHb
 kgs
@@ -135476,7 +134727,7 @@ lwZ
 fWX
 cug
 tqK
-yaG
+tgT
 gte
 qpr
 nov
@@ -135746,7 +134997,7 @@ bhw
 bhw
 bhw
 bhw
-qYo
+hrs
 efQ
 aaa
 aaa
@@ -136110,7 +135361,7 @@ aaa
 aaa
 aaa
 aad
-cbY
+qld
 fZV
 rbR
 kJd
@@ -136517,7 +135768,7 @@ tHV
 tHV
 tHV
 tHV
-qYo
+hrs
 qYo
 aaa
 aaa
@@ -136955,7 +136206,7 @@ jQw
 hup
 jPC
 pFy
-qoD
+hup
 xkw
 aaa
 aaa
@@ -136966,7 +136217,7 @@ duA
 fqN
 mzL
 sFu
-uDj
+sFu
 duA
 tAL
 nEk
@@ -137123,7 +136374,7 @@ qld
 qld
 qld
 sjt
-cbY
+qld
 qld
 xyL
 qld
@@ -137134,7 +136385,7 @@ woB
 qld
 xyL
 qld
-pkd
+qld
 sjt
 qld
 qld
@@ -137280,7 +136531,7 @@ tHV
 tHV
 tHV
 tHV
-xyu
+tHV
 eKU
 imN
 exJ
@@ -137475,7 +136726,7 @@ aaa
 aaa
 vpK
 elM
-bRl
+uJm
 ksK
 ksK
 maS
@@ -137713,7 +136964,7 @@ bog
 jlZ
 gOU
 swj
-jeI
+aby
 aby
 igb
 gOU
@@ -139004,7 +138255,7 @@ aby
 wRz
 aGZ
 teA
-nSv
+ivA
 lnm
 tLa
 nDn
@@ -139177,9 +138428,9 @@ aad
 abi
 adR
 xrr
-smO
+xrr
 eTZ
-coH
+xrr
 xrr
 adR
 abi
@@ -139197,7 +138448,7 @@ mtu
 jdL
 jQx
 siV
-uRt
+iql
 kdg
 ccy
 jdL
@@ -139766,12 +139017,12 @@ diL
 uQD
 drj
 bog
-ksJ
+xaF
 gOU
 prt
 wqT
 epd
-tTj
+aby
 iKC
 ivA
 hmA
@@ -139787,7 +139038,7 @@ vDJ
 pgv
 sXg
 vIQ
-rBB
+srQ
 jiC
 pVb
 ksK
@@ -140043,7 +139294,7 @@ vIQ
 twE
 vIQ
 vIQ
-aFE
+vIQ
 jaV
 tPc
 ksK
@@ -140296,7 +139547,7 @@ lSl
 mta
 jol
 lSl
-ltY
+lSl
 lSl
 lSl
 dbU
@@ -141092,7 +140343,7 @@ cao
 cao
 hvm
 idj
-uow
+hvm
 nyC
 hvm
 cao
@@ -141647,8 +140898,8 @@ oWo
 oWo
 oGK
 oGK
-pHy
-aaa
+oGK
+tjk
 qYo
 qYo
 aaa
@@ -142325,7 +141576,7 @@ lDu
 taO
 eCQ
 tpZ
-uoz
+jAe
 tpZ
 aaa
 lhY
@@ -142613,7 +141864,7 @@ aSi
 aSi
 aSi
 aSi
-tpJ
+iVq
 wmM
 iVq
 oKL
@@ -142841,7 +142092,7 @@ bhJ
 tpZ
 tpZ
 tpZ
-aad
+vzw
 lhY
 yah
 vZE
@@ -142895,8 +142146,8 @@ gnh
 nHY
 gnh
 aBz
-dzn
-pPl
+teU
+yeh
 pPl
 pPl
 vPf
@@ -143865,7 +143116,7 @@ rYR
 hYO
 aFH
 gME
-aaa
+igZ
 aaa
 aaa
 aaa
@@ -143901,7 +143152,7 @@ rrF
 qKk
 ltK
 iVq
-lRk
+dCg
 bPv
 iee
 iYi
@@ -144180,7 +143431,7 @@ sRT
 nHY
 sRT
 gIZ
-dzn
+teU
 wtU
 pPl
 pPl
@@ -144731,8 +143982,8 @@ vNn
 vNn
 oGK
 oGK
-pHy
-aaa
+oGK
+tjk
 qYo
 aaa
 aaa
@@ -144958,7 +144209,7 @@ ifp
 sNC
 qMf
 eOS
-cAs
+wjQ
 wZE
 wZE
 tFQ
@@ -145668,13 +144919,13 @@ abj
 aad
 aad
 aad
-faF
+btm
 aGz
 btm
 aad
 btm
 aGz
-faF
+btm
 aad
 aad
 dCk
@@ -145975,7 +145226,7 @@ cao
 cao
 hvm
 vmL
-uow
+hvm
 hCe
 hvm
 cao
@@ -146190,7 +145441,7 @@ gjB
 wpQ
 plC
 pBg
-iIz
+xxF
 wsC
 mVO
 nHs
@@ -146209,7 +145460,7 @@ xzH
 dth
 ddC
 ajq
-sIY
+vHY
 rYA
 oCP
 oCP
@@ -146243,7 +145494,7 @@ nkL
 lvL
 qMf
 lrr
-qTb
+pOT
 wZE
 jCw
 nEM
@@ -146267,8 +145518,8 @@ kgf
 cVh
 uuP
 brb
-uDI
-aaa
+brb
+tjk
 aaa
 aaa
 qYo
@@ -146708,7 +145959,7 @@ xxF
 kCa
 lim
 lim
-uZM
+lim
 lim
 lim
 lim
@@ -146754,7 +146005,7 @@ gDV
 gDV
 gDV
 gDV
-dyw
+qMf
 qMf
 jaz
 eMU
@@ -147002,7 +146253,7 @@ xIu
 xIu
 xIu
 aSJ
-gri
+fSK
 nXH
 uhX
 qJR
@@ -147439,7 +146690,7 @@ aaa
 aaa
 abj
 aaa
-jgH
+sHt
 aad
 aaa
 aaa
@@ -147553,7 +146804,7 @@ gcB
 brb
 brb
 brb
-aaa
+tjk
 aaa
 aaa
 qYo
@@ -147772,7 +147023,7 @@ vBH
 mcG
 gua
 yaI
-ouy
+cLV
 fSK
 nXH
 smG
@@ -147967,7 +147218,7 @@ wDX
 xNU
 hlr
 hzx
-ygY
+wDX
 sYM
 vyO
 yiA
@@ -148280,7 +147531,7 @@ uCp
 oQn
 hMd
 ftk
-yjF
+ftk
 ftk
 xOC
 ftk
@@ -148486,7 +147737,7 @@ mSe
 hpN
 krO
 hAo
-pEH
+dFG
 kWE
 sBg
 hsg
@@ -148732,7 +147983,7 @@ iPK
 lYv
 lTv
 iPK
-mQz
+tTQ
 lTv
 iPK
 tTQ
@@ -148997,7 +148248,7 @@ lTv
 lnX
 aAr
 mSe
-iCo
+mWi
 nYt
 lET
 oWt
@@ -149057,7 +148308,7 @@ gUJ
 bhg
 bsd
 yaI
-ouy
+cLV
 geH
 nXH
 myZ
@@ -149306,11 +148557,11 @@ wgE
 xUB
 dtR
 yaI
-goj
+upk
 lpt
 sKM
 yaI
-tYs
+bwS
 bXJ
 gEz
 yaI
@@ -149563,7 +148814,7 @@ xQZ
 xnF
 tnR
 yaI
-upk
+jAC
 cse
 tiP
 yaI
@@ -149768,7 +149019,7 @@ tUB
 pcA
 ouc
 qWZ
-iCo
+cWD
 krO
 guZ
 lET
@@ -149804,7 +149055,7 @@ ufR
 phL
 qpz
 adM
-xTk
+nIn
 dth
 dBH
 rYA
@@ -149828,8 +149079,8 @@ xxN
 oLO
 qfH
 yaI
-ouy
-bfe
+tXN
+geH
 nXH
 qPE
 jBm
@@ -149842,15 +149093,15 @@ qOK
 nXH
 nXH
 nXH
-njz
+nXH
 eLG
 nXH
 nXH
 bHA
 vNa
-lkx
+vNa
 dvu
-oCG
+vNa
 nXH
 cln
 udq
@@ -150065,7 +149316,7 @@ uAL
 hEF
 aad
 aad
-pHa
+aad
 aad
 aad
 uKw
@@ -150543,7 +149794,7 @@ sgh
 lTJ
 gJk
 qIH
-etw
+aad
 qYo
 hQq
 fNW
@@ -150577,7 +149828,7 @@ osc
 adM
 hci
 hEF
-aad
+vfR
 aad
 aad
 aad
@@ -150800,7 +150051,7 @@ kiB
 krO
 vRz
 qIH
-aaa
+tjk
 aaa
 hQq
 rYf
@@ -150880,7 +150131,7 @@ pWe
 bbr
 pWe
 fHG
-qYo
+pOQ
 aaa
 aaa
 qYo
@@ -151053,7 +150304,7 @@ cSi
 cSF
 nOT
 vxs
-iCo
+cWD
 yiA
 afQ
 eoB
@@ -151571,7 +150822,7 @@ iCo
 xwa
 qIH
 qIH
-kvt
+aad
 aad
 kOA
 kOA
@@ -151587,7 +150838,7 @@ iDq
 dql
 iDq
 iDq
-aad
+vfR
 aaa
 aad
 bLs
@@ -151843,11 +151094,11 @@ aaa
 qYo
 aaa
 qYo
-kMQ
+sHt
 qYo
 aaa
 qYo
-pHa
+aad
 bLs
 bLs
 bLs
@@ -151856,7 +151107,7 @@ bLs
 bLs
 bLs
 bLs
-ptN
+rGA
 nEZ
 pgZ
 uHu
@@ -152107,10 +151358,10 @@ efQ
 aaa
 aaa
 aaa
-mfO
+qYo
 ctN
 aaa
-mfO
+qYo
 aaa
 aaa
 aaa
@@ -152119,7 +151370,7 @@ rPb
 fvD
 knp
 nEZ
-qYo
+rGA
 aaa
 aaa
 aad
@@ -152598,7 +151849,7 @@ eHO
 vip
 vhW
 qIH
-aad
+kvt
 aad
 aad
 bRF
@@ -153124,7 +152375,7 @@ okz
 nGO
 kOA
 kOA
-aad
+vqS
 efQ
 aaa
 efQ
@@ -153151,7 +152402,7 @@ qYo
 uHd
 qYo
 aad
-uTd
+sHt
 uKw
 mfC
 xFk
@@ -153872,7 +153123,7 @@ aad
 aaa
 aaa
 bCC
-pTT
+hhn
 lyd
 rnf
 fmY
@@ -154407,8 +153658,8 @@ nSR
 nSR
 nSR
 kOA
-kOA
-aaa
+hNe
+tAi
 efQ
 aaa
 efQ
@@ -154658,13 +153909,13 @@ gJk
 aaa
 aad
 aaa
-kMQ
+sHt
 aad
 aaa
 aad
 aaa
 aad
-kMQ
+sHt
 aaa
 qYo
 aaa
@@ -155982,7 +155233,7 @@ aaa
 efQ
 aad
 aaa
-uOC
+aad
 uKw
 mfC
 uKw

--- a/_maps/map_files/Deltastation/DeltaStation2.dmm
+++ b/_maps/map_files/Deltastation/DeltaStation2.dmm
@@ -479,6 +479,8 @@
 	pixel_x = 11;
 	pixel_y = -2
 	},
+/obj/structure/sign/warning/deathsposal/directional/north,
+/obj/structure/extinguisher_cabinet/directional/west,
 /turf/open/floor/iron,
 /area/station/science/xenobiology)
 "afD" = (
@@ -802,10 +804,6 @@
 	},
 /turf/open/floor/iron,
 /area/station/security/checkpoint/arrivals)
-"ajf" = (
-/obj/machinery/atmospherics/pipe/smart/simple/dark/visible,
-/turf/open/floor/iron,
-/area/station/maintenance/disposal/incinerator)
 "ajq" = (
 /obj/effect/landmark/blobstart,
 /obj/structure/disposalpipe/segment{
@@ -822,6 +820,13 @@
 	},
 /turf/open/floor/iron,
 /area/station/maintenance/department/eva/abandoned)
+"ajz" = (
+/obj/machinery/suit_storage_unit/security,
+/obj/effect/turf_decal/bot_red,
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/item/radio/intercom/directional/north,
+/turf/open/floor/iron/dark,
+/area/station/security/evidence)
 "ajP" = (
 /obj/machinery/holopad,
 /obj/structure/disposalpipe/segment,
@@ -831,7 +836,7 @@
 /area/station/service/library/lounge)
 "ajY" = (
 /obj/structure/chair/sofa/corner/brown,
-/obj/structure/noticeboard/directional/east,
+/obj/structure/sign/poster/official/help_others/directional/north,
 /turf/open/floor/carpet/blue,
 /area/station/medical/psychology)
 "akf" = (
@@ -1795,7 +1800,6 @@
 /obj/structure/table,
 /obj/item/stack/package_wrap,
 /obj/item/hand_labeler,
-/obj/machinery/airalarm/directional/west,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron/dark,
 /area/station/security/evidence)
@@ -2010,6 +2014,17 @@
 	},
 /turf/open/floor/iron,
 /area/station/maintenance/department/crew_quarters/bar)
+"awN" = (
+/obj/structure/cable,
+/obj/machinery/door/poddoor/preopen{
+	id = "ceblast";
+	name = "Chief Engineer's Office Blast Doors";
+	dir = 4;
+	manual_align = 1
+	},
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
+/area/station/command/heads_quarters/ce)
 "awT" = (
 /obj/structure/chair/stool/directional/east,
 /turf/open/floor/iron/cafeteria,
@@ -2279,6 +2294,7 @@
 /obj/item/toy/figure/ce,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /obj/machinery/light/directional/north,
+/obj/structure/extinguisher_cabinet/directional/north,
 /turf/open/floor/iron/dark,
 /area/station/command/heads_quarters/ce)
 "aBy" = (
@@ -2363,6 +2379,10 @@
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron/dark,
 /area/station/service/chapel/funeral)
+"aCA" = (
+/obj/machinery/status_display/evac/directional/south,
+/turf/open/floor/iron/white,
+/area/station/science/research)
 "aCJ" = (
 /obj/structure/cable,
 /obj/effect/decal/cleanable/dirt,
@@ -2543,7 +2563,6 @@
 /turf/open/space,
 /area/space/nearstation)
 "aFp" = (
-/obj/structure/sign/warning/secure_area/directional/south,
 /obj/effect/turf_decal/trimline/purple/filled/line{
 	dir = 10
 	},
@@ -3353,9 +3372,6 @@
 /obj/effect/turf_decal/trimline/purple/filled/mid_joiner{
 	dir = 4
 	},
-/obj/item/radio/intercom/directional/east{
-	pixel_y = 2
-	},
 /turf/open/floor/iron/white,
 /area/station/science/ordnance/storage)
 "aPc" = (
@@ -3493,13 +3509,11 @@
 /obj/structure/cable,
 /obj/structure/table/wood,
 /obj/machinery/door/firedoor,
-/obj/structure/sign/picture_frame/portrait/bar{
-	pixel_y = 32
-	},
 /obj/item/storage/fancy/cigarettes/cigars,
 /obj/item/storage/fancy/cigarettes/cigars/cohiba{
 	pixel_y = 3
 	},
+/obj/structure/sign/picture_frame/portrait/bar,
 /turf/open/floor/iron/dark/smooth_half{
 	dir = 1
 	},
@@ -3963,16 +3977,16 @@
 /turf/open/floor/iron,
 /area/station/hallway/primary/fore)
 "aXI" = (
-/obj/machinery/light/small/directional/east,
-/obj/machinery/newscaster/directional/north,
-/obj/machinery/button/door/directional/south{
-	id = "Arrivals_Toilet3";
-	name = "Lock Control";
-	normaldoorcontrol = 1;
-	specialfunctions = 4
-	},
 /obj/machinery/recharge_station,
 /obj/effect/turf_decal/bot_red,
+/obj/machinery/newscaster/directional/east,
+/obj/machinery/light/small/directional/north,
+/obj/machinery/button/door/directional/north{
+	id = "Arrivals_Toilet3";
+	name = "Lock Control";
+	specialfunctions = 4;
+	normaldoorcontrol = 1
+	},
 /turf/open/floor/iron,
 /area/station/commons/toilet/restrooms)
 "aXK" = (
@@ -4497,13 +4511,13 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 5
 	},
-/obj/structure/sign/warning/biohazard/directional/north,
 /obj/machinery/camera/directional/north{
 	c_tag = "Science - Xenobiology Access";
 	name = "science camera";
 	network = list("ss13","rd")
 	},
 /obj/structure/sink/directional/west,
+/obj/structure/sign/warning/biohazard/directional/north,
 /turf/open/floor/iron,
 /area/station/maintenance/department/science)
 "bfn" = (
@@ -4758,6 +4772,10 @@
 /obj/effect/turf_decal/bot,
 /obj/machinery/newscaster/directional/south,
 /obj/machinery/light/small/directional/south,
+/obj/machinery/camera/directional/south{
+	name = "cargo camera";
+	c_tag = "Cargo - Mining"
+	},
 /turf/open/floor/iron,
 /area/station/cargo/miningoffice)
 "bhN" = (
@@ -4828,7 +4846,7 @@
 /obj/effect/turf_decal/bot,
 /obj/machinery/atmospherics/components/unary/portables_connector/visible,
 /obj/machinery/light/small/red/directional/north,
-/obj/structure/sign/warning/secure_area/directional/north,
+/obj/structure/sign/warning/biohazard/directional/north,
 /turf/open/floor/iron/smooth,
 /area/station/science/xenobiology)
 "biv" = (
@@ -5324,9 +5342,6 @@
 /obj/effect/mapping_helpers/airlock/cyclelink_helper_multi{
 	cycle_id = "bridge-right"
 	},
-/obj/machinery/door/airlock/command/glass{
-	name = "Bridge Access"
-	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
@@ -5335,11 +5350,15 @@
 	},
 /obj/effect/mapping_helpers/airlock/access/all/command/general,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/machinery/door/airlock/command/glass{
+	name = "Bridge Access";
+	dir = 4;
+	manual_align = 1
+	},
 /turf/open/floor/iron/dark,
 /area/station/command/bridge)
 "bpd" = (
 /obj/machinery/light/small/directional/north,
-/obj/item/radio/intercom/directional/north,
 /turf/open/floor/wood,
 /area/station/hallway/secondary/service)
 "bpg" = (
@@ -5777,7 +5796,7 @@
 /obj/machinery/light/small/directional/south,
 /obj/effect/landmark/start/hangover,
 /obj/machinery/newscaster/directional/west,
-/obj/machinery/button/door/directional/south{
+/obj/machinery/button/door/directional/east{
 	id = "Toilet1";
 	name = "Lock Control";
 	normaldoorcontrol = 1;
@@ -5994,11 +6013,6 @@
 /area/station/engineering/break_room)
 "byP" = (
 /obj/machinery/firealarm/directional/east,
-/obj/machinery/camera{
-	c_tag = "Cargo Bay - Drone Bay";
-	dir = 4;
-	name = "cargo camera"
-	},
 /obj/effect/turf_decal/tile/brown/half/contrasted{
 	dir = 4
 	},
@@ -6024,6 +6038,7 @@
 /obj/item/seeds/garlic,
 /obj/item/seeds/onion,
 /obj/item/paper/guides/jobs/hydroponics,
+/obj/structure/sign/warning/electric_shock/directional/north,
 /turf/open/floor/iron,
 /area/station/security/prison/garden)
 "byX" = (
@@ -6043,14 +6058,14 @@
 /turf/open/floor/iron/dark,
 /area/station/engineering/transit_tube)
 "bzf" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /obj/effect/turf_decal/stripes/corner{
 	dir = 4
 	},
 /obj/effect/turf_decal/siding/yellow/corner{
 	dir = 8
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 9
 	},
 /turf/open/floor/iron,
 /area/station/engineering/atmos/hfr_room)
@@ -6487,6 +6502,18 @@
 /obj/structure/sign/warning/electric_shock,
 /turf/closed/wall/r_wall,
 /area/station/engineering/lobby)
+"bEc" = (
+/obj/machinery/conveyor{
+	dir = 4;
+	id = "garbage"
+	},
+/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/structure/sign/warning/vacuum/directional/north,
+/turf/open/floor/plating,
+/area/station/maintenance/disposal)
 "bEd" = (
 /obj/structure/chair/wood{
 	dir = 4
@@ -7585,19 +7612,15 @@
 /turf/open/floor/plating,
 /area/station/maintenance/port)
 "bRw" = (
-/obj/structure/sign/warning/deathsposal/directional/east,
-/obj/structure/disposalpipe/trunk{
+/obj/machinery/light/directional/east,
+/obj/effect/turf_decal/tile/purple/half/contrasted{
 	dir = 8
 	},
-/obj/machinery/light/directional/east,
+/obj/machinery/hydroponics/constructable,
 /obj/effect/turf_decal/bot,
 /obj/effect/turf_decal/siding/purple{
 	dir = 8
 	},
-/obj/effect/turf_decal/tile/purple/half/contrasted{
-	dir = 8
-	},
-/obj/machinery/disposal/bin/tagger,
 /turf/open/floor/iron,
 /area/station/science/xenobiology)
 "bRy" = (
@@ -8895,6 +8918,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 5
 	},
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/iron,
 /area/station/engineering/atmos/hfr_room)
 "cit" = (
@@ -9037,29 +9061,18 @@
 /turf/open/floor/iron,
 /area/station/medical/medbay)
 "cky" = (
-/obj/machinery/button/door/directional/south{
-	id = "psych_shutters";
-	name = "Shutter Control";
-	pixel_x = -4;
-	req_access = list("psychology")
-	},
 /obj/machinery/light_switch/directional/south{
 	pixel_x = 6
-	},
-/obj/machinery/airalarm/directional/west,
-/obj/machinery/button/door/directional/south{
-	id = "psych_bolt";
-	name = "Bolt Control";
-	normaldoorcontrol = 1;
-	pixel_x = -4;
-	pixel_y = -35;
-	req_access = list("psychology");
-	specialfunctions = 4
 	},
 /obj/structure/table/wood,
 /obj/machinery/computer/records/medical/laptop{
 	dir = 1;
 	pixel_y = 4
+	},
+/obj/machinery/button/door/directional/west{
+	id = "psych_bolt";
+	name = "Bolt Control";
+	req_access = list("psychology")
 	},
 /turf/open/floor/wood,
 /area/station/medical/psychology)
@@ -9252,7 +9265,6 @@
 /obj/structure/toilet{
 	dir = 8
 	},
-/obj/machinery/newscaster/directional/north,
 /obj/machinery/button/door/directional/south{
 	id = "Arrivals_Toilet1";
 	name = "Lock Control";
@@ -9260,7 +9272,14 @@
 	specialfunctions = 4
 	},
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/light/small/broken/directional/east,
+/obj/machinery/newscaster/directional/east,
+/obj/machinery/light/small/directional/north,
+/obj/machinery/button/door/directional/north{
+	id = "Arrivals_Toilet1";
+	name = "Lock Control";
+	normaldoorcontrol = 1;
+	specialfunctions = 4
+	},
 /turf/open/floor/plating,
 /area/station/commons/toilet/restrooms)
 "cmd" = (
@@ -9309,6 +9328,7 @@
 /obj/effect/turf_decal/tile/blue/half/contrasted{
 	dir = 1
 	},
+/obj/machinery/light_switch/directional/north,
 /turf/open/floor/iron/dark,
 /area/station/command/bridge)
 "cmI" = (
@@ -9980,7 +10000,6 @@
 /obj/effect/turf_decal/tile/blue{
 	dir = 8
 	},
-/obj/machinery/light/small/directional/west,
 /turf/open/floor/iron/white,
 /area/station/medical/paramedic)
 "cvr" = (
@@ -10097,6 +10116,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 6
 	},
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/iron,
 /area/station/engineering/atmos/hfr_room)
 "cxe" = (
@@ -10391,9 +10411,7 @@
 /area/station/engineering/atmos)
 "cAV" = (
 /obj/effect/landmark/start/hangover,
-/obj/machinery/light_switch/directional/north{
-	pixel_x = -8
-	},
+/obj/item/radio/intercom/directional/north,
 /turf/open/floor/wood,
 /area/station/hallway/secondary/service)
 "cAZ" = (
@@ -10672,19 +10690,6 @@
 	},
 /turf/open/floor/iron,
 /area/station/security/execution/transfer)
-"cDK" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/green/visible/layer2,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 4
-	},
-/turf/open/floor/iron/dark/corner{
-	dir = 1
-	},
-/area/station/maintenance/disposal/incinerator)
 "cDM" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -10976,7 +10981,6 @@
 	dir = 8
 	},
 /obj/machinery/light/small/directional/south,
-/obj/item/radio/intercom/directional/south,
 /obj/effect/mapping_helpers/broken_floor,
 /turf/open/floor/wood,
 /area/station/hallway/secondary/service)
@@ -11134,12 +11138,12 @@
 /area/station/hallway/secondary/exit/departure_lounge)
 "cJX" = (
 /obj/structure/table/reinforced,
-/obj/machinery/status_display/evac/directional/west,
 /obj/effect/spawner/random/food_or_drink/donkpockets{
 	pixel_y = -1
 	},
 /obj/effect/spawner/random/food_or_drink/refreshing_beverage,
 /obj/effect/spawner/random/food_or_drink/snack,
+/obj/item/radio/intercom/directional/west,
 /turf/open/floor/wood,
 /area/station/engineering/break_room)
 "cKa" = (
@@ -11367,18 +11371,6 @@
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 8
-	},
-/obj/machinery/button/door/directional/south{
-	id = "teleportershutters";
-	name = "Teleporter Shutters";
-	pixel_x = -6;
-	req_access = list("command")
-	},
-/obj/machinery/button/door/directional/south{
-	id = "evastorage";
-	name = "E.V.A. Shutters";
-	pixel_x = 6;
-	req_access = list("command")
 	},
 /turf/open/floor/carpet,
 /area/station/command/bridge)
@@ -11665,18 +11657,6 @@
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 4
-	},
-/obj/machinery/button/door/directional/south{
-	id = "bridgewindows";
-	name = "Bridge View Blast Doors";
-	pixel_x = -6;
-	req_access = list("command")
-	},
-/obj/machinery/button/door/directional/south{
-	id = "bridgedoors";
-	name = "Bridge Access Blast Doors";
-	pixel_x = 6;
-	req_access = list("command")
 	},
 /turf/open/floor/carpet,
 /area/station/command/bridge)
@@ -12373,15 +12353,17 @@
 /turf/open/floor/plating,
 /area/station/maintenance/department/crew_quarters/bar)
 "dan" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
 /obj/effect/turf_decal/tile/purple/half/contrasted{
 	dir = 4
 	},
+/obj/structure/disposalpipe/sorting/mail{
+	dir = 8;
+	name = "Xeniobio Junction"
+	},
+/obj/effect/mapping_helpers/mail_sorting/science/xenobiology,
 /turf/open/floor/iron/white,
 /area/station/science/xenobiology)
 "das" = (
@@ -13636,9 +13618,6 @@
 	pixel_x = 8
 	},
 /obj/effect/turf_decal/box/corners,
-/obj/machinery/status_display/supply{
-	pixel_x = 32
-	},
 /obj/effect/turf_decal/tile/brown/half/contrasted{
 	dir = 4
 	},
@@ -13859,10 +13838,27 @@
 "dtS" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/green/visible/layer2,
 /obj/machinery/atmospherics/pipe/smart/simple/dark/visible{
-	dir = 10
+	dir = 4
 	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron,
+/obj/machinery/door/airlock/public/glass/incinerator/atmos_interior{
+	dir = 4;
+	manual_align = 1
+	},
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 8
+	},
+/obj/effect/mapping_helpers/airlock/locked,
+/obj/machinery/airlock_controller/incinerator_atmos{
+	pixel_y = -24
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/effect/mapping_helpers/airlock/access/all/engineering/atmos,
+/turf/open/floor/engine,
 /area/station/maintenance/disposal/incinerator)
 "dtX" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible,
@@ -13933,12 +13929,8 @@
 /turf/open/floor/iron/dark/smooth_large,
 /area/station/science/breakroom)
 "duK" = (
-/obj/structure/disposalpipe/sorting/mail/flip{
-	dir = 2;
-	name = "Xenobio Junction"
-	},
 /obj/effect/landmark/event_spawn,
-/obj/effect/mapping_helpers/mail_sorting/science/xenobiology,
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/iron,
 /area/station/science/xenobiology)
 "duV" = (
@@ -14828,7 +14820,6 @@
 /obj/machinery/status_display/ai/directional/south,
 /obj/machinery/camera/directional/south{
 	c_tag = "Service - Cafeteria Aft";
-	dir = 5;
 	name = "service camera"
 	},
 /obj/effect/turf_decal/tile/neutral/fourcorners,
@@ -15065,7 +15056,9 @@
 /area/station/service/abandoned_gambling_den)
 "dKe" = (
 /obj/effect/turf_decal/stripes/line,
-/obj/structure/sign/warning/deathsposal,
+/obj/effect/turf_decal/siding/yellow{
+	dir = 4
+	},
 /turf/open/floor/iron,
 /area/station/engineering/atmos/hfr_room)
 "dKg" = (
@@ -15180,17 +15173,17 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/light/small/directional/south,
 /obj/machinery/newscaster/directional/west,
-/obj/machinery/button/door/directional/south{
-	id = "Toilet3";
-	name = "Lock Control";
-	normaldoorcontrol = 1;
-	specialfunctions = 4
-	},
 /obj/effect/spawner/random/trash/graffiti{
 	pixel_x = 32
 	},
 /obj/machinery/recharge_station,
 /obj/effect/turf_decal/bot_red,
+/obj/machinery/button/door/directional/east{
+	id = "Toilet3";
+	name = "Lock Control";
+	normaldoorcontrol = 1;
+	specialfunctions = 4
+	},
 /turf/open/floor/iron,
 /area/station/commons/toilet/locker)
 "dLJ" = (
@@ -15315,6 +15308,7 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/machinery/vending/wallmed/directional/south,
 /turf/open/floor/iron,
 /area/station/medical/surgery/theatre)
 "dNb" = (
@@ -16035,6 +16029,7 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/tile/blue/fourcorners,
+/obj/machinery/light_switch/directional/north,
 /turf/open/floor/iron,
 /area/station/medical/paramedic)
 "dWd" = (
@@ -16577,6 +16572,7 @@
 	},
 /obj/effect/turf_decal/box/red,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/structure/sign/warning/electric_shock/directional/north,
 /turf/open/floor/iron/dark,
 /area/station/security/execution/education)
 "edq" = (
@@ -16678,12 +16674,10 @@
 	},
 /obj/item/folder/yellow,
 /obj/machinery/power/apc/auto_name/directional/north,
-/obj/machinery/light_switch/directional/north{
-	pixel_x = 12
-	},
 /obj/effect/turf_decal/tile/brown/anticorner/contrasted{
 	dir = 1
 	},
+/obj/machinery/light_switch/directional/north,
 /turf/open/floor/iron,
 /area/station/cargo/sorting)
 "eex" = (
@@ -16855,7 +16849,6 @@
 /obj/effect/turf_decal/trimline/neutral/warning{
 	dir = 8
 	},
-/obj/structure/extinguisher_cabinet/directional/south,
 /turf/open/floor/iron/dark/textured_half{
 	dir = 1
 	},
@@ -16905,12 +16898,12 @@
 /area/station/cargo/storage)
 "eif" = (
 /obj/item/kirbyplants/random,
-/obj/machinery/firealarm/directional/north,
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 9
 	},
 /obj/machinery/power/apc/auto_name/directional/west,
 /obj/structure/cable,
+/obj/machinery/light_switch/directional/north,
 /turf/open/floor/iron/white,
 /area/station/medical/surgery/theatre)
 "eio" = (
@@ -17004,6 +16997,10 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/white,
 /area/station/medical/virology)
+"eko" = (
+/obj/structure/cable,
+/turf/open/floor/iron/dark,
+/area/station/hallway/secondary/service)
 "ekF" = (
 /obj/machinery/light/directional/south,
 /obj/structure/window/reinforced/spawner/directional/west,
@@ -17065,10 +17062,6 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/station/maintenance/disposal/incinerator)
-"elK" = (
-/obj/structure/sign/warning/no_smoking,
-/turf/closed/wall,
-/area/station/engineering/main)
 "elM" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -17183,6 +17176,8 @@
 /obj/effect/turf_decal/tile/brown/half/contrasted{
 	dir = 1
 	},
+/obj/structure/cable,
+/obj/machinery/power/apc/auto_name/directional/north,
 /turf/open/floor/iron,
 /area/station/cargo/office)
 "env" = (
@@ -18933,32 +18928,32 @@
 /area/station/science/research/abandoned)
 "eKL" = (
 /obj/structure/table/reinforced,
-/obj/machinery/button/door{
-	id = "rdordnance";
-	name = "Ordnance Containment Control";
-	pixel_x = -7;
-	pixel_y = -4;
-	req_access = list("rd")
-	},
-/obj/machinery/button/door{
+/obj/machinery/button/door/table{
 	id = "sci_experimentor";
 	name = "Experimentor Containment Control";
-	pixel_x = -7;
-	pixel_y = 7;
+	req_access = list("rd");
+	pixel_y = 13;
+	pixel_x = -6
+	},
+/obj/machinery/button/door/table{
+	pixel_x = -6;
+	pixel_y = 4;
+	name = "Ordnance Containment Control";
+	id = "rdordnance";
 	req_access = list("rd")
 	},
-/obj/machinery/button/door{
+/obj/machinery/button/door/table{
 	id = "rdrnd";
 	name = "Research and Development Containment Control";
-	pixel_x = 7;
-	pixel_y = 7;
-	req_access = list("rd")
+	req_access = list("rd");
+	pixel_y = 13;
+	pixel_x = 6
 	},
-/obj/machinery/button/door{
-	id = "rdoffice";
+/obj/machinery/button/door/table{
+	pixel_x = 6;
+	pixel_y = 4;
 	name = "Privacy Control";
-	pixel_x = 7;
-	pixel_y = -4;
+	id = "rdoffice";
 	req_access = list("rd")
 	},
 /turf/open/floor/iron/white,
@@ -19593,11 +19588,15 @@
 	pixel_x = -8;
 	pixel_y = 12
 	},
-/obj/machinery/newscaster/directional/north,
 /obj/effect/turf_decal/tile/neutral/half/contrasted{
 	dir = 1
 	},
 /obj/machinery/light/small/directional/north,
+/obj/machinery/camera/directional/north{
+	c_tag = "Xenobiology - Cytology Desk";
+	name = "xenobiology camera";
+	network = list("ss13","xeno","rd")
+	},
 /turf/open/floor/iron,
 /area/station/science/xenobiology)
 "eSD" = (
@@ -19666,6 +19665,7 @@
 	name = "Moffee"
 	},
 /obj/machinery/light/warm/directional/north,
+/obj/structure/noticeboard/directional/north,
 /turf/open/floor/carpet/blue,
 /area/station/medical/psychology)
 "eTP" = (
@@ -19673,6 +19673,7 @@
 /obj/effect/turf_decal/tile/neutral/anticorner/contrasted{
 	dir = 1
 	},
+/obj/structure/sign/warning/biohazard/directional/north,
 /turf/open/floor/iron,
 /area/station/maintenance/department/science)
 "eTS" = (
@@ -19830,11 +19831,13 @@
 /area/station/science/auxlab/firing_range)
 "eVb" = (
 /obj/structure/cable,
+/obj/effect/turf_decal/tile/neutral/fourcorners,
 /obj/machinery/door/poddoor/preopen{
 	id = "bridgedoors";
-	name = "Bridge Access Blast Door"
+	name = "Bridge Access Blast Door";
+	dir = 4;
+	manual_align = 1
 	},
-/obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron/dark,
 /area/station/command/bridge)
 "eVc" = (
@@ -20232,9 +20235,6 @@
 /turf/open/floor/plating,
 /area/station/maintenance/port/aft)
 "eZV" = (
-/obj/machinery/light_switch/directional/east{
-	pixel_x = 22
-	},
 /obj/machinery/modular_computer/preset/id{
 	dir = 8
 	},
@@ -21272,16 +21272,6 @@
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron/dark,
 /area/station/hallway/secondary/exit/departure_lounge)
-"fmY" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/door/poddoor/preopen{
-	id = "justicechamber";
-	name = "Justice Chamber Blast Door"
-	},
-/obj/structure/sign/warning/electric_shock/directional/east,
-/obj/structure/cable,
-/turf/open/floor/plating,
-/area/station/security/execution/education)
 "fnb" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable,
@@ -21447,18 +21437,15 @@
 /turf/open/floor/iron,
 /area/station/hallway/primary/port)
 "fpt" = (
-/obj/structure/table/reinforced,
-/obj/machinery/reagentgrinder{
-	pixel_y = 5
-	},
-/obj/item/stack/sheet/mineral/plasma{
-	amount = 5
-	},
-/obj/structure/sign/warning/secure_area/directional/west,
-/obj/effect/turf_decal/siding/purple,
 /obj/effect/turf_decal/tile/purple/anticorner/contrasted{
 	dir = 8
 	},
+/obj/machinery/disposal/bin/tagger,
+/obj/structure/disposalpipe/trunk{
+	dir = 4
+	},
+/obj/effect/turf_decal/bot,
+/obj/effect/turf_decal/siding/purple,
 /turf/open/floor/iron,
 /area/station/science/xenobiology)
 "fpv" = (
@@ -21517,7 +21504,6 @@
 	dir = 4
 	},
 /obj/machinery/light/small/directional/north,
-/obj/machinery/airalarm/directional/north,
 /turf/open/floor/iron/dark,
 /area/station/security/evidence)
 "fqx" = (
@@ -21614,6 +21600,11 @@
 	},
 /turf/open/floor/iron,
 /area/station/maintenance/fore)
+"fsm" = (
+/obj/structure/lattice/catwalk,
+/obj/structure/sign/warning/secure_area/directional/north,
+/turf/open/space/basic,
+/area/space/nearstation)
 "fso" = (
 /obj/effect/spawner/structure/window,
 /turf/open/floor/plating,
@@ -22041,7 +22032,6 @@
 /turf/open/floor/iron,
 /area/station/cargo/miningoffice)
 "fxP" = (
-/obj/machinery/computer/security/telescreen/entertainment/directional/west,
 /obj/structure/table/wood,
 /obj/item/folder/white{
 	pixel_x = -2;
@@ -22055,6 +22045,11 @@
 /obj/item/flashlight/lamp/green{
 	pixel_x = 9;
 	pixel_y = 5
+	},
+/obj/machinery/button/door/directional/west{
+	id = "psych_shutters";
+	name = "Shutter Control";
+	req_access = list("psychology")
 	},
 /turf/open/floor/wood,
 /area/station/medical/psychology)
@@ -22603,8 +22598,8 @@
 	},
 /obj/effect/turf_decal/delivery,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
-/obj/machinery/airalarm/directional/north,
 /obj/effect/mapping_helpers/airalarm/unlocked,
+/obj/structure/sign/warning/no_smoking/directional/north,
 /turf/open/floor/iron/dark,
 /area/station/maintenance/disposal/incinerator)
 "fFo" = (
@@ -22895,16 +22890,16 @@
 /area/station/security/prison/work)
 "fIX" = (
 /obj/structure/table/reinforced,
-/obj/structure/extinguisher_cabinet/directional/north,
-/obj/item/folder/white,
-/obj/machinery/camera/directional/north{
-	c_tag = "Xenobiology - Cytology Desk";
-	name = "xenobiology camera";
-	network = list("ss13","xeno","rd")
-	},
 /obj/effect/turf_decal/tile/neutral/half/contrasted{
 	dir = 1
 	},
+/obj/machinery/reagentgrinder{
+	pixel_y = 5
+	},
+/obj/item/stack/sheet/mineral/plasma{
+	amount = 5
+	},
+/obj/machinery/newscaster/directional/north,
 /turf/open/floor/iron,
 /area/station/science/xenobiology)
 "fIY" = (
@@ -23206,14 +23201,13 @@
 /turf/open/floor/iron,
 /area/station/security/brig)
 "fNF" = (
-/obj/structure/cable,
 /obj/structure/table,
-/obj/machinery/power/apc/auto_name/directional/north,
 /obj/item/paper_bin/carbon,
 /obj/item/pen,
 /obj/effect/turf_decal/tile/brown/half/contrasted{
 	dir = 1
 	},
+/obj/machinery/status_display/supply,
 /turf/open/floor/iron,
 /area/station/cargo/office)
 "fNN" = (
@@ -23388,9 +23382,6 @@
 /obj/machinery/firealarm/directional/east,
 /obj/machinery/light_switch/directional/east{
 	pixel_x = 38
-	},
-/obj/structure/extinguisher_cabinet/directional/north{
-	pixel_x = 32
 	},
 /obj/structure/closet/secure_closet/security/cargo,
 /obj/effect/turf_decal/tile/red/anticorner/contrasted{
@@ -23647,9 +23638,6 @@
 /turf/open/floor/iron/dark,
 /area/station/science/ordnance)
 "fTz" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
@@ -24849,6 +24837,7 @@
 /obj/machinery/rnd/production/circuit_imprinter,
 /obj/effect/turf_decal/bot,
 /obj/effect/turf_decal/tile/neutral/half/contrasted,
+/obj/machinery/status_display/evac/directional/north,
 /turf/open/floor/iron/dark,
 /area/station/engineering/storage_shared)
 "ghq" = (
@@ -25232,7 +25221,9 @@
 	cycle_id = "brig-entrance"
 	},
 /obj/machinery/door/airlock/security/glass{
-	name = "Brig"
+	name = "Brig";
+	manual_align = 1;
+	dir = 4
 	},
 /obj/effect/mapping_helpers/airlock/access/all/security/entrance,
 /obj/effect/turf_decal/stripes/line{
@@ -25242,7 +25233,10 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/tile/neutral/fourcorners,
-/obj/machinery/scanner_gate/preset_guns,
+/obj/machinery/scanner_gate/preset_guns{
+	dir = 4
+	},
+/obj/machinery/door/firedoor,
 /turf/open/floor/iron/dark,
 /area/station/security/brig)
 "gmD" = (
@@ -25646,24 +25640,18 @@
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
 "gqR" = (
-/obj/structure/disposalpipe/segment,
 /obj/structure/cable,
-/obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 4
-	},
-/turf/open/floor/iron/dark/corner{
+/obj/structure/disposalpipe/junction/flip{
 	dir = 1
 	},
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/turf/open/floor/iron/dark,
 /area/station/maintenance/disposal/incinerator)
 "gqZ" = (
 /obj/machinery/door/firedoor,
 /obj/effect/mapping_helpers/airlock/cyclelink_helper_multi{
 	cycle_id = "brig-entrance"
-	},
-/obj/machinery/door/airlock/security/glass{
-	name = "Brig"
 	},
 /obj/effect/mapping_helpers/airlock/access/all/security/entrance,
 /obj/effect/turf_decal/stripes/line{
@@ -25673,6 +25661,11 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/machinery/door/airlock/security/glass{
+	name = "Brig";
+	manual_align = 1;
+	dir = 4
+	},
 /turf/open/floor/iron/dark,
 /area/station/security/brig)
 "grl" = (
@@ -26184,6 +26177,7 @@
 	dir = 4
 	},
 /obj/effect/spawner/random/structure/closet_private,
+/obj/machinery/light_switch/directional/west,
 /turf/open/floor/wood,
 /area/station/hallway/secondary/service)
 "gwx" = (
@@ -26348,11 +26342,9 @@
 /turf/open/floor/iron/dark,
 /area/station/command/heads_quarters/ce)
 "gyW" = (
-/obj/structure/cable,
 /obj/effect/turf_decal/siding/wood/corner{
 	dir = 1
 	},
-/obj/machinery/power/apc/auto_name/directional/north,
 /obj/machinery/light/directional/north,
 /turf/open/floor/iron/dark,
 /area/station/hallway/secondary/service)
@@ -26822,10 +26814,6 @@
 	},
 /turf/open/floor/iron,
 /area/station/security/office)
-"gEz" = (
-/obj/structure/sign/calendar/directional/south,
-/turf/open/floor/carpet/blue,
-/area/station/commons/dorms)
 "gEA" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -27004,7 +26992,6 @@
 	dir = 1
 	},
 /obj/item/radio/intercom/directional/north,
-/obj/machinery/light/small/directional/north,
 /turf/open/floor/iron,
 /area/station/security/checkpoint/escape)
 "gGF" = (
@@ -27053,16 +27040,19 @@
 /obj/machinery/button/door/directional/north{
 	id = "ceblast";
 	name = "Office Lockdown Control";
-	pixel_x = 6;
-	pixel_y = 26;
+	pixel_y = 35;
 	req_access = list("ce")
-	},
-/obj/machinery/light_switch/directional/north{
-	pixel_x = -6
 	},
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron/dark,
 /area/station/command/heads_quarters/ce)
+"gHx" = (
+/obj/effect/turf_decal/tile/neutral/half/contrasted{
+	dir = 1
+	},
+/obj/structure/sign/poster/random/directional/north,
+/turf/open/floor/iron,
+/area/station/commons/dorms)
 "gHE" = (
 /obj/machinery/requests_console/directional/north{
 	department = "Chapel";
@@ -27119,9 +27109,6 @@
 /turf/open/floor/iron,
 /area/station/security/holding_cell)
 "gIq" = (
-/obj/structure/disposalpipe/segment{
-	dir = 5
-	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
@@ -27177,7 +27164,6 @@
 /obj/effect/turf_decal/tile/neutral/half/contrasted{
 	dir = 8
 	},
-/obj/structure/sign/warning/deathsposal,
 /turf/open/floor/iron,
 /area/station/science/xenobiology)
 "gIJ" = (
@@ -27326,6 +27312,7 @@
 "gKI" = (
 /obj/structure/cable,
 /obj/machinery/power/apc/auto_name/directional/north,
+/obj/machinery/light_switch/directional/north,
 /turf/open/floor/wood,
 /area/station/command/meeting_room/council)
 "gKT" = (
@@ -27533,6 +27520,7 @@
 /obj/machinery/light/small/directional/east,
 /obj/effect/turf_decal/bot,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/machinery/airalarm/directional/east,
 /turf/open/floor/iron/dark,
 /area/station/security/office)
 "gNO" = (
@@ -27868,16 +27856,12 @@
 "gSB" = (
 /obj/structure/cable,
 /obj/machinery/button/door/incinerator_vent_atmos_main{
-	pixel_x = -8;
-	pixel_y = 36
-	},
-/obj/machinery/button/door/incinerator_vent_atmos_aux{
-	pixel_x = -8;
-	pixel_y = 24
+	pixel_x = -8
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/chair/stool/directional/south,
 /obj/machinery/light/small/directional/north,
+/obj/machinery/button/door/incinerator_vent_atmos_aux/directional/north,
 /turf/open/floor/iron,
 /area/station/maintenance/disposal/incinerator)
 "gSR" = (
@@ -28148,14 +28132,16 @@
 /obj/effect/mapping_helpers/airlock/cyclelink_helper_multi{
 	cycle_id = "bridge-left"
 	},
-/obj/machinery/door/airlock/command/glass{
-	name = "Bridge Access"
-	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
 /obj/effect/mapping_helpers/airlock/access/all/command/general,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/machinery/door/airlock/command/glass{
+	name = "Bridge Access";
+	dir = 4;
+	manual_align = 1
+	},
 /turf/open/floor/iron/dark,
 /area/station/command/bridge)
 "gWv" = (
@@ -28236,8 +28222,8 @@
 /area/station/hallway/secondary/exit)
 "gXm" = (
 /obj/item/kirbyplants/random,
-/obj/machinery/firealarm/directional/south,
 /obj/effect/turf_decal/tile/blue/half/contrasted,
+/obj/machinery/newscaster/directional/south,
 /turf/open/floor/iron/white,
 /area/station/medical/paramedic)
 "gXn" = (
@@ -28678,11 +28664,11 @@
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
 "hdR" = (
-/obj/machinery/light_switch/directional/north,
 /obj/structure/cable,
 /obj/effect/turf_decal/tile/red/anticorner/contrasted{
 	dir = 4
 	},
+/obj/machinery/firealarm/directional/north,
 /turf/open/floor/iron,
 /area/station/security/checkpoint/escape)
 "hdU" = (
@@ -28796,7 +28782,10 @@
 /obj/machinery/atmospherics/pipe/smart/simple/dark/visible{
 	dir = 4
 	},
-/obj/machinery/door/airlock/public/glass/incinerator/atmos_exterior,
+/obj/machinery/door/airlock/public/glass/incinerator/atmos_exterior{
+	manual_align = 1;
+	dir = 4
+	},
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 4
 	},
@@ -29342,13 +29331,6 @@
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron/dark,
 /area/station/engineering/atmos)
-"hnd" = (
-/obj/structure/sign/poster/random/directional/north,
-/obj/effect/turf_decal/tile/neutral/half/contrasted{
-	dir = 1
-	},
-/turf/open/floor/iron,
-/area/station/commons/dorms)
 "hnk" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/grimy,
@@ -29460,9 +29442,6 @@
 /obj/item/folder/yellow,
 /obj/item/stack/package_wrap,
 /obj/item/hand_labeler,
-/obj/structure/extinguisher_cabinet/directional/north{
-	pixel_x = 32
-	},
 /obj/item/radio/intercom/directional/east{
 	pixel_x = 38;
 	pixel_y = 3
@@ -29493,6 +29472,7 @@
 /obj/effect/turf_decal/tile/brown/half/contrasted{
 	dir = 1
 	},
+/obj/machinery/light_switch/directional/north,
 /turf/open/floor/iron,
 /area/station/command/heads_quarters/qm)
 "hoQ" = (
@@ -30530,7 +30510,33 @@
 "hEI" = (
 /obj/structure/window/reinforced/spawner/directional/west,
 /obj/structure/table/wood,
-/obj/item/taperecorder,
+/obj/machinery/button/door/incinerator_vent_atmos_aux/table{
+	pixel_x = 1;
+	id = "evastorage";
+	name = "E.V.A. Shutters";
+	req_access = list("command")
+	},
+/obj/machinery/button/door/incinerator_vent_atmos_aux/table{
+	pixel_y = 8;
+	pixel_x = -4;
+	id = "teleportershutters";
+	name = "Teleporter Shutters";
+	req_access = list("command")
+	},
+/obj/machinery/button/door/incinerator_vent_atmos_aux/table{
+	pixel_y = 16;
+	pixel_x = 1;
+	id = "bridgewindows";
+	name = "Bridge View Blast Doors";
+	req_access = list("command")
+	},
+/obj/machinery/button/door/incinerator_vent_atmos_aux/table{
+	pixel_x = 7;
+	pixel_y = 8;
+	id = "bridgedoors";
+	name = "Bridge Access Blast Doors";
+	req_access = list("command")
+	},
 /turf/open/floor/iron/grimy,
 /area/station/command/bridge)
 "hEL" = (
@@ -31327,6 +31333,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/cargo/office)
 "hPx" = (
@@ -31852,9 +31859,11 @@
 /turf/open/floor/carpet,
 /area/station/command/meeting_room/council)
 "hWz" = (
-/obj/structure/closet/secure_closet/atmospherics,
+/obj/machinery/disposal/bin,
+/obj/structure/disposalpipe/trunk,
+/obj/structure/sign/warning/deathsposal/directional/north,
 /obj/effect/turf_decal/bot,
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/station/engineering/atmos/hfr_room)
 "hWA" = (
 /obj/structure/table/reinforced,
@@ -32229,6 +32238,7 @@
 	dir = 4
 	},
 /obj/effect/decal/cleanable/dirt,
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/iron/dark,
 /area/station/engineering/atmos/hfr_room)
 "iaT" = (
@@ -32909,8 +32919,8 @@
 /obj/structure/closet{
 	name = "evidence closet"
 	},
-/obj/machinery/firealarm/directional/west,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/machinery/firealarm/directional/north,
 /turf/open/floor/iron/dark,
 /area/station/security/evidence)
 "ijx" = (
@@ -33851,11 +33861,7 @@
 /obj/machinery/button/door/directional/north{
 	id = "paramed_dispatch";
 	name = "Privacy Shutters";
-	pixel_x = 6;
 	req_access = list("medical")
-	},
-/obj/machinery/light_switch/directional/north{
-	pixel_x = -8
 	},
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
@@ -34266,6 +34272,10 @@
 /obj/structure/sign/warning/firing_range/directional/north,
 /turf/open/floor/iron,
 /area/station/maintenance/department/science)
+"iBs" = (
+/obj/structure/sign/warning/xeno_mining/directional/north,
+/turf/open/floor/glass/reinforced,
+/area/station/maintenance/department/science/xenobiology)
 "iBx" = (
 /obj/effect/spawner/random/structure/closet_private,
 /obj/structure/extinguisher_cabinet/directional/east,
@@ -34286,6 +34296,7 @@
 	desc = "Maybe hugging this will make you feel better about yourself.";
 	name = "Therabee"
 	},
+/obj/machinery/airalarm/directional/east,
 /turf/open/floor/wood,
 /area/station/medical/psychology)
 "iBO" = (
@@ -34878,8 +34889,8 @@
 /area/station/hallway/secondary/exit/departure_lounge)
 "iJD" = (
 /obj/structure/window/spawner/directional/south,
-/obj/structure/sign/poster/official/random/directional/north,
 /obj/structure/water_source/puddle,
+/obj/structure/sign/warning/electric_shock/directional/north,
 /turf/open/misc/sandy_dirt,
 /area/station/security/prison/garden)
 "iJE" = (
@@ -35894,6 +35905,7 @@
 /obj/effect/turf_decal/tile/yellow/anticorner/contrasted{
 	dir = 4
 	},
+/obj/machinery/airalarm/directional/north,
 /turf/open/floor/iron,
 /area/station/engineering/lobby)
 "iXj" = (
@@ -36105,16 +36117,6 @@
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron/dark,
 /area/station/service/electronic_marketing_den)
-"iZU" = (
-/obj/structure/disposalpipe/segment{
-	dir = 10
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/purple,
-/turf/open/floor/iron/white,
-/area/station/science/xenobiology)
 "iZY" = (
 /obj/machinery/atmospherics/components/unary/outlet_injector/monitored/mix_input{
 	dir = 4
@@ -36206,10 +36208,8 @@
 /turf/open/floor/iron,
 /area/station/hallway/secondary/command)
 "jaX" = (
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible{
-	dir = 9
-	},
 /obj/machinery/status_display/evac/directional/south,
+/obj/effect/turf_decal/siding/yellow,
 /turf/open/floor/iron,
 /area/station/engineering/atmos/hfr_room)
 "jaZ" = (
@@ -36428,6 +36428,7 @@
 	},
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /obj/effect/turf_decal/bot_white,
+/obj/machinery/firealarm/directional/east,
 /turf/open/floor/iron/dark,
 /area/station/medical/surgery/theatre)
 "jdg" = (
@@ -36610,6 +36611,8 @@
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/command/nuke_storage)
 "jff" = (
+/obj/machinery/atmospherics/pipe/smart/simple/dark/visible,
+/obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
@@ -36771,7 +36774,6 @@
 /turf/open/floor/wood,
 /area/station/service/theater)
 "jgS" = (
-/obj/structure/sign/warning/secure_area/directional/west,
 /obj/structure/cable,
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -37152,7 +37154,6 @@
 "jlN" = (
 /obj/structure/table/reinforced,
 /obj/machinery/recharger,
-/obj/machinery/airalarm/directional/west,
 /obj/item/restraints/handcuffs,
 /obj/structure/extinguisher_cabinet/directional/north,
 /obj/machinery/light/small/directional/west,
@@ -37945,12 +37946,10 @@
 /turf/open/floor/iron/white,
 /area/station/medical/chemistry)
 "jvT" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /obj/effect/turf_decal/stripes/corner{
 	dir = 1
 	},
+/obj/effect/turf_decal/siding/yellow/corner,
 /turf/open/floor/iron,
 /area/station/engineering/atmos/hfr_room)
 "jvX" = (
@@ -38660,7 +38659,9 @@
 /obj/structure/cable,
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/command/glass{
-	name = "Bridge Access"
+	name = "Bridge Access";
+	dir = 4;
+	manual_align = 1
 	},
 /obj/effect/mapping_helpers/airlock/cyclelink_helper_multi{
 	cycle_id = "bridge-left"
@@ -39085,7 +39086,6 @@
 	},
 /area/station/service/kitchen)
 "jKE" = (
-/obj/machinery/light_switch/directional/north,
 /obj/machinery/light/small/directional/north,
 /turf/open/floor/wood,
 /area/station/command/meeting_room/council)
@@ -39373,12 +39373,12 @@
 /area/station/security/checkpoint/customs/fore)
 "jNY" = (
 /obj/structure/table/optable,
-/obj/machinery/newscaster/directional/north,
 /obj/effect/turf_decal/bot_red,
 /obj/machinery/light/small/directional/north,
 /obj/effect/turf_decal/tile/dark_blue/half/contrasted{
 	dir = 1
 	},
+/obj/structure/sign/clock/directional/north,
 /turf/open/floor/iron/dark,
 /area/station/medical/morgue)
 "jNZ" = (
@@ -40236,16 +40236,19 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/chair/stool/bar/directional/west,
 /obj/machinery/power/apc/auto_name/directional/north,
+/obj/machinery/light_switch/directional/north,
 /turf/open/floor/plating,
 /area/station/service/abandoned_gambling_den/gaming)
 "jYX" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/tile/neutral/fourcorners,
 /obj/machinery/door/poddoor/preopen{
 	id = "bridgedoors";
-	name = "Bridge Access Blast Door"
+	name = "Bridge Access Blast Door";
+	dir = 4;
+	manual_align = 1
 	},
-/obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron/dark,
 /area/station/command/bridge)
 "jZc" = (
@@ -40777,9 +40780,12 @@
 /obj/item/reagent_containers/cup/soda_cans/space_mountain_wind{
 	pixel_x = 5
 	},
-/obj/machinery/camera/autoname/directional/south,
 /obj/item/toy/figure/bitrunner{
 	pixel_x = -6
+	},
+/obj/machinery/camera/directional/south{
+	name = "cargo camera";
+	c_tag = "Cargo - Bitrunners"
 	},
 /turf/open/floor/iron/dark/smooth_large,
 /area/station/cargo/bitrunning/den)
@@ -40826,9 +40832,6 @@
 /turf/open/floor/iron,
 /area/station/hallway/primary/central/fore)
 "kfL" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
@@ -41059,6 +41062,7 @@
 	},
 /obj/effect/landmark/start/cargo_technician,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/cargo/office)
 "kiq" = (
@@ -41103,6 +41107,7 @@
 	name = "evidence closet"
 	},
 /obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/item/radio/intercom/directional/north,
 /turf/open/floor/iron/dark,
 /area/station/security/evidence)
 "kiP" = (
@@ -41424,8 +41429,18 @@
 /obj/effect/turf_decal/tile/neutral/half/contrasted,
 /turf/open/floor/iron,
 /area/station/service/hydroponics)
+"kmi" = (
+/obj/effect/turf_decal/trimline/purple/filled/line{
+	dir = 8
+	},
+/obj/machinery/airalarm/directional/west,
+/turf/open/floor/iron/white,
+/area/station/science/research)
 "kmE" = (
-/obj/machinery/door/poddoor/incinerator_atmos_aux,
+/obj/machinery/door/poddoor/incinerator_atmos_aux{
+	manual_align = 1;
+	dir = 4
+	},
 /turf/open/floor/engine,
 /area/station/maintenance/disposal/incinerator)
 "kmS" = (
@@ -41552,12 +41567,12 @@
 /turf/open/floor/wood,
 /area/station/service/abandoned_gambling_den)
 "koB" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /obj/effect/decal/cleanable/oil,
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 5
 	},
 /turf/open/floor/iron,
 /area/station/maintenance/disposal/incinerator)
@@ -42379,6 +42394,7 @@
 	dir = 6
 	},
 /obj/structure/reagent_dispensers/water_cooler,
+/obj/machinery/computer/security/telescreen/entertainment/directional/south,
 /turf/open/floor/iron/white/smooth_large,
 /area/station/medical/psychology)
 "kAE" = (
@@ -42414,9 +42430,6 @@
 /area/station/security/detectives_office)
 "kBc" = (
 /obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/security/glass{
-	name = "Brig"
-	},
 /obj/structure/cable,
 /obj/effect/landmark/navigate_destination,
 /obj/effect/mapping_helpers/airlock/cyclelink_helper_multi{
@@ -42432,7 +42445,14 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
-/obj/machinery/scanner_gate/preset_guns,
+/obj/machinery/scanner_gate/preset_guns{
+	dir = 4
+	},
+/obj/machinery/door/airlock/security/glass{
+	name = "Brig";
+	manual_align = 1;
+	dir = 4
+	},
 /turf/open/floor/iron/dark,
 /area/station/security/brig)
 "kBz" = (
@@ -43462,10 +43482,10 @@
 /turf/open/floor/iron,
 /area/station/service/hydroponics)
 "kRi" = (
-/obj/structure/disposalpipe/segment,
 /obj/structure/cable,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/green/visible/layer2,
 /turf/open/floor/iron/dark,
 /area/station/maintenance/disposal/incinerator)
 "kRk" = (
@@ -43944,6 +43964,7 @@
 /obj/item/reagent_containers/syringe,
 /obj/structure/table/reinforced/rglass,
 /obj/effect/turf_decal/tile/blue/fourcorners,
+/obj/machinery/firealarm/directional/west,
 /turf/open/floor/iron,
 /area/station/medical/treatment_center)
 "kXb" = (
@@ -44044,6 +44065,11 @@
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron/dark,
 /area/station/hallway/secondary/exit/departure_lounge)
+"kYi" = (
+/obj/structure/lattice,
+/obj/structure/sign/warning/fire/directional/north,
+/turf/open/space/basic,
+/area/space/nearstation)
 "kYn" = (
 /turf/open/floor/iron/dark,
 /area/station/service/abandoned_gambling_den/gaming)
@@ -45316,6 +45342,7 @@
 /obj/effect/turf_decal/tile/brown{
 	dir = 4
 	},
+/obj/structure/extinguisher_cabinet/directional/north,
 /turf/open/floor/iron,
 /area/station/cargo/storage)
 "lpk" = (
@@ -45611,6 +45638,7 @@
 "ltx" = (
 /obj/structure/cable,
 /obj/effect/decal/cleanable/dirt,
+/obj/machinery/button/door/incinerator_vent_atmos_main/directional/north,
 /turf/open/floor/iron,
 /area/station/maintenance/disposal/incinerator)
 "ltz" = (
@@ -46251,9 +46279,6 @@
 /obj/effect/mapping_helpers/airlock/cyclelink_helper_multi{
 	cycle_id = "bridge-left"
 	},
-/obj/machinery/door/airlock/command/glass{
-	name = "Bridge Access"
-	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
@@ -46262,6 +46287,11 @@
 	},
 /obj/effect/mapping_helpers/airlock/access/all/command/general,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/machinery/door/airlock/command/glass{
+	name = "Bridge Access";
+	dir = 4;
+	manual_align = 1
+	},
 /turf/open/floor/iron/dark,
 /area/station/command/bridge)
 "lBk" = (
@@ -47215,6 +47245,10 @@
 /obj/machinery/status_display/ai/directional/north,
 /turf/open/floor/engine,
 /area/station/science/explab)
+"lLt" = (
+/obj/structure/sign/warning/secure_area/directional/north,
+/turf/open/floor/engine/xenobio,
+/area/station/science/xenobiology)
 "lLy" = (
 /obj/effect/turf_decal/siding/white{
 	dir = 8
@@ -47232,7 +47266,6 @@
 	dir = 1
 	},
 /obj/structure/extinguisher_cabinet/directional/west,
-/obj/machinery/vending/wallmed/directional/south,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron,
 /area/station/medical/surgery/theatre)
@@ -47844,8 +47877,8 @@
 "lVn" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
-/obj/structure/extinguisher_cabinet/directional/north,
 /obj/effect/turf_decal/tile/red,
+/obj/structure/sign/warning/pods/directional/north,
 /turf/open/floor/iron,
 /area/station/security/execution/transfer)
 "lVv" = (
@@ -47931,6 +47964,7 @@
 /obj/item/wrench,
 /obj/item/radio,
 /obj/effect/turf_decal/tile/red/fourcorners,
+/obj/machinery/airalarm/directional/west,
 /turf/open/floor/iron,
 /area/station/security/checkpoint/escape)
 "lXl" = (
@@ -48148,7 +48182,6 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 5
 	},
-/obj/structure/sign/warning/secure_area/directional/south,
 /turf/open/floor/plating,
 /area/station/science/xenobiology)
 "lZG" = (
@@ -48475,20 +48508,20 @@
 /turf/open/floor/iron/large,
 /area/station/security/brig)
 "meZ" = (
-/obj/machinery/light/small/directional/east,
 /obj/structure/toilet{
 	dir = 8
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/spawner/random/trash/mess,
-/obj/machinery/newscaster/directional/north,
-/obj/machinery/button/door/directional/south{
+/obj/effect/turf_decal/bot,
+/obj/machinery/newscaster/directional/east,
+/obj/machinery/light/small/directional/north,
+/obj/machinery/button/door/directional/north{
 	id = "Arrivals_Toilet2";
 	name = "Lock Control";
 	normaldoorcontrol = 1;
 	specialfunctions = 4
 	},
-/obj/effect/turf_decal/bot,
 /turf/open/floor/iron,
 /area/station/commons/toilet/restrooms)
 "mfq" = (
@@ -49240,6 +49273,7 @@
 /area/station/security/office)
 "mqV" = (
 /obj/structure/dresser,
+/obj/item/radio/intercom/directional/east,
 /turf/open/floor/wood,
 /area/station/hallway/secondary/service)
 "mra" = (
@@ -49401,10 +49435,10 @@
 	},
 /obj/item/multitool,
 /obj/effect/turf_decal/bot,
-/obj/machinery/computer/security/telescreen/entertainment/directional/south,
 /obj/effect/turf_decal/tile/neutral/half/contrasted{
 	dir = 1
 	},
+/obj/machinery/status_display/evac/directional/south,
 /turf/open/floor/iron/dark,
 /area/station/engineering/break_room)
 "mti" = (
@@ -49489,6 +49523,7 @@
 /obj/effect/turf_decal/trimline/dark_red/filled/line{
 	dir = 8
 	},
+/obj/machinery/airalarm/directional/north,
 /turf/open/floor/iron/dark,
 /area/station/security/evidence)
 "muh" = (
@@ -50994,6 +51029,11 @@
 /obj/effect/turf_decal/bot,
 /turf/open/floor/iron,
 /area/station/cargo/storage)
+"mLE" = (
+/obj/machinery/power/apc/auto_name/directional/north,
+/obj/structure/cable,
+/turf/open/floor/iron/dark,
+/area/station/hallway/secondary/service)
 "mLP" = (
 /obj/effect/mapping_helpers/airlock/access/all/security/general,
 /obj/effect/turf_decal/stripes/line,
@@ -52012,7 +52052,6 @@
 /turf/open/floor/iron,
 /area/station/security/warden)
 "nbs" = (
-/obj/machinery/status_display/evac/directional/south,
 /obj/effect/turf_decal/trimline/neutral/warning{
 	dir = 1
 	},
@@ -52025,10 +52064,10 @@
 /turf/open/floor/iron/dark/textured_half,
 /area/station/medical/morgue)
 "nbv" = (
-/obj/machinery/atmospherics/components/unary/portables_connector/visible{
-	dir = 4
-	},
 /obj/effect/turf_decal/stripes/corner{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/visible{
 	dir = 1
 	},
 /turf/open/floor/iron,
@@ -52445,6 +52484,24 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/science/explab)
+"nht" = (
+/obj/effect/turf_decal/tile/neutral/half/contrasted{
+	dir = 1
+	},
+/obj/structure/sign/calendar/directional/north,
+/turf/open/floor/iron,
+/area/station/commons/dorms)
+"nhw" = (
+/obj/structure/chair/office/light{
+	dir = 1
+	},
+/obj/effect/turf_decal/siding/purple,
+/obj/effect/turf_decal/tile/purple/half/contrasted,
+/obj/structure/disposalpipe/segment{
+	dir = 10
+	},
+/turf/open/floor/iron,
+/area/station/science/xenobiology)
 "nhA" = (
 /obj/machinery/atmospherics/components/unary/portables_connector/visible{
 	dir = 8
@@ -53954,11 +54011,13 @@
 /turf/open/floor/iron,
 /area/station/security/checkpoint/arrivals)
 "nBJ" = (
+/obj/effect/turf_decal/tile/neutral/fourcorners,
 /obj/machinery/door/poddoor/preopen{
 	id = "bridgedoors";
-	name = "Bridge Access Blast Door"
+	name = "Bridge Access Blast Door";
+	dir = 4;
+	manual_align = 1
 	},
-/obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron/dark,
 /area/station/command/bridge)
 "nBL" = (
@@ -54268,9 +54327,6 @@
 /area/station/maintenance/department/science)
 "nGC" = (
 /obj/machinery/vending/hydroseeds,
-/obj/machinery/light_switch/directional/north{
-	pixel_x = -8
-	},
 /obj/machinery/light/small/directional/north,
 /turf/open/floor/iron/dark,
 /area/station/service/hydroponics/garden)
@@ -54532,7 +54588,6 @@
 /turf/open/floor/iron,
 /area/station/security/prison)
 "nJh" = (
-/obj/machinery/firealarm/directional/north,
 /obj/item/stack/medical/gauze,
 /obj/item/stack/medical/mesh,
 /obj/structure/table/reinforced/rglass,
@@ -55320,8 +55375,8 @@
 /turf/open/floor/wood,
 /area/station/commons/dorms)
 "nUc" = (
-/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/visible{
-	dir = 4
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible{
+	dir = 9
 	},
 /turf/open/floor/iron,
 /area/station/engineering/atmos/hfr_room)
@@ -55506,6 +55561,7 @@
 /obj/machinery/light_switch/directional/south{
 	pixel_x = 8
 	},
+/obj/machinery/light_switch/directional/west,
 /turf/open/floor/wood,
 /area/station/hallway/secondary/service)
 "nWY" = (
@@ -55557,6 +55613,8 @@
 /obj/effect/turf_decal/tile/yellow{
 	dir = 8
 	},
+/obj/structure/closet/radiation,
+/obj/item/analyzer,
 /turf/open/floor/iron/dark/corner,
 /area/station/maintenance/disposal/incinerator)
 "nXH" = (
@@ -56001,13 +56059,13 @@
 /area/station/hallway/secondary/entry)
 "odc" = (
 /obj/structure/reagent_dispensers/water_cooler,
-/obj/machinery/newscaster/directional/south,
 /obj/machinery/camera/directional/east{
 	c_tag = "Medbay - Paramedic Dispatch";
 	name = "medbay camera";
 	network = list("ss13","medbay")
 	},
 /obj/effect/turf_decal/tile/blue,
+/obj/machinery/light/small/directional/south,
 /turf/open/floor/iron/white,
 /area/station/medical/paramedic)
 "odd" = (
@@ -56140,15 +56198,12 @@
 /area/station/maintenance/port)
 "ofu" = (
 /obj/structure/cable,
-/obj/structure/sign/warning/no_smoking/directional/north,
-/obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/smart/simple/green/visible{
 	dir = 6
 	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 4
-	},
-/turf/open/floor/iron/checker,
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/machinery/airalarm/directional/north,
+/turf/open/floor/iron/dark,
 /area/station/maintenance/disposal/incinerator)
 "ofx" = (
 /obj/structure/cable,
@@ -56363,6 +56418,43 @@
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron,
 /area/station/construction/mining/aux_base)
+"oip" = (
+/obj/structure/table/reinforced,
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/machinery/button/door/table{
+	pixel_x = 6;
+	pixel_y = 12;
+	id = "atmoslock";
+	name = "Atmospherics Lockdown Control";
+	req_access = list("atmospherics")
+	},
+/obj/machinery/keycard_auth{
+	pixel_y = -6;
+	pixel_x = 1
+	},
+/obj/machinery/button/door/table{
+	pixel_x = -5;
+	pixel_y = 4;
+	id = "transitlock";
+	name = "Transit Tube Lockdown Control";
+	req_access = list("command")
+	},
+/obj/machinery/button/door/table{
+	pixel_x = -5;
+	pixel_y = 12;
+	id = "engstorage";
+	name = "Engineering Secure Storage Control";
+	req_access = list("engine_equip")
+	},
+/obj/machinery/button/door/table{
+	pixel_x = 6;
+	pixel_y = 4;
+	id = "engielock";
+	name = "Engineering Lockdown Control";
+	req_access = list("engineering")
+	},
+/turf/open/floor/iron,
+/area/station/command/heads_quarters/ce)
 "ois" = (
 /obj/structure/table/glass,
 /obj/effect/decal/cleanable/dirt,
@@ -56865,7 +56957,9 @@
 "ooq" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/security/glass{
-	name = "Brig"
+	name = "Brig";
+	manual_align = 1;
+	dir = 4
 	},
 /obj/structure/cable,
 /obj/effect/mapping_helpers/airlock/cyclelink_helper_multi{
@@ -57141,9 +57235,10 @@
 "osO" = (
 /obj/machinery/disposal/bin,
 /obj/effect/turf_decal/bot,
-/obj/item/radio/intercom/directional/north,
 /obj/structure/disposalpipe/trunk,
 /obj/effect/turf_decal/tile/neutral/anticorner/contrasted,
+/obj/structure/sign/warning/secure_area/directional/north,
+/obj/item/radio/intercom/directional/west,
 /turf/open/floor/iron,
 /area/station/command/heads_quarters/rd)
 "osR" = (
@@ -58272,7 +58367,6 @@
 /area/station/cargo/storage)
 "oJW" = (
 /obj/structure/closet/secure_closet/evidence,
-/obj/item/radio/intercom/directional/south,
 /obj/machinery/light/small/directional/south,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron/dark,
@@ -59535,7 +59629,7 @@
 /obj/effect/turf_decal/trimline/purple/filled/corner{
 	dir = 4
 	},
-/obj/machinery/airalarm/directional/north,
+/obj/machinery/light/directional/north,
 /turf/open/floor/iron/white,
 /area/station/science/research)
 "pca" = (
@@ -59754,13 +59848,14 @@
 /area/station/commons/fitness/recreation)
 "pen" = (
 /obj/effect/turf_decal/bot,
-/obj/structure/disposalpipe/trunk{
-	dir = 1
-	},
 /obj/effect/turf_decal/tile/neutral/anticorner/contrasted{
 	dir = 1
 	},
-/obj/machinery/disposal/bin/tagger,
+/obj/structure/rack,
+/obj/item/crowbar,
+/obj/item/wrench,
+/obj/item/clothing/mask/gas,
+/obj/machinery/light_switch/directional/east,
 /turf/open/floor/iron,
 /area/station/science/xenobiology)
 "peo" = (
@@ -59986,6 +60081,7 @@
 /obj/effect/turf_decal/tile/red/opposingcorners{
 	dir = 1
 	},
+/obj/machinery/digital_clock/directional/east,
 /turf/open/floor/iron,
 /area/station/commons/lounge)
 "pgP" = (
@@ -60439,13 +60535,13 @@
 /obj/effect/turf_decal/loading_area,
 /turf/open/floor/iron,
 /area/station/command/teleporter)
+"plG" = (
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/iron/dark,
+/area/station/engineering/atmos/hfr_room)
 "plK" = (
-/obj/structure/disposalpipe/segment{
-	dir = 10
-	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
-	dir = 4
-	},
+/obj/effect/turf_decal/siding/yellow,
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible,
 /turf/open/floor/iron,
 /area/station/engineering/atmos/hfr_room)
 "plO" = (
@@ -61608,9 +61704,6 @@
 	},
 /area/station/hallway/secondary/entry)
 "pBw" = (
-/obj/machinery/status_display/supply{
-	pixel_y = 32
-	},
 /obj/effect/turf_decal/arrows{
 	dir = 4
 	},
@@ -61618,6 +61711,7 @@
 	c_tag = "Cargo - Waiting Room";
 	name = "cargo camera"
 	},
+/obj/machinery/status_display/supply,
 /turf/open/floor/iron,
 /area/station/cargo/lobby)
 "pBB" = (
@@ -61642,6 +61736,7 @@
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible{
 	dir = 10
 	},
+/obj/structure/lattice/catwalk,
 /turf/open/space/basic,
 /area/space/nearstation)
 "pBM" = (
@@ -61680,9 +61775,6 @@
 /obj/structure/table,
 /obj/item/clipboard,
 /obj/item/toy/figure/cargotech,
-/obj/machinery/status_display/supply{
-	pixel_y = -32
-	},
 /obj/effect/turf_decal/tile/brown/half/contrasted,
 /turf/open/floor/iron,
 /area/station/cargo/office)
@@ -61752,7 +61844,6 @@
 /obj/effect/turf_decal/siding/thinplating/dark{
 	dir = 1
 	},
-/obj/structure/sign/xenobio_guide/directional/south,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron/dark,
 /area/station/science/xenobiology)
@@ -61898,7 +61989,7 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/tile/yellow/opposingcorners,
-/obj/machinery/airalarm/directional/north,
+/obj/machinery/newscaster/directional/north,
 /turf/open/floor/iron,
 /area/station/commons/lounge)
 "pEU" = (
@@ -61967,6 +62058,7 @@
 /area/station/engineering/main)
 "pFu" = (
 /obj/effect/turf_decal/stripes/corner,
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/iron,
 /area/station/engineering/atmos/hfr_room)
 "pFy" = (
@@ -62090,12 +62182,14 @@
 /area/station/service/kitchen/abandoned)
 "pGC" = (
 /obj/item/kirbyplants/random,
-/obj/machinery/light_switch/directional/north{
-	pixel_x = -8
-	},
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron/dark,
 /area/station/service/abandoned_gambling_den/gaming)
+"pGF" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/iron/dark,
+/area/station/engineering/atmos/hfr_room)
 "pGJ" = (
 /obj/structure/table/reinforced,
 /obj/item/folder/blue{
@@ -63438,7 +63532,6 @@
 "pWb" = (
 /obj/machinery/washing_machine,
 /obj/effect/decal/cleanable/cobweb,
-/obj/structure/sign/warning/electric_shock/directional/west,
 /obj/effect/turf_decal/tile/yellow{
 	dir = 1
 	},
@@ -63469,7 +63562,6 @@
 /obj/machinery/firealarm/directional/north,
 /obj/machinery/camera/directional/north{
 	c_tag = "Service - Service Hall";
-	dir = 9;
 	name = "service camera"
 	},
 /turf/open/floor/iron/dark,
@@ -63595,6 +63687,7 @@
 "pXB" = (
 /obj/structure/table/reinforced,
 /obj/machinery/coffeemaker/impressa,
+/obj/machinery/newscaster/directional/north,
 /turf/open/floor/wood,
 /area/station/engineering/break_room)
 "pXK" = (
@@ -63693,7 +63786,6 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/structure/sign/warning/secure_area/directional/south,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron,
@@ -63702,10 +63794,9 @@
 /obj/effect/turf_decal/tile/red{
 	dir = 4
 	},
-/obj/machinery/status_display/door_timer{
+/obj/machinery/status_display/door_timer/directional/west{
 	id = "Isolation_Cell";
-	name = "Isolation Cell";
-	pixel_x = -32
+	name = "Isolation Cell"
 	},
 /turf/open/floor/iron,
 /area/station/security/execution/transfer)
@@ -64141,7 +64232,6 @@
 /area/station/command/bridge)
 "qeF" = (
 /obj/effect/turf_decal/bot,
-/obj/machinery/airalarm/directional/south,
 /obj/structure/rack,
 /obj/item/book/manual/wiki/medicine{
 	pixel_x = -4;
@@ -64225,13 +64315,11 @@
 /turf/open/floor/iron/dark,
 /area/station/maintenance/department/science)
 "qfO" = (
-/obj/structure/disposalpipe/segment,
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/simple/dark/visible{
 	dir = 4
 	},
 /obj/effect/turf_decal/tile/neutral/fourcorners,
-/obj/structure/sign/warning/deathsposal,
 /turf/open/floor/iron/dark,
 /area/station/maintenance/disposal/incinerator)
 "qfP" = (
@@ -65863,6 +65951,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/iron,
 /area/station/maintenance/disposal/incinerator)
 "qCC" = (
@@ -66157,6 +66246,7 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/tile/yellow/opposingcorners,
+/obj/machinery/airalarm/directional/south,
 /turf/open/floor/iron,
 /area/station/commons/lounge)
 "qGQ" = (
@@ -66311,7 +66401,9 @@
 /area/station/security/detectives_office/private_investigators_office)
 "qIv" = (
 /obj/structure/table/reinforced,
-/obj/machinery/cell_charger,
+/obj/machinery/cell_charger{
+	pixel_y = 0
+	},
 /obj/item/stock_parts/power_store/cell/high,
 /obj/machinery/firealarm/directional/south,
 /obj/machinery/light_switch/directional/east,
@@ -66487,13 +66579,13 @@
 /obj/effect/turf_decal/bot,
 /obj/effect/landmark/start/hangover,
 /obj/machinery/newscaster/directional/west,
-/obj/machinery/button/door/directional/south{
+/obj/effect/landmark/start/assistant,
+/obj/machinery/button/door/directional/east{
 	id = "Toilet2";
 	name = "Lock Control";
 	normaldoorcontrol = 1;
 	specialfunctions = 4
 	},
-/obj/effect/landmark/start/assistant,
 /turf/open/floor/iron,
 /area/station/commons/toilet/locker)
 "qKH" = (
@@ -66610,6 +66702,9 @@
 	},
 /obj/effect/turf_decal/siding/purple,
 /obj/effect/turf_decal/tile/purple/half/contrasted,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/open/floor/iron,
 /area/station/science/xenobiology)
 "qLw" = (
@@ -66800,6 +66895,7 @@
 	department = "Garden";
 	name = "Garden Requests Console"
 	},
+/obj/machinery/light_switch/directional/north,
 /turf/open/floor/iron/dark,
 /area/station/service/hydroponics/garden)
 "qNK" = (
@@ -67620,9 +67716,6 @@
 /area/station/command/corporate_showroom)
 "raL" = (
 /obj/structure/cable,
-/obj/structure/disposalpipe/segment{
-	dir = 6
-	},
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/layer_manifold/green/visible{
 	dir = 4
@@ -67775,10 +67868,12 @@
 /turf/open/floor/iron/white/smooth_large,
 /area/station/science/robotics/lab)
 "rdq" = (
-/obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
+/obj/structure/disposalpipe/junction{
+	dir = 1
+	},
 /turf/open/floor/iron,
 /area/station/science/xenobiology)
 "rdu" = (
@@ -67973,7 +68068,6 @@
 /obj/effect/turf_decal/stripes/corner{
 	dir = 1
 	},
-/obj/machinery/light/directional/north,
 /turf/open/floor/iron/white,
 /area/station/science/research)
 "rgf" = (
@@ -69426,9 +69520,6 @@
 /turf/open/floor/carpet/red,
 /area/station/hallway/secondary/service)
 "ryl" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
@@ -69727,9 +69818,6 @@
 /obj/effect/mapping_helpers/airlock/cyclelink_helper_multi{
 	cycle_id = "bridge-right"
 	},
-/obj/machinery/door/airlock/command/glass{
-	name = "Bridge Access"
-	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
@@ -69738,6 +69826,11 @@
 	},
 /obj/effect/mapping_helpers/airlock/access/all/command/general,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/machinery/door/airlock/command/glass{
+	name = "Bridge Access";
+	dir = 4;
+	manual_align = 1
+	},
 /turf/open/floor/iron/dark,
 /area/station/command/bridge)
 "rCc" = (
@@ -69975,7 +70068,6 @@
 	c_tag = "Security - Office Fore";
 	dir = 9
 	},
-/obj/machinery/airalarm/directional/north,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /obj/machinery/light/directional/north,
 /obj/machinery/disposal/bin/tagger,
@@ -70066,16 +70158,16 @@
 "rHn" = (
 /obj/structure/table/wood,
 /obj/structure/window/reinforced/spawner/directional/east,
-/obj/item/folder/blue,
+/obj/item/folder/blue{
+	pixel_y = 3
+	},
 /obj/item/pen,
+/obj/item/taperecorder{
+	pixel_y = -6;
+	pixel_x = -2
+	},
 /turf/open/floor/iron/grimy,
 /area/station/command/bridge)
-"rHp" = (
-/obj/machinery/portable_atmospherics/canister/plasma,
-/obj/effect/turf_decal/bot,
-/obj/item/radio/intercom/directional/west,
-/turf/open/floor/iron/dark/textured,
-/area/station/science/ordnance/storage)
 "rHq" = (
 /obj/structure/chair/office,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
@@ -70596,11 +70688,6 @@
 /area/station/engineering/atmos/storage/gas)
 "rNV" = (
 /obj/item/kirbyplants/random,
-/obj/machinery/status_display/door_timer{
-	id = "brig1";
-	name = "Cell 1";
-	pixel_x = -32
-	},
 /obj/machinery/light/directional/west,
 /obj/machinery/camera/directional/west{
 	c_tag = "Security - Brig Center"
@@ -70609,6 +70696,10 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/turf_decal/tile/red/half/contrasted{
 	dir = 8
+	},
+/obj/machinery/status_display/door_timer/directional/west{
+	id = "brig1";
+	name = "Cell 1"
 	},
 /turf/open/floor/iron,
 /area/station/security/brig)
@@ -70740,6 +70831,7 @@
 /obj/effect/turf_decal/tile/purple{
 	dir = 4
 	},
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/iron/white,
 /area/station/science/xenobiology)
 "rOX" = (
@@ -70947,9 +71039,6 @@
 /turf/open/floor/wood,
 /area/station/maintenance/port/aft)
 "rQI" = (
-/obj/machinery/airlock_sensor/incinerator_atmos{
-	pixel_x = 24
-	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden,
 /obj/machinery/light/small/directional/south,
 /turf/open/floor/engine,
@@ -71163,10 +71252,10 @@
 "rSZ" = (
 /obj/machinery/vending/cigarette,
 /obj/effect/turf_decal/delivery,
-/obj/item/radio/intercom/directional/south,
 /obj/effect/turf_decal/tile/neutral/half/contrasted{
 	dir = 1
 	},
+/obj/structure/extinguisher_cabinet/directional/south,
 /turf/open/floor/iron/dark,
 /area/station/engineering/break_room)
 "rTr" = (
@@ -71181,9 +71270,7 @@
 /turf/open/floor/iron,
 /area/station/cargo/lobby)
 "rTB" = (
-/obj/machinery/status_display/supply{
-	pixel_y = 32
-	},
+/obj/machinery/status_display/supply,
 /turf/open/floor/iron,
 /area/station/cargo/storage)
 "rTG" = (
@@ -71815,10 +71902,10 @@
 /area/station/service/kitchen/abandoned)
 "saR" = (
 /obj/machinery/disposal/bin,
-/obj/structure/extinguisher_cabinet/directional/north,
 /obj/effect/turf_decal/bot,
 /obj/structure/disposalpipe/trunk,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/machinery/light_switch/directional/north,
 /turf/open/floor/iron/dark,
 /area/station/command/heads_quarters/ce)
 "saS" = (
@@ -71854,14 +71941,6 @@
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron/dark,
 /area/station/security/interrogation)
-"sbl" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/stripes/line{
-	dir = 10
-	},
-/obj/structure/sign/warning/biohazard/directional/south,
-/turf/open/floor/iron,
-/area/station/maintenance/department/science)
 "sbP" = (
 /obj/structure/disposalpipe/segment,
 /obj/effect/decal/cleanable/dirt,
@@ -72221,6 +72300,7 @@
 /obj/structure/cable,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /obj/effect/turf_decal/tile/red,
+/obj/structure/extinguisher_cabinet/directional/north,
 /turf/open/floor/iron,
 /area/station/security/execution/transfer)
 "sgj" = (
@@ -72747,11 +72827,6 @@
 	},
 /turf/open/floor/plating,
 /area/station/science/genetics)
-"snK" = (
-/obj/machinery/atmospherics/pipe/smart/simple/dark/visible,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron,
-/area/station/maintenance/disposal/incinerator)
 "snW" = (
 /obj/structure/rack,
 /obj/effect/turf_decal/bot,
@@ -72966,15 +73041,12 @@
 	},
 /area/station/science/lobby)
 "srd" = (
-/obj/structure/disposalpipe/trunk{
-	dir = 1
-	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/disposal/bin,
 /obj/effect/turf_decal/tile/yellow{
 	dir = 8
 	},
+/obj/structure/table/reinforced,
 /turf/open/floor/iron/checker,
 /area/station/maintenance/disposal/incinerator)
 "srg" = (
@@ -73247,6 +73319,7 @@
 /obj/machinery/modular_computer/preset/civilian,
 /obj/effect/turf_decal/bot,
 /obj/effect/turf_decal/tile/neutral/half/contrasted,
+/obj/machinery/status_display/ai/directional/north,
 /turf/open/floor/iron/dark,
 /area/station/engineering/storage_shared)
 "suQ" = (
@@ -73633,6 +73706,9 @@
 /obj/effect/turf_decal/trimline/purple/filled/mid_joiner{
 	dir = 4
 	},
+/obj/item/radio/intercom/directional/east{
+	pixel_y = 2
+	},
 /turf/open/floor/iron/white/smooth_large,
 /area/station/science/ordnance/storage)
 "szn" = (
@@ -73686,7 +73762,6 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/xenoblood,
 /obj/effect/decal/cleanable/cobweb/cobweb2,
-/obj/structure/sign/warning/xeno_mining/directional/north,
 /turf/open/floor/iron/smooth,
 /area/station/maintenance/department/science/xenobiology)
 "sAm" = (
@@ -74172,6 +74247,9 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 9
 	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
+	dir = 4
+	},
 /turf/open/floor/iron,
 /area/station/engineering/atmos/hfr_room)
 "sHn" = (
@@ -74384,10 +74462,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/circuit/green,
 /area/station/ai_monitored/command/nuke_storage)
-"sJF" = (
-/obj/machinery/button/ignition/incinerator/atmos,
-/turf/closed/wall/r_wall,
-/area/station/maintenance/disposal/incinerator)
 "sJG" = (
 /obj/item/reagent_containers/chem_pack{
 	pixel_x = 3;
@@ -74975,6 +75049,10 @@
 /obj/effect/turf_decal/tile/brown/half/contrasted{
 	dir = 4
 	},
+/obj/machinery/camera/directional/east{
+	c_tag = "Cargo Bay - Drone Bay";
+	name = "cargo camera"
+	},
 /turf/open/floor/iron,
 /area/station/cargo/drone_bay)
 "sRd" = (
@@ -75089,10 +75167,8 @@
 "sSZ" = (
 /obj/machinery/button/door/directional/north{
 	id = "surgery_shutters";
-	name = "Privacy Shutters";
-	pixel_y = 36
+	name = "Privacy Shutters"
 	},
-/obj/machinery/light_switch/directional/north,
 /obj/structure/window/reinforced/spawner/directional/east,
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 1
@@ -75744,15 +75820,14 @@
 /area/station/maintenance/department/chapel)
 "tbZ" = (
 /obj/item/kirbyplants/random,
-/obj/machinery/status_display/door_timer{
-	id = "brig2";
-	name = "Cell 2";
-	pixel_x = -32
-	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/turf_decal/tile/red{
 	dir = 1
+	},
+/obj/machinery/status_display/door_timer/directional/west{
+	id = "brig2";
+	name = "Cell 2"
 	},
 /turf/open/floor/iron,
 /area/station/security/brig)
@@ -75796,6 +75871,7 @@
 /obj/effect/turf_decal/tile/blue/half/contrasted{
 	dir = 1
 	},
+/obj/structure/fireaxecabinet/directional/north,
 /turf/open/floor/iron/dark,
 /area/station/command/bridge)
 "tcn" = (
@@ -76237,9 +76313,6 @@
 /area/station/commons/dorms)
 "thO" = (
 /obj/structure/cable,
-/obj/structure/disposalpipe/junction{
-	dir = 1
-	},
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron/dark,
 /area/station/maintenance/disposal/incinerator)
@@ -76631,6 +76704,7 @@
 /obj/effect/turf_decal/trimline/neutral/warning{
 	dir = 8
 	},
+/obj/structure/extinguisher_cabinet/directional/north,
 /turf/open/floor/iron/dark/textured_half{
 	dir = 1
 	},
@@ -77040,7 +77114,6 @@
 /turf/open/floor/iron/white,
 /area/station/command/heads_quarters/rd)
 "tug" = (
-/obj/structure/disposalpipe/segment,
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
@@ -77059,10 +77132,10 @@
 /turf/open/floor/engine,
 /area/station/science/explab)
 "tuk" = (
-/obj/structure/disposalpipe/junction/flip{
-	dir = 8
-	},
 /obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/open/floor/iron/dark,
 /area/station/science/xenobiology)
 "tum" = (
@@ -77212,9 +77285,6 @@
 "tvF" = (
 /obj/structure/cable,
 /obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/command/glass{
-	name = "Bridge Access"
-	},
 /obj/effect/landmark/navigate_destination,
 /obj/effect/mapping_helpers/airlock/cyclelink_helper_multi{
 	cycle_id = "bridge-right"
@@ -77227,6 +77297,11 @@
 	},
 /obj/effect/mapping_helpers/airlock/access/all/command/general,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/machinery/door/airlock/command/glass{
+	name = "Bridge Access";
+	dir = 4;
+	manual_align = 1
+	},
 /turf/open/floor/iron/dark,
 /area/station/command/bridge)
 "tvG" = (
@@ -77395,11 +77470,10 @@
 /turf/open/floor/plating,
 /area/station/engineering/atmos/hfr_room)
 "tzj" = (
-/obj/structure/disposalpipe/trunk{
+/obj/machinery/atmospherics/components/unary/portables_connector/visible{
 	dir = 1
 	},
-/obj/machinery/disposal/bin,
-/obj/effect/turf_decal/bot,
+/obj/effect/turf_decal/bot_red,
 /turf/open/floor/iron/dark,
 /area/station/engineering/atmos/hfr_room)
 "tzm" = (
@@ -77869,12 +77943,6 @@
 "tEw" = (
 /obj/structure/table/reinforced,
 /obj/item/flashlight/lamp,
-/obj/effect/turf_decal/tile/neutral/fourcorners,
-/turf/open/floor/iron,
-/area/station/command/heads_quarters/ce)
-"tEE" = (
-/obj/structure/table/reinforced,
-/obj/machinery/keycard_auth,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron,
 /area/station/command/heads_quarters/ce)
@@ -78853,7 +78921,9 @@
 /turf/open/floor/iron/white,
 /area/station/science/lobby)
 "tQz" = (
-/obj/machinery/door/poddoor/incinerator_atmos_main,
+/obj/machinery/door/poddoor/incinerator_atmos_main{
+	manual_align = 1
+	},
 /turf/open/floor/engine,
 /area/station/maintenance/disposal/incinerator)
 "tQE" = (
@@ -78961,14 +79031,6 @@
 /mob/living/carbon/human/species/monkey,
 /turf/open/floor/iron/white,
 /area/station/medical/virology)
-"tSa" = (
-/obj/effect/turf_decal/tile/red/opposingcorners{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/yellow/opposingcorners,
-/obj/machinery/digital_clock/directional/south,
-/turf/open/floor/iron,
-/area/station/commons/lounge)
 "tSh" = (
 /obj/structure/cable,
 /obj/effect/mapping_helpers/broken_floor,
@@ -79704,6 +79766,7 @@
 /obj/machinery/computer/operating,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /obj/effect/turf_decal/bot_white,
+/obj/machinery/airalarm/directional/east,
 /turf/open/floor/iron/dark,
 /area/station/medical/surgery/theatre)
 "ubL" = (
@@ -80434,19 +80497,6 @@
 /obj/machinery/door/firedoor/border_only,
 /turf/open/floor/wood,
 /area/station/service/theater)
-"ulQ" = (
-/obj/machinery/status_display/evac/directional/north,
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/camera/directional/north{
-	c_tag = "Arrivals - Garden Access";
-	dir = 9;
-	name = "arrivals camera"
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/turf/open/floor/iron,
-/area/station/hallway/secondary/entry)
 "ulR" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/duct,
@@ -80796,10 +80846,10 @@
 "upX" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/status_display/evac/directional/north,
 /obj/effect/turf_decal/tile/brown{
 	dir = 4
 	},
+/obj/machinery/status_display/supply,
 /turf/open/floor/iron,
 /area/station/hallway/primary/central/fore)
 "uqd" = (
@@ -81144,9 +81194,6 @@
 /turf/open/floor/iron/dark,
 /area/station/hallway/primary/central/fore)
 "uuC" = (
-/obj/structure/disposalpipe/segment{
-	dir = 9
-	},
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/stripes/line{
 	dir = 9
@@ -81155,6 +81202,7 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/box/corners,
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/iron,
 /area/station/maintenance/disposal/incinerator)
 "uuJ" = (
@@ -81304,6 +81352,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
+/obj/machinery/status_display/supply,
 /turf/open/floor/iron,
 /area/station/hallway/primary/central/fore)
 "uwL" = (
@@ -81316,6 +81365,7 @@
 /obj/structure/bodycontainer/morgue{
 	dir = 2
 	},
+/obj/machinery/status_display/ai/directional/north,
 /turf/open/floor/iron/dark/textured_half{
 	dir = 1
 	},
@@ -81780,6 +81830,7 @@
 /obj/effect/turf_decal/tile/blue{
 	dir = 8
 	},
+/obj/machinery/firealarm/directional/south,
 /turf/open/floor/iron/white,
 /area/station/medical/paramedic)
 "uCp" = (
@@ -81831,14 +81882,6 @@
 	},
 /turf/open/floor/iron,
 /area/station/engineering/lobby)
-"uDk" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/structure/sign/warning/secure_area/directional/south,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating,
-/area/station/maintenance/port)
 "uDl" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/door/poddoor/shutters/preopen{
@@ -82022,7 +82065,6 @@
 /obj/structure/table/reinforced,
 /obj/item/paper_bin,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
-/obj/machinery/incident_display/bridge/directional/south,
 /turf/open/floor/iron/dark,
 /area/station/command/bridge)
 "uFX" = (
@@ -82507,7 +82549,6 @@
 /turf/open/floor/iron,
 /area/station/engineering/break_room)
 "uLx" = (
-/obj/machinery/status_display/ai/directional/south,
 /obj/effect/turf_decal/siding/thinplating/dark/corner,
 /obj/effect/turf_decal/siding/thinplating/dark{
 	dir = 8
@@ -82762,7 +82803,6 @@
 /obj/effect/turf_decal/tile/purple{
 	dir = 1
 	},
-/obj/machinery/hydroponics/constructable,
 /turf/open/floor/iron/white,
 /area/station/science/xenobiology)
 "uOH" = (
@@ -83396,7 +83436,6 @@
 "uWm" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/xenoblood,
-/obj/structure/sign/warning/xeno_mining/directional/south,
 /turf/open/floor/iron/smooth,
 /area/station/maintenance/department/science/xenobiology)
 "uWI" = (
@@ -83868,7 +83907,6 @@
 	dir = 4;
 	id = "garbage"
 	},
-/obj/structure/sign/warning/vacuum/directional/north,
 /obj/effect/turf_decal/stripes/line,
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -84212,9 +84250,6 @@
 /area/station/service/bar/backroom)
 "vhW" = (
 /obj/item/kirbyplants/random,
-/obj/structure/sign/warning/pods/directional/south{
-	dir = 8
-	},
 /obj/effect/turf_decal/tile/red/half/contrasted{
 	dir = 4
 	},
@@ -84229,6 +84264,7 @@
 	},
 /obj/structure/closet,
 /obj/effect/turf_decal/trimline/dark_blue/filled/line,
+/obj/machinery/light_switch/directional/east,
 /turf/open/floor/iron/dark,
 /area/station/medical/morgue)
 "vii" = (
@@ -84259,32 +84295,6 @@
 /turf/open/floor/iron,
 /area/station/security/checkpoint/escape)
 "viB" = (
-/obj/machinery/button/door/directional/west{
-	id = "engielock";
-	name = "Engineering Lockdown Control";
-	pixel_y = -8;
-	req_access = list("engineering")
-	},
-/obj/machinery/button/door/directional/west{
-	id = "atmoslock";
-	name = "Atmospherics Lockdown Control";
-	pixel_y = 4;
-	req_access = list("atmospherics")
-	},
-/obj/machinery/button/door/directional/west{
-	id = "engstorage";
-	name = "Engineering Secure Storage Control";
-	pixel_x = -36;
-	pixel_y = 4;
-	req_access = list("engine_equip")
-	},
-/obj/machinery/button/door/directional/west{
-	id = "transitlock";
-	name = "Transit Tube Lockdown Control";
-	pixel_x = -36;
-	pixel_y = -8;
-	req_access = list("command")
-	},
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron/dark,
 /area/station/command/heads_quarters/ce)
@@ -84977,6 +84987,7 @@
 /obj/effect/turf_decal/tile/blue/half/contrasted{
 	dir = 1
 	},
+/obj/machinery/incident_display/bridge/directional/north,
 /turf/open/floor/iron/dark,
 /area/station/command/bridge)
 "vtc" = (
@@ -85200,6 +85211,7 @@
 "vvD" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/visible,
+/obj/machinery/button/ignition/incinerator/atmos/directional/north,
 /turf/open/floor/iron,
 /area/station/maintenance/disposal/incinerator)
 "vvF" = (
@@ -85900,23 +85912,12 @@
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron/dark,
 /area/station/command/heads_quarters/captain)
-"vDw" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/green/visible/layer2,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 4
-	},
-/turf/open/floor/iron/dark/corner{
-	dir = 1
-	},
-/area/station/maintenance/disposal/incinerator)
 "vDy" = (
 /obj/structure/disposalpipe/segment,
 /obj/effect/turf_decal/trimline/blue/filled/corner{
 	dir = 1
 	},
 /obj/structure/sink/directional/east,
-/obj/structure/mirror/directional/west,
 /turf/open/floor/iron/dark,
 /area/station/medical/morgue)
 "vDH" = (
@@ -86782,10 +86783,10 @@
 /turf/open/floor/iron,
 /area/station/science/robotics/lab)
 "vPZ" = (
+/obj/machinery/atmospherics/pipe/smart/simple/dark/visible,
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
-/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
 /area/station/maintenance/disposal/incinerator)
 "vQb" = (
@@ -87330,9 +87331,6 @@
 "vXP" = (
 /obj/structure/cable,
 /obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/command/glass{
-	name = "Bridge Access"
-	},
 /obj/effect/mapping_helpers/airlock/cyclelink_helper_multi{
 	cycle_id = "bridge-left"
 	},
@@ -87341,6 +87339,11 @@
 	},
 /obj/effect/mapping_helpers/airlock/access/all/command/general,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/machinery/door/airlock/command/glass{
+	name = "Bridge Access";
+	dir = 4;
+	manual_align = 1
+	},
 /turf/open/floor/iron/dark,
 /area/station/command/bridge)
 "vXQ" = (
@@ -87995,6 +87998,7 @@
 /obj/structure/closet/secure_closet/security,
 /obj/effect/turf_decal/bot,
 /obj/effect/turf_decal/tile/red/anticorner/contrasted,
+/obj/structure/reagent_dispensers/wall/peppertank/directional/east,
 /turf/open/floor/iron,
 /area/station/security/checkpoint/escape)
 "wgO" = (
@@ -88358,26 +88362,14 @@
 /area/station/engineering/atmos/storage)
 "wlH" = (
 /obj/structure/cable,
-/obj/machinery/button/door/incinerator_vent_atmos_aux{
-	pixel_x = -8;
-	pixel_y = 24
+/obj/structure/disposalpipe/trunk{
+	dir = 4
 	},
-/obj/machinery/button/door/incinerator_vent_atmos_main{
-	pixel_x = -8;
-	pixel_y = 36
-	},
-/obj/machinery/button/ignition/incinerator/atmos{
-	pixel_x = 8;
-	pixel_y = 36
-	},
-/obj/structure/closet/radiation,
-/obj/item/analyzer,
-/obj/effect/turf_decal/tile/yellow/opposingcorners{
-	dir = 1
-	},
-/turf/open/floor/iron/dark/corner{
-	dir = 1
-	},
+/obj/machinery/disposal/bin,
+/obj/structure/sign/warning/deathsposal/directional/north,
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/effect/turf_decal/bot,
+/turf/open/floor/iron/dark,
 /area/station/maintenance/disposal/incinerator)
 "wlI" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -88989,6 +88981,7 @@
 "wsd" = (
 /obj/machinery/monkey_recycler,
 /obj/effect/turf_decal/bot_red,
+/obj/structure/sign/xenobio_guide/directional/north,
 /turf/open/floor/iron/dark,
 /area/station/science/xenobiology)
 "wse" = (
@@ -89057,6 +89050,7 @@
 "wsT" = (
 /obj/structure/table/reinforced,
 /obj/machinery/microwave/engineering/cell_included,
+/obj/machinery/computer/security/telescreen/entertainment/directional/north,
 /turf/open/floor/wood,
 /area/station/engineering/break_room)
 "wsU" = (
@@ -89214,11 +89208,6 @@
 	},
 /turf/open/floor/iron/white,
 /area/station/science/ordnance/storage)
-"wuV" = (
-/obj/structure/fireaxecabinet/directional/south,
-/obj/effect/turf_decal/tile/blue/half/contrasted,
-/turf/open/floor/iron/dark,
-/area/station/command/bridge)
 "wuZ" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -89400,6 +89389,7 @@
 /obj/effect/turf_decal/tile/red/anticorner/contrasted{
 	dir = 1
 	},
+/obj/machinery/light_switch/directional/north,
 /turf/open/floor/iron,
 /area/station/security/checkpoint/escape)
 "wxo" = (
@@ -89480,6 +89470,7 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/sign/warning/test_chamber/directional/north,
 /turf/open/floor/iron/dark,
 /area/station/science/xenobiology)
 "wyH" = (
@@ -89498,14 +89489,11 @@
 /obj/item/taperecorder{
 	pixel_y = 7
 	},
-/obj/machinery/light_switch/directional/north{
-	pixel_x = 9;
-	pixel_y = 32
-	},
 /obj/effect/turf_decal/tile/neutral/anticorner/contrasted{
 	dir = 8
 	},
 /obj/machinery/light/small/directional/east,
+/obj/structure/sign/warning/secure_area/directional/north,
 /turf/open/floor/iron,
 /area/station/command/heads_quarters/rd)
 "wzb" = (
@@ -90332,6 +90320,9 @@
 	},
 /turf/open/floor/iron/white,
 /area/station/medical/pharmacy)
+"wIO" = (
+/turf/open/floor/engine,
+/area/station/maintenance/disposal/incinerator)
 "wJa" = (
 /obj/machinery/light/small/directional/west,
 /turf/open/floor/engine/vacuum,
@@ -90754,6 +90745,17 @@
 /obj/machinery/light/small/directional/south,
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/command/nuke_storage)
+"wPW" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/green/visible/layer2,
+/obj/machinery/atmospherics/pipe/smart/simple/dark/visible{
+	dir = 10
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/station/maintenance/disposal/incinerator)
 "wQo" = (
 /obj/structure/table/wood,
 /obj/machinery/recharger{
@@ -90960,21 +90962,7 @@
 /obj/machinery/atmospherics/pipe/smart/simple/dark/visible{
 	dir = 4
 	},
-/obj/machinery/door/airlock/public/glass/incinerator/atmos_interior,
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 8
-	},
-/obj/effect/mapping_helpers/airlock/locked,
-/obj/machinery/airlock_controller/incinerator_atmos{
-	pixel_y = -24
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/obj/effect/mapping_helpers/airlock/access/all/engineering/atmos,
+/obj/machinery/airlock_sensor/incinerator_atmos,
 /turf/open/floor/engine,
 /area/station/maintenance/disposal/incinerator)
 "wTg" = (
@@ -91288,6 +91276,11 @@
 "wZE" = (
 /turf/closed/wall,
 /area/station/maintenance/department/electrical)
+"wZS" = (
+/obj/structure/cable,
+/obj/structure/sign/calendar/directional/north,
+/turf/open/floor/wood,
+/area/station/command/meeting_room/council)
 "wZT" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
@@ -91328,7 +91321,6 @@
 /turf/open/floor/plating,
 /area/station/maintenance/solars/starboard/fore)
 "xao" = (
-/obj/machinery/status_display/evac/directional/north,
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -91433,6 +91425,10 @@
 	},
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
+	},
+/obj/machinery/camera/directional/north{
+	c_tag = "Arrivals - Garden Access";
+	name = "arrivals camera"
 	},
 /turf/open/floor/iron,
 /area/station/hallway/secondary/entry)
@@ -92728,7 +92724,6 @@
 /turf/open/floor/iron/dark,
 /area/station/command/bridge)
 "xrS" = (
-/obj/structure/sign/warning/secure_area/directional/south,
 /obj/effect/turf_decal/trimline/purple/filled/line{
 	dir = 6
 	},
@@ -92895,6 +92890,7 @@
 	name = "evidence closet"
 	},
 /obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/machinery/airalarm/directional/north,
 /turf/open/floor/iron/dark,
 /area/station/security/evidence)
 "xtf" = (
@@ -92910,9 +92906,6 @@
 "xtg" = (
 /obj/structure/cable,
 /obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/command/glass{
-	name = "Bridge Access"
-	},
 /obj/effect/mapping_helpers/airlock/cyclelink_helper_multi{
 	cycle_id = "bridge-right"
 	},
@@ -92924,6 +92917,11 @@
 	},
 /obj/effect/mapping_helpers/airlock/access/all/command/general,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/machinery/door/airlock/command/glass{
+	name = "Bridge Access";
+	dir = 4;
+	manual_align = 1
+	},
 /turf/open/floor/iron/dark,
 /area/station/command/bridge)
 "xtj" = (
@@ -93043,6 +93041,7 @@
 	name = "engineering camera"
 	},
 /obj/effect/turf_decal/tile/neutral/half/contrasted,
+/obj/machinery/newscaster/directional/north,
 /turf/open/floor/iron/dark,
 /area/station/engineering/storage_shared)
 "xvo" = (
@@ -93537,10 +93536,10 @@
 /area/station/security/detectives_office/private_investigators_office)
 "xAr" = (
 /obj/structure/mannequin/skeleton,
-/obj/machinery/status_display/ai/directional/north,
 /obj/effect/turf_decal/tile/dark_blue/half/contrasted{
 	dir = 1
 	},
+/obj/machinery/newscaster/directional/north,
 /turf/open/floor/iron/dark,
 /area/station/medical/morgue)
 "xAt" = (
@@ -93664,16 +93663,17 @@
 /turf/open/floor/circuit/telecomms/mainframe,
 /area/station/tcommsat/server)
 "xCb" = (
-/obj/machinery/light_switch/directional/east,
-/obj/structure/table,
-/obj/item/crowbar,
-/obj/item/wrench,
-/obj/item/clothing/mask/gas,
 /obj/effect/turf_decal/tile/neutral/half/contrasted{
 	dir = 8
 	},
 /obj/machinery/light/cold/directional/north,
-/obj/machinery/airalarm/directional/north,
+/obj/effect/turf_decal/bot,
+/obj/machinery/disposal/bin/tagger,
+/obj/structure/disposalpipe/trunk{
+	dir = 8
+	},
+/obj/structure/sign/warning/deathsposal/directional/north,
+/obj/machinery/airalarm/directional/east,
 /turf/open/floor/iron,
 /area/station/science/xenobiology)
 "xCf" = (
@@ -93753,10 +93753,10 @@
 /area/station/service/abandoned_gambling_den)
 "xDz" = (
 /obj/structure/chair/office/light,
-/obj/structure/sign/warning/secure_area/directional/west,
 /obj/effect/turf_decal/tile/neutral/anticorner/contrasted{
 	dir = 8
 	},
+/obj/structure/extinguisher_cabinet/directional/west,
 /turf/open/floor/iron,
 /area/station/science/xenobiology)
 "xDU" = (
@@ -94497,6 +94497,10 @@
 /obj/machinery/atmospherics/pipe/smart/simple/dark/visible{
 	dir = 5
 	},
+/obj/machinery/camera/directional/north{
+	c_tag = "Atmospherics - Incinerator Control";
+	name = "atmospherics camera"
+	},
 /turf/open/floor/iron,
 /area/station/maintenance/disposal/incinerator)
 "xMo" = (
@@ -94762,10 +94766,10 @@
 	dir = 4
 	},
 /obj/machinery/light/directional/north,
-/obj/machinery/airalarm/directional/north,
 /obj/effect/turf_decal/tile/yellow/half/contrasted{
 	dir = 1
 	},
+/obj/structure/sign/warning/no_smoking/directional/north,
 /turf/open/floor/iron,
 /area/station/engineering/lobby)
 "xQM" = (
@@ -94801,6 +94805,7 @@
 /obj/effect/turf_decal/tile/neutral/opposingcorners{
 	dir = 1
 	},
+/obj/machinery/light_switch/directional/east,
 /turf/open/floor/iron,
 /area/station/command/heads_quarters/rd)
 "xRo" = (
@@ -95285,6 +95290,7 @@
 /obj/effect/turf_decal/tile/red/half/contrasted{
 	dir = 8
 	},
+/obj/machinery/light/small/directional/west,
 /turf/open/floor/iron,
 /area/station/security/checkpoint/escape)
 "xYI" = (
@@ -95581,6 +95587,7 @@
 /obj/effect/turf_decal/tile/neutral/anticorner/contrasted{
 	dir = 4
 	},
+/obj/item/folder/white,
 /turf/open/floor/iron,
 /area/station/science/xenobiology)
 "ycz" = (
@@ -95795,6 +95802,8 @@
 /area/station/engineering/atmos)
 "yfY" = (
 /obj/item/radio/intercom/directional/east,
+/obj/effect/turf_decal/bot,
+/obj/structure/closet/secure_closet/atmospherics,
 /turf/open/floor/iron,
 /area/station/engineering/atmos/hfr_room)
 "yga" = (
@@ -115155,7 +115164,7 @@ rXu
 nCi
 mFq
 nCi
-iyO
+lLt
 kiP
 lBA
 iyO
@@ -115410,7 +115419,7 @@ nCi
 iUF
 gbe
 nCi
-vPU
+iBs
 nCi
 iyO
 iyO
@@ -115420,7 +115429,7 @@ iyO
 iyO
 iyO
 nCi
-vPU
+iBs
 cfb
 imw
 nCi
@@ -115848,7 +115857,7 @@ edx
 pEP
 edx
 edx
-hrs
+kYi
 efQ
 efQ
 efQ
@@ -116362,7 +116371,7 @@ edx
 luo
 edx
 edx
-vVc
+fsm
 pxN
 pxN
 pxN
@@ -116615,7 +116624,7 @@ pkp
 edx
 hfb
 edx
-sJF
+edx
 gSB
 pGt
 pEP
@@ -116867,7 +116876,7 @@ aaa
 aaa
 qYo
 kvq
-aaa
+qYo
 pBL
 mJH
 pHl
@@ -117125,10 +117134,10 @@ aaa
 qYo
 kvq
 qYo
-edx
+vVc
 edx
 wTc
-edx
+wIO
 edx
 ltx
 aIp
@@ -117382,11 +117391,11 @@ qYo
 qYo
 hNg
 vVc
+vVc
 edx
-vDw
 dtS
-ajf
-snK
+edx
+edx
 xMi
 dvA
 edx
@@ -117639,9 +117648,9 @@ aaa
 qYo
 kvq
 edx
+mJH
 edx
-cDK
-jff
+wPW
 vPZ
 jff
 kGI
@@ -118204,11 +118213,11 @@ bAR
 bAR
 iBR
 iBR
-dEL
+awN
 iBR
-dEL
+awN
 iBR
-dEL
+awN
 iBR
 gAw
 nOZ
@@ -119233,8 +119242,8 @@ bAR
 aBw
 gsV
 vEZ
+oip
 fzY
-tEE
 tEw
 aHE
 iov
@@ -121322,11 +121331,11 @@ qcM
 bYq
 pTC
 fIX
-qLu
+nhw
 rOV
 dan
 pGk
-iZU
+gIq
 gIq
 yeZ
 oSK
@@ -121493,9 +121502,9 @@ dYj
 hWz
 pFu
 cxc
-nBW
+pGF
 iaS
-uAK
+plG
 cij
 bzf
 wUZ
@@ -121547,7 +121556,7 @@ oGb
 lGF
 qOL
 iNJ
-elK
+tqo
 nOx
 xbD
 kgP
@@ -123124,7 +123133,7 @@ tGJ
 wEI
 cxb
 iaG
-sbl
+lUF
 wEI
 eTP
 jUx
@@ -125437,7 +125446,7 @@ kVT
 vcB
 xao
 tDE
-dyx
+aCA
 sIX
 xTB
 umC
@@ -126200,7 +126209,7 @@ wFE
 rrU
 wFE
 qcM
-uDk
+eHn
 pTC
 nzM
 cPa
@@ -127510,7 +127519,7 @@ hIB
 xop
 xop
 mcC
-rHp
+kLi
 rSR
 qgo
 qex
@@ -127751,7 +127760,7 @@ igg
 rgb
 kyD
 qmd
-bNU
+kmi
 bNU
 hiq
 dxZ
@@ -132594,7 +132603,7 @@ jeF
 bog
 kCV
 sQA
-tNL
+wZS
 jBt
 wSy
 eXf
@@ -132826,7 +132835,7 @@ pri
 qkA
 nWI
 bQN
-tSa
+msR
 vnU
 bTy
 eex
@@ -133620,7 +133629,7 @@ diL
 wco
 drj
 bog
-wuV
+nkU
 sQA
 awc
 ijB
@@ -134353,8 +134362,8 @@ kVP
 xSf
 mqV
 kVP
-giz
-giz
+mLE
+eko
 qSC
 lJJ
 maV
@@ -135374,7 +135383,7 @@ ogg
 uqK
 jJc
 jJc
-ulQ
+lEI
 iWA
 rkS
 qnI
@@ -138246,7 +138255,7 @@ diL
 cmE
 drj
 bog
-iMg
+nkU
 gOU
 cBE
 kDL
@@ -143081,7 +143090,7 @@ aac
 aac
 aad
 kic
-gdM
+bEc
 qvW
 rEb
 jMk
@@ -146766,7 +146775,7 @@ hLA
 vty
 kUC
 yaI
-ouy
+gHx
 gBQ
 nXH
 jcn
@@ -147280,7 +147289,7 @@ tFR
 yaI
 yaI
 yaI
-hnd
+ouy
 omY
 nXH
 pMS
@@ -148563,9 +148572,9 @@ sKM
 yaI
 bwS
 bXJ
-gEz
+tsc
 yaI
-ouy
+nht
 geH
 nXH
 gWF
@@ -150067,7 +150076,7 @@ tNy
 ukq
 vGX
 vgK
-aWO
+ajz
 dav
 aWO
 bLs
@@ -153126,7 +153135,7 @@ bCC
 hhn
 lyd
 rnf
-fmY
+oHS
 jxg
 iGx
 nkn

--- a/_maps/map_files/Deltastation/DeltaStation2.dmm
+++ b/_maps/map_files/Deltastation/DeltaStation2.dmm
@@ -1621,9 +1621,6 @@
 /area/station/maintenance/department/medical/morgue)
 "asO" = (
 /obj/machinery/porta_turret/ai,
-/obj/structure/sign/nanotrasen{
-	pixel_y = -32
-	},
 /turf/open/floor/circuit/green,
 /area/station/ai_monitored/turret_protected/ai_upload)
 "asS" = (
@@ -2267,12 +2264,6 @@
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron,
 /area/station/command/heads_quarters/qm)
-"aBn" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/structure/cable,
-/obj/structure/sign/warning/vacuum/directional/south,
-/turf/open/floor/plating,
-/area/station/security/checkpoint/escape)
 "aBp" = (
 /obj/machinery/status_display/evac/directional/south,
 /obj/item/kirbyplants/random,
@@ -3178,9 +3169,6 @@
 /area/station/medical/treatment_center)
 "aNb" = (
 /obj/structure/window/reinforced/spawner/directional/west,
-/obj/machinery/computer/pod/old/mass_driver_controller/ordnancedriver{
-	pixel_y = -24
-	},
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron/dark,
 /area/station/science/ordnance/testlab)
@@ -3641,12 +3629,6 @@
 /area/station/service/library/abandoned)
 "aSW" = (
 /obj/structure/cable,
-/obj/machinery/button/flasher{
-	id = "Cell 3";
-	name = "Prisoner Flash";
-	pixel_x = 25;
-	pixel_y = 7
-	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/button/door/directional/east{
@@ -3657,6 +3639,10 @@
 	},
 /obj/effect/turf_decal/tile/red{
 	dir = 8
+	},
+/obj/machinery/button/flasher/directional/east{
+	id = "Cell 3";
+	name = "Prisoner Flash"
 	},
 /turf/open/floor/iron,
 /area/station/security/execution/transfer)
@@ -4016,19 +4002,10 @@
 /obj/machinery/modular_computer/preset/id{
 	dir = 1
 	},
-/obj/machinery/keycard_auth/wall_mounted/directional/south{
-	pixel_x = -5
-	},
-/obj/machinery/button/door/directional/south{
-	id = "cmoshutter";
-	name = "CMO Office Shutters";
-	pixel_x = 8;
-	pixel_y = -26;
-	req_access = list("cmo")
-	},
 /obj/effect/turf_decal/tile/neutral/anticorner/contrasted{
 	dir = 4
 	},
+/obj/machinery/keycard_auth/wall_mounted/directional/south,
 /turf/open/floor/iron,
 /area/station/command/heads_quarters/cmo)
 "aYs" = (
@@ -4179,6 +4156,7 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/caution/stand_clear,
+/obj/structure/sign/warning/vacuum/directional/north,
 /turf/open/floor/iron,
 /area/station/hallway/secondary/entry)
 "ban" = (
@@ -4422,6 +4400,7 @@
 /obj/effect/turf_decal/trimline/neutral/mid_joiner{
 	dir = 1
 	},
+/obj/machinery/status_display/door_timer/directional/west,
 /turf/open/floor/iron/dark/textured_half,
 /area/station/security/detectives_office)
 "bdF" = (
@@ -5368,6 +5347,9 @@
 	},
 /obj/effect/turf_decal/siding/yellow{
 	dir = 1
+	},
+/obj/machinery/atmospherics/components/unary/portables_connector/visible{
+	dir = 8
 	},
 /turf/open/floor/iron,
 /area/station/engineering/atmos/hfr_room)
@@ -6498,10 +6480,6 @@
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron,
 /area/station/maintenance/department/chapel)
-"bDX" = (
-/obj/structure/sign/warning/electric_shock,
-/turf/closed/wall/r_wall,
-/area/station/engineering/lobby)
 "bEc" = (
 /obj/machinery/conveyor{
 	dir = 4;
@@ -6512,6 +6490,7 @@
 	dir = 1
 	},
 /obj/structure/sign/warning/vacuum/directional/north,
+/obj/structure/window/half/directional/south,
 /turf/open/floor/plating,
 /area/station/maintenance/disposal)
 "bEd" = (
@@ -6711,18 +6690,6 @@
 	name = "Custom Channel";
 	pixel_y = -8
 	},
-/obj/machinery/button/door/directional/south{
-	id = "aicoredoor";
-	name = "AI Chamber Access Control";
-	pixel_x = -24;
-	req_access = list("ai_upload")
-	},
-/obj/machinery/button/door/directional/south{
-	id = "aicorewindow";
-	name = "AI Core Shutters";
-	pixel_x = 24;
-	req_access = list("ai_upload")
-	},
 /turf/open/floor/circuit/green,
 /area/station/ai_monitored/turret_protected/ai)
 "bFV" = (
@@ -6742,11 +6709,10 @@
 /area/station/ai_monitored/turret_protected/aisat_interior)
 "bGa" = (
 /obj/structure/table/wood/fancy,
-/obj/structure/sign/painting/large/library{
-	dir = 8;
-	pixel_x = -28
-	},
 /obj/machinery/door/window/right/directional/east,
+/obj/structure/sign/painting/large/library{
+	dir = 8
+	},
 /turf/open/floor/wood/tile,
 /area/station/service/library/artgallery)
 "bGc" = (
@@ -7540,10 +7506,6 @@
 	},
 /turf/open/floor/iron/cafeteria,
 /area/station/security/prison/mess)
-"bPH" = (
-/obj/structure/sign/plaques/kiddie,
-/turf/closed/wall/r_wall,
-/area/station/ai_monitored/turret_protected/aisat_interior)
 "bPI" = (
 /obj/machinery/light/small/directional/south,
 /turf/open/floor/engine,
@@ -7682,10 +7644,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/turret_protected/aisat_interior)
-"bRP" = (
-/obj/structure/sign/warning/vacuum,
-/turf/closed/wall,
-/area/space/nearstation)
 "bRQ" = (
 /obj/structure/lattice,
 /obj/structure/transit_tube/curved/flipped{
@@ -7837,6 +7795,7 @@
 	},
 /obj/item/bedsheet/medical,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/machinery/airalarm/directional/north,
 /turf/open/floor/iron/dark,
 /area/station/security/medical)
 "bSZ" = (
@@ -7904,11 +7863,9 @@
 "bTy" = (
 /obj/effect/turf_decal/siding/wood,
 /obj/machinery/vending/clothing,
-/obj/machinery/button/curtain{
+/obj/machinery/button/curtain/directional/north{
 	id = "theater_curtains";
 	name = "curtain control";
-	pixel_x = -24;
-	pixel_y = -8;
 	req_access = list("theatre")
 	},
 /turf/open/floor/iron/dark,
@@ -8242,6 +8199,7 @@
 /obj/effect/turf_decal/loading_area{
 	dir = 8
 	},
+/obj/structure/sign/warning/electric_shock/directional/north,
 /turf/open/floor/iron/dark/side{
 	dir = 4
 	},
@@ -8385,8 +8343,8 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
-/obj/structure/window/reinforced/spawner/directional/east,
 /obj/item/radio/intercom/directional/south,
+/obj/structure/window/half/directional/east,
 /turf/open/floor/iron,
 /area/station/cargo/sorting)
 "cao" = (
@@ -9072,7 +9030,9 @@
 /obj/machinery/button/door/directional/west{
 	id = "psych_bolt";
 	name = "Bolt Control";
-	req_access = list("psychology")
+	req_access = list("psychology");
+	normaldoorcontrol = 1;
+	specialfunctions = 4
 	},
 /turf/open/floor/wood,
 /area/station/medical/psychology)
@@ -9443,11 +9403,15 @@
 /area/station/maintenance/fore)
 "cnp" = (
 /obj/machinery/photocopier,
-/obj/machinery/status_display/ai/directional/north,
 /obj/structure/reagent_dispensers/wall/peppertank/directional/east,
 /obj/effect/turf_decal/bot_white,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /obj/machinery/light/small/directional/east,
+/obj/machinery/button/door/directional/north{
+	id = "detectivewindows";
+	name = "Privacy Shutters";
+	req_access = list("detective")
+	},
 /turf/open/floor/iron/dark,
 /area/station/security/detectives_office)
 "cnu" = (
@@ -9637,12 +9601,12 @@
 /turf/open/floor/iron,
 /area/station/security/lockers)
 "cqp" = (
-/obj/structure/window/reinforced/spawner/directional/north,
 /obj/effect/turf_decal/trimline/blue/end{
 	dir = 8
 	},
 /obj/machinery/shower/directional/west,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/structure/window/half/directional/north,
 /turf/open/floor/iron/textured,
 /area/station/medical/cryo)
 "cqt" = (
@@ -10209,7 +10173,6 @@
 /turf/open/floor/iron,
 /area/station/hallway/primary/central/fore)
 "cyv" = (
-/obj/machinery/light_switch/directional/south,
 /obj/machinery/camera/directional/south{
 	c_tag = "Bridge - Teleporter";
 	name = "command camera"
@@ -10351,7 +10314,8 @@
 "cAb" = (
 /obj/structure/table/reinforced,
 /obj/structure/window/reinforced/spawner/directional/east,
-/obj/machinery/button/door{
+/obj/machinery/button/door/incinerator_vent_atmos_aux/table{
+	pixel_y = 6;
 	id = "xeno3";
 	name = "Containment Control";
 	req_access = list("xenobiology")
@@ -11356,13 +11320,12 @@
 /turf/open/floor/iron,
 /area/station/maintenance/department/engine/atmos)
 "cMM" = (
-/obj/machinery/status_display/door_timer{
-	id = "medsci-cell";
-	name = "Med-Sci Cell";
-	pixel_y = -32
-	},
 /obj/effect/landmark/start/depsec/science,
 /obj/effect/turf_decal/tile/red/anticorner/contrasted,
+/obj/machinery/status_display/door_timer/directional/south{
+	id = "medsci-cell";
+	name = "Med-Sci Cell"
+	},
 /turf/open/floor/iron,
 /area/station/security/checkpoint/medical/medsci)
 "cMZ" = (
@@ -12515,13 +12478,14 @@
 /area/station/maintenance/starboard/aft)
 "dco" = (
 /obj/structure/table/reinforced,
-/obj/machinery/button/door{
+/obj/structure/window/reinforced/spawner/directional/east,
+/obj/effect/turf_decal/bot,
+/obj/machinery/button/door/incinerator_vent_atmos_aux/table{
+	pixel_y = 6;
 	id = "xeno8";
 	name = "Containment Control";
 	req_access = list("xenobiology")
 	},
-/obj/structure/window/reinforced/spawner/directional/east,
-/obj/effect/turf_decal/bot,
 /turf/open/floor/iron,
 /area/station/science/xenobiology)
 "dcz" = (
@@ -13131,9 +13095,6 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/chair/office,
-/obj/machinery/status_display/supply{
-	pixel_x = 32
-	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
@@ -13152,8 +13113,11 @@
 /area/station/hallway/primary/central/fore)
 "dkF" = (
 /obj/structure/table,
-/obj/structure/window/reinforced/spawner/directional/south,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/machinery/computer/pod/old/mass_driver_controller/ordnancedriver{
+	pixel_y = -32
+	},
+/obj/structure/window/reinforced/spawner/directional/south,
 /turf/open/floor/iron/dark,
 /area/station/science/ordnance/testlab)
 "dkH" = (
@@ -13271,15 +13235,6 @@
 /obj/structure/table/wood,
 /obj/structure/secure_safe/directional/east,
 /obj/machinery/computer/security/wooden_tv,
-/obj/machinery/light_switch/directional/south{
-	pixel_x = 8
-	},
-/obj/machinery/button/door/directional/south{
-	id = "detectivewindows";
-	name = "Privacy Shutters";
-	pixel_x = -6;
-	req_access = list("detective")
-	},
 /turf/open/floor/carpet,
 /area/station/security/detectives_office)
 "dmq" = (
@@ -13371,6 +13326,9 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/machinery/atmospherics/components/binary/valve/digital{
+	dir = 4
+	},
 /turf/open/floor/iron,
 /area/station/maintenance/disposal/incinerator)
 "dnV" = (
@@ -13715,6 +13673,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
+/obj/structure/sign/nanotrasen,
 /turf/open/floor/iron,
 /area/station/hallway/primary/port)
 "dsC" = (
@@ -13825,6 +13784,9 @@
 /obj/effect/turf_decal/tile/red/half/contrasted{
 	dir = 1
 	},
+/obj/machinery/camera/directional/north{
+	c_tag = "Security - Office Fore"
+	},
 /turf/open/floor/iron,
 /area/station/security/office)
 "dtM" = (
@@ -13836,10 +13798,6 @@
 /turf/open/floor/carpet/purple,
 /area/station/commons/dorms)
 "dtS" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/green/visible/layer2,
-/obj/machinery/atmospherics/pipe/smart/simple/dark/visible{
-	dir = 4
-	},
 /obj/machinery/door/airlock/public/glass/incinerator/atmos_interior{
 	dir = 4;
 	manual_align = 1
@@ -13848,9 +13806,6 @@
 	dir = 8
 	},
 /obj/effect/mapping_helpers/airlock/locked,
-/obj/machinery/airlock_controller/incinerator_atmos{
-	pixel_y = -24
-	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
@@ -13858,6 +13813,9 @@
 	dir = 8
 	},
 /obj/effect/mapping_helpers/airlock/access/all/engineering/atmos,
+/obj/machinery/atmospherics/pipe/layer_manifold/green/visible{
+	dir = 4
+	},
 /turf/open/floor/engine,
 /area/station/maintenance/disposal/incinerator)
 "dtX" = (
@@ -14538,6 +14496,15 @@
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron,
 /area/station/science/research)
+"dCD" = (
+/obj/machinery/button/door/directional/east{
+	id = "permashut1";
+	name = "Cell Lockdown Button";
+	pixel_y = -6;
+	req_access = list("brig")
+	},
+/turf/closed/wall/r_wall,
+/area/station/security/execution/transfer)
 "dCH" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 8
@@ -14633,7 +14600,6 @@
 	},
 /obj/item/storage/pill_bottle/mannitol,
 /obj/item/reagent_containers/dropper,
-/obj/structure/window/reinforced/spawner/directional/south,
 /obj/machinery/camera/directional/west{
 	c_tag = "Medbay - Cryogenics";
 	name = "medical camera";
@@ -14645,6 +14611,7 @@
 /obj/effect/turf_decal/siding/blue,
 /obj/structure/table/glass,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/structure/window/half/directional/south,
 /turf/open/floor/iron,
 /area/station/medical/cryo)
 "dEv" = (
@@ -15050,10 +15017,6 @@
 /obj/machinery/light/small/directional/south,
 /turf/open/floor/iron/grimy,
 /area/station/service/chapel)
-"dJY" = (
-/obj/structure/sign/calendar/directional/south,
-/turf/open/floor/plating,
-/area/station/service/abandoned_gambling_den)
 "dKe" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/effect/turf_decal/siding/yellow{
@@ -15261,7 +15224,6 @@
 /area/station/hallway/primary/central/aft)
 "dMD" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/smart/manifold/green/visible,
 /obj/effect/turf_decal/stripes/line{
 	dir = 5
 	},
@@ -15269,6 +15231,7 @@
 /obj/effect/turf_decal/box/corners{
 	dir = 8
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/green/visible,
 /turf/open/floor/iron,
 /area/station/maintenance/disposal/incinerator)
 "dMH" = (
@@ -16520,6 +16483,9 @@
 	dir = 5
 	},
 /obj/machinery/light/small/directional/north,
+/obj/machinery/atmospherics/pipe/smart/simple/green/visible{
+	dir = 4
+	},
 /turf/open/floor/iron,
 /area/station/engineering/atmos/hfr_room)
 "ecX" = (
@@ -16732,6 +16698,26 @@
 "efg" = (
 /obj/structure/table/reinforced,
 /obj/effect/turf_decal/tile/red/half/contrasted,
+/obj/machinery/button/door/table{
+	pixel_y = 15;
+	id = "brigwindows";
+	name = "Cell Window Control";
+	req_access = list("security")
+	},
+/obj/machinery/button/door/table{
+	pixel_y = 7;
+	id = "brigfront";
+	name = "Brig Access Control";
+	req_access = list("security");
+	pixel_x = 6
+	},
+/obj/machinery/button/door/table{
+	pixel_y = 7;
+	id = "brigprison";
+	name = "Prison Lockdown";
+	req_access = list("brig");
+	pixel_x = -6
+	},
 /turf/open/floor/iron,
 /area/station/security/warden)
 "efh" = (
@@ -18454,6 +18440,7 @@
 /obj/effect/turf_decal/tile/brown/opposingcorners{
 	dir = 1
 	},
+/obj/machinery/light_switch/directional/north,
 /turf/open/floor/iron,
 /area/station/commons/vacant_room/commissary)
 "eEn" = (
@@ -19185,6 +19172,7 @@
 /area/station/service/library/lounge)
 "eOb" = (
 /obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/structure/sign/warning/vacuum/directional/north,
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/aisat/exterior)
 "eOe" = (
@@ -19738,10 +19726,6 @@
 /obj/machinery/ai_slipper{
 	uses = 10
 	},
-/obj/machinery/flasher/directional/south{
-	id = "AI";
-	pixel_x = 26
-	},
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/turret_protected/ai)
@@ -20192,8 +20176,7 @@
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /obj/machinery/button/door/directional/north{
 	id = "viro_private_shutters";
-	name = "Privacy Shutters";
-	pixel_y = 36
+	name = "Privacy Shutters"
 	},
 /turf/open/floor/iron/dark,
 /area/station/medical/virology)
@@ -20343,14 +20326,11 @@
 /obj/item/reagent_containers/cup/bowl{
 	pixel_y = 3
 	},
-/obj/machinery/light_switch/directional/north{
-	pixel_x = -8;
-	pixel_y = 23
-	},
 /obj/structure/table,
 /obj/effect/turf_decal/tile/red/opposingcorners{
 	dir = 1
 	},
+/obj/machinery/light_switch/directional/north,
 /turf/open/floor/iron/cafeteria,
 /area/station/service/barber)
 "fco" = (
@@ -20364,7 +20344,9 @@
 "fcx" = (
 /obj/machinery/door/morgue{
 	name = "Curator's Study";
-	req_access = list("library")
+	req_access = list("library");
+	manual_align = 1;
+	dir = 4
 	},
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -20552,15 +20534,12 @@
 /obj/effect/landmark/start/hangover,
 /obj/effect/turf_decal/siding/wood/corner,
 /obj/item/radio/intercom/directional/east,
-/obj/machinery/status_display/ai/directional/north,
-/obj/machinery/button/curtain{
+/obj/machinery/light/small/directional/east,
+/obj/machinery/button/curtain/directional/north{
 	id = "theater_curtains";
 	name = "curtain control";
-	pixel_x = 24;
-	pixel_y = -8;
 	req_access = list("theatre")
 	},
-/obj/machinery/light/small/directional/east,
 /turf/open/floor/wood,
 /area/station/service/theater)
 "feB" = (
@@ -20988,7 +20967,6 @@
 /turf/open/floor/plating/airless,
 /area/station/science/ordnance/bomb)
 "fkg" = (
-/obj/structure/cable,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 4
 	},
@@ -20996,6 +20974,7 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/station/engineering/transit_tube)
 "fkl" = (
@@ -21654,9 +21633,9 @@
 	pixel_y = 3
 	},
 /obj/item/storage/box/beakers,
-/obj/structure/window/reinforced/spawner/directional/east,
 /obj/structure/table/reinforced/rglass,
 /obj/effect/turf_decal/tile/blue/fourcorners,
+/obj/structure/window/half/directional/east,
 /turf/open/floor/iron,
 /area/station/medical/treatment_center)
 "fsC" = (
@@ -22164,14 +22143,8 @@
 /area/station/hallway/primary/fore)
 "fzx" = (
 /obj/effect/turf_decal/stripes/line,
-/obj/machinery/atmospherics/components/binary/valve/digital{
+/obj/machinery/atmospherics/pipe/smart/simple/dark/visible{
 	dir = 4
-	},
-/obj/effect/turf_decal/box/corners{
-	dir = 4
-	},
-/obj/effect/turf_decal/box/corners{
-	dir = 1
 	},
 /turf/open/floor/iron,
 /area/station/maintenance/disposal/incinerator)
@@ -22495,7 +22468,9 @@
 "fEh" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/security/glass{
-	name = "Prison Wing"
+	name = "Prison Wing";
+	dir = 4;
+	manual_align = 1
 	},
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 4
@@ -22515,10 +22490,6 @@
 "fEr" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/dark/visible{
-	dir = 4
-	},
-/obj/machinery/meter,
 /obj/effect/turf_decal/tile/yellow{
 	dir = 8
 	},
@@ -23403,14 +23374,6 @@
 	pixel_y = -6;
 	req_access = list("hos")
 	},
-/obj/machinery/keycard_auth/wall_mounted/directional/east{
-	pixel_x = 38;
-	pixel_y = 6
-	},
-/obj/machinery/light_switch/directional/east{
-	pixel_x = 37;
-	pixel_y = -6
-	},
 /obj/structure/tank_holder/extinguisher,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /obj/machinery/light/small/directional/east,
@@ -23479,20 +23442,10 @@
 /area/station/security/checkpoint/customs/aft)
 "fQL" = (
 /obj/structure/disposalpipe/segment,
-/obj/machinery/button/door{
-	id = "Disposal Exit";
-	name = "Disposal Vent Control";
-	pixel_x = -25;
-	pixel_y = 4;
-	req_access = list("maint_tunnels")
-	},
 /obj/structure/chair/stool/directional/west,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/delivery,
-/obj/machinery/computer/pod/old/mass_driver_controller/trash{
-	pixel_x = -24;
-	pixel_y = -7
-	},
+/obj/machinery/computer/pod/old/mass_driver_controller/trash,
 /turf/open/floor/iron,
 /area/station/maintenance/disposal)
 "fQW" = (
@@ -23562,16 +23515,20 @@
 /area/station/science/explab)
 "fRO" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/window/reinforced/spawner/directional/south,
 /obj/effect/turf_decal/loading_area{
 	dir = 4
 	},
+/obj/structure/window/half/directional/south,
 /turf/open/floor/iron,
 /area/station/cargo/storage)
 "fRP" = (
-/obj/machinery/airalarm/directional/north,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /obj/effect/turf_decal/tile/neutral/full,
+/obj/machinery/button/door/directional/north{
+	id = "Interro_shutters";
+	name = "Shutters Control";
+	req_access = list("security")
+	},
 /turf/open/floor/iron/dark/smooth_large,
 /area/station/security/interrogation)
 "fSg" = (
@@ -23738,7 +23695,8 @@
 "fUF" = (
 /obj/structure/table/reinforced,
 /obj/structure/window/reinforced/spawner/directional/east,
-/obj/machinery/button/door{
+/obj/machinery/button/door/incinerator_vent_atmos_aux/table{
+	pixel_y = 6;
 	id = "xeno1";
 	name = "Containment Control";
 	req_access = list("xenobiology")
@@ -23972,6 +23930,8 @@
 /obj/machinery/light_switch/directional/east,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /obj/machinery/light/small/directional/north,
+/obj/machinery/power/apc/auto_name/directional/north,
+/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/station/engineering/transit_tube)
 "fXz" = (
@@ -23983,12 +23943,6 @@
 	id = "brigprison";
 	name = "Prison Blast Door"
 	},
-/obj/machinery/button/flasher{
-	id = "Cell 1";
-	name = "Prisoner Flash";
-	pixel_x = 25;
-	pixel_y = 7
-	},
 /obj/machinery/door/firedoor,
 /obj/effect/turf_decal/delivery,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -23998,6 +23952,10 @@
 	name = "Cell Lockdown Button";
 	pixel_y = -6;
 	req_access = list("brig")
+	},
+/obj/machinery/button/flasher/directional/east{
+	id = "Cell 1";
+	name = "Prisoner Flash"
 	},
 /turf/open/floor/iron,
 /area/station/security/execution/transfer)
@@ -24429,7 +24387,6 @@
 	pixel_x = -32;
 	pixel_y = -32
 	},
-/obj/item/radio/intercom/directional/west,
 /obj/effect/turf_decal/tile/red/anticorner/contrasted{
 	dir = 8
 	},
@@ -24554,6 +24511,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
+/obj/structure/window/half/directional/south,
 /turf/open/floor/plating,
 /area/station/maintenance/disposal)
 "gdR" = (
@@ -24921,6 +24879,7 @@
 /obj/item/hand_tele,
 /obj/structure/cable,
 /obj/machinery/power/apc/auto_name/directional/north,
+/obj/machinery/light_switch/directional/north,
 /turf/open/floor/iron,
 /area/station/command/teleporter)
 "giu" = (
@@ -24966,12 +24925,6 @@
 /area/station/maintenance/port/fore)
 "gjc" = (
 /obj/structure/cable,
-/obj/machinery/button/flasher{
-	id = "Cell 4";
-	name = "Prisoner Flash";
-	pixel_x = 25;
-	pixel_y = 7
-	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/button/door/directional/east{
@@ -24982,6 +24935,10 @@
 	},
 /obj/effect/turf_decal/tile/red{
 	dir = 8
+	},
+/obj/machinery/button/flasher/directional/east{
+	id = "Cell 5";
+	name = "Prisoner Flash"
 	},
 /turf/open/floor/iron,
 /area/station/security/execution/transfer)
@@ -25604,6 +25561,7 @@
 /area/station/medical/virology)
 "gqq" = (
 /obj/structure/dresser,
+/obj/structure/sign/nanotrasen,
 /turf/open/floor/iron/grimy,
 /area/station/command/heads_quarters/hop)
 "gqA" = (
@@ -25893,6 +25851,13 @@
 /obj/effect/turf_decal/tile/neutral/half/contrasted{
 	dir = 8
 	},
+/obj/machinery/door_buttons/airlock_controller/directional/north{
+	req_access = list("virology");
+	name = "Virology Access Console";
+	idSelf = "virology_airlock_control";
+	idInterior = "virology_airlock_interior";
+	idExterior = "virology_airlock_exterior"
+	},
 /turf/open/floor/iron,
 /area/station/medical/virology)
 "gtp" = (
@@ -26165,11 +26130,6 @@
 "gwr" = (
 /obj/item/kirbyplants/random,
 /obj/effect/turf_decal/stripes/line,
-/obj/machinery/button/door/directional/south{
-	id = "evashutters";
-	name = "E.V.A. Shutters";
-	req_access = list("command")
-	},
 /turf/open/floor/iron,
 /area/station/ai_monitored/command/storage/eva)
 "gwt" = (
@@ -26263,17 +26223,11 @@
 /area/station/hallway/primary/port)
 "gxT" = (
 /obj/structure/table/reinforced,
-/obj/structure/window/reinforced/spawner/directional/south,
-/obj/machinery/button/door{
-	id = "xenosecure";
-	name = "Containment Control";
-	pixel_y = -3;
-	req_access = list("xenobiology")
-	},
-/obj/item/radio/intercom{
-	pixel_y = 5
-	},
 /obj/effect/turf_decal/tile/neutral/anticorner/contrasted,
+/obj/item/radio/intercom{
+	pixel_y = 32
+	},
+/obj/structure/window/reinforced/spawner/directional/south,
 /turf/open/floor/iron,
 /area/station/science/xenobiology)
 "gxW" = (
@@ -26529,13 +26483,32 @@
 /area/station/science/research)
 "gBs" = (
 /obj/structure/table/reinforced,
-/obj/item/clipboard,
-/obj/item/toy/figure/secofficer,
 /obj/machinery/newscaster/directional/west,
 /obj/effect/turf_decal/tile/red/half/contrasted{
 	dir = 8
 	},
 /obj/machinery/light/small/directional/west,
+/obj/machinery/button/flasher/table{
+	pixel_y = 4;
+	pixel_x = 3;
+	id = "brigflashdoor";
+	name = "Flash Control";
+	req_access = list("security")
+	},
+/obj/machinery/button/door/table{
+	pixel_y = 12;
+	pixel_x = 3;
+	req_access = list("security");
+	name = "Brig Access Control";
+	id = "brigfront"
+	},
+/obj/machinery/button/door/table{
+	pixel_y = -4;
+	pixel_x = 3;
+	id = "brigwindows";
+	name = "Cell Window Control";
+	req_access = list("security")
+	},
 /turf/open/floor/iron,
 /area/station/security/holding_cell)
 "gBx" = (
@@ -27012,7 +26985,8 @@
 	dir = 8
 	},
 /obj/machinery/newscaster/directional/west,
-/obj/machinery/button/door/directional/south{
+/obj/machinery/button/door/directional/east{
+	dir = 8;
 	id = "Toilet_Research";
 	name = "Lock Control";
 	normaldoorcontrol = 1;
@@ -27796,39 +27770,15 @@
 /area/station/engineering/main)
 "gRU" = (
 /obj/structure/table/reinforced,
-/obj/machinery/button/ignition{
-	id = "justicespark";
-	pixel_x = 7;
-	pixel_y = 24;
-	req_access = list("armory")
-	},
-/obj/machinery/button/flasher{
-	id = "justiceflash";
-	pixel_x = 6;
-	pixel_y = 34;
-	req_access = list("armory")
-	},
 /obj/item/folder/red{
 	pixel_x = 3
 	},
 /obj/item/restraints/handcuffs,
 /obj/item/taperecorder,
-/obj/machinery/button/door/directional/north{
-	id = "justiceblast";
-	name = "Justice Shutters Control";
-	pixel_x = -6;
-	req_access = list("armory")
-	},
-/obj/machinery/button/door/directional/north{
-	id = "justicechamber";
-	name = "Justice Chamber Control";
-	pixel_x = -6;
-	pixel_y = 34;
-	req_access = list("armory")
-	},
 /obj/effect/turf_decal/tile/red/half/contrasted{
 	dir = 1
 	},
+/obj/structure/sign/warning/electric_shock/directional/north,
 /turf/open/floor/iron/dark,
 /area/station/security/execution/education)
 "gSe" = (
@@ -27855,9 +27805,6 @@
 /area/station/maintenance/department/engine/atmos)
 "gSB" = (
 /obj/structure/cable,
-/obj/machinery/button/door/incinerator_vent_atmos_main{
-	pixel_x = -8
-	},
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/chair/stool/directional/south,
 /obj/machinery/light/small/directional/north,
@@ -28778,7 +28725,6 @@
 /turf/open/floor/iron,
 /area/station/medical/pharmacy)
 "hfb" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/green/visible/layer2,
 /obj/machinery/atmospherics/pipe/smart/simple/dark/visible{
 	dir = 4
 	},
@@ -28791,6 +28737,9 @@
 	},
 /obj/effect/mapping_helpers/airlock/locked,
 /obj/effect/mapping_helpers/airlock/access/all/engineering/atmos,
+/obj/machinery/atmospherics/pipe/smart/simple/green/visible/layer2{
+	dir = 8
+	},
 /turf/open/floor/engine/vacuum,
 /area/station/maintenance/disposal/incinerator)
 "hfe" = (
@@ -28928,10 +28877,6 @@
 /obj/machinery/newscaster/directional/east,
 /turf/open/floor/plating,
 /area/station/service/library/abandoned)
-"hhK" = (
-/obj/structure/sign/warning/vacuum,
-/turf/closed/wall,
-/area/station/cargo/storage)
 "hhM" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
@@ -30500,10 +30445,6 @@
 /obj/structure/chair/stool/directional/south,
 /turf/open/floor/plating,
 /area/station/maintenance/port/fore)
-"hEt" = (
-/obj/structure/sign/warning/vacuum,
-/turf/closed/wall/r_wall,
-/area/station/maintenance/port/aft)
 "hEF" = (
 /turf/closed/wall/r_wall,
 /area/station/security/lockers)
@@ -31043,14 +30984,6 @@
 /obj/effect/mapping_helpers/broken_floor,
 /turf/open/floor/wood,
 /area/station/maintenance/port/fore)
-"hLt" = (
-/obj/structure/sign/directions/engineering{
-	desc = "A sign that shows there are doors here. There are doors everywhere!";
-	icon_state = "doors";
-	name = "WARNING: EXTERNAL AIRLOCK"
-	},
-/turf/closed/wall,
-/area/station/hallway/secondary/exit/departure_lounge)
 "hLA" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/carpet/orange,
@@ -33084,6 +33017,7 @@
 /obj/effect/turf_decal/tile/neutral/half/contrasted{
 	dir = 1
 	},
+/obj/structure/sign/nanotrasen,
 /turf/open/floor/iron,
 /area/station/maintenance/department/science)
 "iln" = (
@@ -33337,9 +33271,11 @@
 /area/station/service/hydroponics)
 "inV" = (
 /obj/structure/table/wood,
-/obj/item/radio/intercom,
 /obj/effect/turf_decal/tile/neutral/half/contrasted{
 	dir = 1
+	},
+/obj/item/radio/intercom{
+	pixel_y = 32
 	},
 /turf/open/floor/iron,
 /area/station/security/courtroom)
@@ -33367,6 +33303,9 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/machinery/atmospherics/pipe/smart/simple/green/visible{
+	dir = 4
+	},
 /turf/open/floor/iron,
 /area/station/maintenance/disposal/incinerator)
 "iov" = (
@@ -34028,6 +33967,7 @@
 	pixel_x = -10;
 	pixel_y = 3
 	},
+/obj/machinery/light_switch/directional/north,
 /turf/open/floor/iron/dark,
 /area/station/security/detectives_office)
 "ixZ" = (
@@ -34425,10 +34365,6 @@
 "iDq" = (
 /turf/closed/wall/r_wall,
 /area/station/security/range)
-"iDs" = (
-/obj/structure/sign/warning/deathsposal,
-/turf/open/space/basic,
-/area/space)
 "iDw" = (
 /obj/machinery/camera/directional/south{
 	c_tag = "Central Hallway - Center Starboard";
@@ -34462,6 +34398,25 @@
 	},
 /turf/open/space,
 /area/space)
+"iDZ" = (
+/obj/structure/cable,
+/obj/structure/table/wood,
+/obj/machinery/button/ticket_machine/table{
+	pixel_y = 3;
+	pixel_x = -6
+	},
+/obj/machinery/button/photobooth/table{
+	pixel_x = 6;
+	pixel_y = 3
+	},
+/obj/machinery/button/flasher/table{
+	pixel_y = 12;
+	id = "hopflash";
+	req_access = list("hop");
+	name = "Queue Flasher"
+	},
+/turf/open/floor/wood,
+/area/station/command/heads_quarters/hop)
 "iEa" = (
 /obj/structure/table/wood,
 /obj/item/clothing/under/costume/maid,
@@ -35678,11 +35633,16 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
-/obj/machinery/firealarm/directional/east,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/tile/red,
 /obj/effect/turf_decal/tile/yellow{
 	dir = 4
+	},
+/obj/machinery/button/door/directional/east{
+	id = "engielock";
+	name = "Engineering Lockdown Control";
+	pixel_y = 8;
+	req_access = list("engineering")
 	},
 /turf/open/floor/iron,
 /area/station/engineering/lobby)
@@ -35741,12 +35701,13 @@
 /area/station/maintenance/department/chapel)
 "iVH" = (
 /obj/structure/table/reinforced,
-/obj/machinery/button/door{
+/obj/structure/window/reinforced/spawner/directional/east,
+/obj/machinery/button/door/incinerator_vent_atmos_aux/table{
+	pixel_y = 6;
 	id = "xeno6";
 	name = "Containment Control";
 	req_access = list("xenobiology")
 	},
-/obj/structure/window/reinforced/spawner/directional/east,
 /turf/open/floor/iron,
 /area/station/science/xenobiology)
 "iVT" = (
@@ -35980,13 +35941,12 @@
 "iXM" = (
 /obj/structure/cable,
 /obj/item/kirbyplants/random,
-/obj/machinery/status_display/door_timer{
-	id = "engcell";
-	name = "Engineering Cell";
-	pixel_y = 32
-	},
 /obj/effect/turf_decal/tile/red/anticorner/contrasted{
 	dir = 1
+	},
+/obj/machinery/status_display/door_timer/directional/north{
+	id = "engcell";
+	name = "Engineering Cell"
 	},
 /turf/open/floor/iron,
 /area/station/security/checkpoint/engineering)
@@ -36611,11 +36571,10 @@
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/command/nuke_storage)
 "jff" = (
-/obj/machinery/atmospherics/pipe/smart/simple/dark/visible,
-/obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
 /area/station/maintenance/disposal/incinerator)
 "jfn" = (
@@ -38402,26 +38361,6 @@
 /obj/machinery/computer/records/security{
 	dir = 8
 	},
-/obj/machinery/button/flasher{
-	id = "brigflashdoor";
-	name = "Flash Control";
-	pixel_x = 26;
-	pixel_y = 7;
-	req_access = list("security")
-	},
-/obj/machinery/button/door/directional/east{
-	id = "brigfront";
-	name = "Brig Access Control";
-	pixel_y = -6;
-	req_access = list("security")
-	},
-/obj/machinery/button/door/directional/east{
-	id = "brigwindows";
-	name = "Cell Window Control";
-	pixel_x = 36;
-	pixel_y = -6;
-	req_access = list("security")
-	},
 /obj/effect/turf_decal/tile/red/anticorner/contrasted{
 	dir = 4
 	},
@@ -38496,6 +38435,13 @@
 /obj/structure/sign/warning/electric_shock/directional/north,
 /turf/open/floor/plating,
 /area/station/maintenance/department/electrical)
+"jCy" = (
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/machinery/flasher/directional/south{
+	id = "AI"
+	},
+/turf/open/floor/iron/dark,
+/area/station/ai_monitored/turret_protected/aisat_interior)
 "jCI" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -39622,11 +39568,6 @@
 /area/station/service/electronic_marketing_den)
 "jQv" = (
 /obj/item/kirbyplants/random,
-/obj/machinery/turretid/directional/south{
-	control_area = "/area/station/ai_monitored/turret_protected/aisat_interior";
-	name = "Antechamber Turret Control";
-	req_access = list("minisat")
-	},
 /obj/machinery/camera/directional/west{
 	c_tag = "AI Satellite - Teleporter";
 	name = "ai camera";
@@ -39634,6 +39575,11 @@
 	start_active = 1
 	},
 /obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/machinery/turretid/directional/west{
+	name = "Antechamber Turret Control";
+	req_access = list("minisat");
+	control_area = "/area/station/ai_monitored/turret_protected/aisat_interior"
+	},
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/turret_protected/aisat_interior)
 "jQw" = (
@@ -40630,10 +40576,10 @@
 /turf/open/floor/iron/dark,
 /area/station/security/checkpoint/customs/aft)
 "kdE" = (
-/obj/structure/window/reinforced/spawner/directional/north,
 /obj/effect/turf_decal/loading_area{
 	dir = 4
 	},
+/obj/structure/window/half/directional/north,
 /turf/open/floor/iron,
 /area/station/cargo/storage)
 "kdM" = (
@@ -40929,6 +40875,10 @@
 	},
 /turf/open/floor/iron/grimy,
 /area/station/service/chapel/office)
+"kgL" = (
+/obj/machinery/atmospherics/pipe/smart/simple/dark/visible,
+/turf/closed/wall/r_wall,
+/area/station/maintenance/disposal/incinerator)
 "kgO" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 1
@@ -41107,7 +41057,6 @@
 	name = "evidence closet"
 	},
 /obj/effect/turf_decal/tile/neutral/fourcorners,
-/obj/item/radio/intercom/directional/north,
 /turf/open/floor/iron/dark,
 /area/station/security/evidence)
 "kiP" = (
@@ -42809,10 +42758,11 @@
 	dir = 4
 	},
 /obj/structure/cable,
+/obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/smart/simple/dark/visible{
 	dir = 4
 	},
-/obj/effect/decal/cleanable/dirt,
+/obj/machinery/meter,
 /turf/open/floor/iron,
 /area/station/maintenance/disposal/incinerator)
 "kGK" = (
@@ -43485,7 +43435,9 @@
 /obj/structure/cable,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/green/visible/layer2,
+/obj/machinery/atmospherics/pipe/smart/simple/green/visible{
+	dir = 9
+	},
 /turf/open/floor/iron/dark,
 /area/station/maintenance/disposal/incinerator)
 "kRk" = (
@@ -43717,6 +43669,14 @@
 	},
 /turf/open/floor/iron/grimy,
 /area/station/command/heads_quarters/hos)
+"kTS" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/yellow/half/contrasted,
+/obj/machinery/firealarm/directional/south,
+/turf/open/floor/iron,
+/area/station/engineering/lobby)
 "kTX" = (
 /obj/machinery/photocopier,
 /obj/item/radio/intercom/directional/south,
@@ -44294,6 +44254,11 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/delivery,
+/obj/machinery/button/door{
+	id = "Disposal Exit";
+	name = "Disposal Vent Control";
+	req_access = list("maint_tunnels")
+	},
 /turf/open/floor/iron,
 /area/station/maintenance/disposal)
 "lbw" = (
@@ -44406,6 +44371,9 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/machinery/atmospherics/pipe/smart/simple/green/visible{
+	dir = 5
+	},
 /turf/open/floor/iron,
 /area/station/maintenance/disposal/incinerator)
 "lcT" = (
@@ -45639,6 +45607,9 @@
 /obj/structure/cable,
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/button/door/incinerator_vent_atmos_main/directional/north,
+/obj/machinery/atmospherics/pipe/smart/simple/dark/visible{
+	dir = 5
+	},
 /turf/open/floor/iron,
 /area/station/maintenance/disposal/incinerator)
 "ltz" = (
@@ -45904,6 +45875,12 @@
 	dir = 1
 	},
 /obj/machinery/light/directional/north,
+/obj/machinery/button/door/table{
+	pixel_y = 14;
+	name = "Ordnance Containment Control";
+	id = "rdordnance";
+	req_access = list("science")
+	},
 /turf/open/floor/iron,
 /area/station/science/ordnance/office)
 "lvZ" = (
@@ -46028,11 +46005,6 @@
 /turf/open/floor/iron,
 /area/station/commons/toilet/locker)
 "lyd" = (
-/obj/machinery/flasher{
-	id = "justiceflash";
-	pixel_x = 26;
-	req_access = list("security")
-	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 8
 	},
@@ -46500,10 +46472,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/service/library/printer)
-"lDV" = (
-/obj/structure/sign/warning/secure_area,
-/turf/closed/wall,
-/area/station/engineering/main)
 "lDY" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -47159,18 +47127,15 @@
 /turf/open/floor/plating,
 /area/station/security/prison/safe)
 "lKw" = (
-/obj/structure/cable,
-/obj/machinery/power/apc/auto_name/directional/north,
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 9
 	},
+/obj/effect/turf_decal/tile/neutral/fourcorners,
 /obj/machinery/button/door/directional/north{
 	id = "transitlock";
 	name = "Transit Tube Lockdown Control";
-	pixel_y = 40;
 	req_access = list("command")
 	},
-/obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron/dark,
 /area/station/engineering/transit_tube)
 "lKy" = (
@@ -47820,9 +47785,6 @@
 /obj/machinery/door/airlock/highsecurity{
 	name = "MiniSat Upload"
 	},
-/obj/machinery/flasher/directional/west{
-	id = "AI"
-	},
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -48147,16 +48109,6 @@
 	pixel_x = -38;
 	pixel_y = 8
 	},
-/obj/machinery/button/flasher{
-	id = "hopflash";
-	pixel_x = -38;
-	pixel_y = -7;
-	req_access = list("kitchen")
-	},
-/obj/machinery/button/ticket_machine{
-	pixel_y = 22;
-	pixel_x = -6
-	},
 /obj/machinery/button/door/directional/west{
 	id = "hopblast";
 	name = "Lockdown Blast Doors";
@@ -48170,10 +48122,6 @@
 	req_access = list("hop")
 	},
 /obj/effect/turf_decal/tile/neutral/fourcorners,
-/obj/machinery/button/photobooth{
-	pixel_y = 22;
-	pixel_x = 6
-	},
 /turf/open/floor/iron/dark,
 /area/station/command/heads_quarters/hop)
 "lZF" = (
@@ -48395,9 +48343,6 @@
 "mdk" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 6
-	},
-/obj/structure/sign/nanotrasen{
-	pixel_y = -32
 	},
 /turf/open/floor/iron,
 /area/station/science/auxlab/firing_range)
@@ -48766,12 +48711,6 @@
 "mhA" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/button/door/directional/south{
-	id = "engielock";
-	name = "Engineering Lockdown Control";
-	pixel_x = -6;
-	req_access = list("engineering")
-	},
 /obj/effect/turf_decal/tile/yellow{
 	dir = 8
 	},
@@ -48830,11 +48769,11 @@
 "mjo" = (
 /obj/machinery/recharge_station,
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/button/door/directional/south{
+/obj/effect/turf_decal/bot_red,
+/obj/machinery/button/door/directional/east{
 	id = "gatewayshutters";
 	name = "Gateway Shutters"
 	},
-/obj/effect/turf_decal/bot_red,
 /turf/open/floor/iron,
 /area/station/command/gateway)
 "mjr" = (
@@ -49481,6 +49420,13 @@
 /obj/effect/turf_decal/tile/yellow/fourcorners,
 /turf/open/floor/iron,
 /area/station/engineering/storage)
+"mtx" = (
+/obj/effect/spawner/structure/window/reinforced/plasma,
+/obj/machinery/atmospherics/pipe/smart/simple/green/visible{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/station/maintenance/disposal/incinerator)
 "mtD" = (
 /obj/machinery/requests_console/directional/north{
 	department = "Medbay";
@@ -50815,13 +50761,11 @@
 "mIO" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/dark/visible{
-	dir = 10
-	},
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/tile/yellow{
 	dir = 8
 	},
+/obj/machinery/atmospherics/pipe/smart/simple/dark/visible,
 /turf/open/floor/iron/dark/corner,
 /area/station/maintenance/disposal/incinerator)
 "mIX" = (
@@ -51551,10 +51495,16 @@
 /area/station/security/checkpoint/customs/aft)
 "mTe" = (
 /obj/effect/turf_decal/stripes/line,
-/obj/machinery/atmospherics/pipe/smart/simple/dark/visible{
-	dir = 10
-	},
 /obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/box/corners{
+	dir = 4
+	},
+/obj/effect/turf_decal/box/corners{
+	dir = 1
+	},
+/obj/machinery/atmospherics/components/binary/valve/digital{
+	dir = 4
+	},
 /turf/open/floor/iron,
 /area/station/maintenance/disposal/incinerator)
 "mTn" = (
@@ -54373,12 +54323,12 @@
 /turf/open/floor/iron,
 /area/station/commons/vacant_room/commissary)
 "nHb" = (
+/obj/effect/turf_decal/tile/neutral/fourcorners,
 /obj/machinery/turretid/directional/south{
 	control_area = "/area/station/ai_monitored/turret_protected/ai_upload";
-	icon_state = "control_stun";
-	name = "AI Upload Turret Control"
+	name = "AI Upload Turret Control";
+	pixel_y = 0
 	},
-/obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/turret_protected/aisat_interior)
 "nHd" = (
@@ -54697,10 +54647,6 @@
 /area/station/maintenance/port/fore)
 "nKE" = (
 /obj/machinery/computer/security/telescreen/entertainment/directional/north,
-/obj/machinery/camera/directional/north{
-	c_tag = "Security - Head of Security's Office";
-	dir = 9
-	},
 /obj/structure/bed/dogbed/lia,
 /obj/item/radio/intercom/directional/west,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
@@ -54933,6 +54879,11 @@
 /obj/effect/turf_decal/tile/neutral,
 /turf/open/floor/iron,
 /area/station/hallway/primary/central/aft)
+"nNV" = (
+/obj/effect/turf_decal/siding/dark_red,
+/obj/machinery/light_switch/directional/west,
+/turf/open/floor/iron/grimy,
+/area/station/command/heads_quarters/hos)
 "nOk" = (
 /obj/item/kirbyplants/random,
 /obj/machinery/status_display/ai/directional/west,
@@ -54964,6 +54915,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 9
 	},
+/obj/structure/sign/warning/secure_area/directional/north,
 /turf/open/floor/iron/dark,
 /area/station/engineering/main)
 "nOy" = (
@@ -55467,6 +55419,7 @@
 /area/station/engineering/supermatter/room)
 "nVw" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/computer/pod/old/mass_driver_controller/chapelgun,
 /turf/open/floor/iron/dark,
 /area/station/service/chapel/funeral)
 "nVB" = (
@@ -55607,9 +55560,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/power/apc/auto_name/directional/south,
 /obj/machinery/light/directional/south,
-/obj/machinery/atmospherics/pipe/smart/simple/dark/visible{
-	dir = 5
-	},
 /obj/effect/turf_decal/tile/yellow{
 	dir = 8
 	},
@@ -55907,12 +55857,6 @@
 /turf/open/floor/plating,
 /area/station/engineering/atmos)
 "obL" = (
-/obj/machinery/button/flasher{
-	id = "Cell 5";
-	name = "Prisoner Flash";
-	pixel_x = 25;
-	pixel_y = 7
-	},
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -55924,6 +55868,10 @@
 	},
 /obj/effect/turf_decal/tile/red{
 	dir = 8
+	},
+/obj/machinery/button/flasher/directional/east{
+	id = "Cell 4";
+	name = "Prisoner Flash"
 	},
 /turf/open/floor/iron,
 /area/station/security/execution/transfer)
@@ -56582,10 +56530,6 @@
 /obj/structure/sign/warning/vacuum/directional/east,
 /turf/open/floor/plating,
 /area/station/security/execution/transfer)
-"okb" = (
-/obj/structure/sign/nanotrasen,
-/turf/closed/wall,
-/area/station/maintenance/department/crew_quarters/bar)
 "oke" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -57009,6 +56953,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/decal/cleanable/blood/old,
+/obj/structure/sign/nanotrasen,
 /turf/open/floor/plating,
 /area/station/maintenance/department/science)
 "opl" = (
@@ -57828,6 +57773,12 @@
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plating,
 /area/station/maintenance/solars/starboard/aft)
+"oBW" = (
+/obj/structure/lattice,
+/obj/structure/window/reinforced/spawner/directional/south,
+/obj/structure/sign/nanotrasen,
+/turf/open/space,
+/area/space/nearstation)
 "oBX" = (
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible,
 /obj/item/kirbyplants/random,
@@ -58581,15 +58532,15 @@
 /turf/open/floor/iron,
 /area/station/hallway/secondary/entry)
 "oMu" = (
-/obj/structure/window/reinforced/spawner/directional/east,
 /obj/effect/turf_decal/loading_area{
 	dir = 1
 	},
-/obj/structure/window/reinforced/spawner/directional/west,
 /obj/machinery/door/window/right/directional/north{
 	name = "Incoming Mail";
 	req_access = list("shipping")
 	},
+/obj/structure/window/half/directional/east,
+/obj/structure/window/half/directional/west,
 /turf/open/floor/iron,
 /area/station/cargo/sorting)
 "oMw" = (
@@ -59083,11 +59034,6 @@
 	},
 /turf/open/floor/iron,
 /area/station/science/xenobiology)
-"oSN" = (
-/obj/structure/lattice,
-/obj/structure/sign/warning/deathsposal,
-/turf/open/space/basic,
-/area/space/nearstation)
 "oSV" = (
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment,
@@ -59110,13 +59056,10 @@
 /area/station/hallway/primary/port)
 "oTg" = (
 /obj/structure/sink/directional/west,
-/obj/machinery/light_switch/directional/east,
-/obj/machinery/firealarm/directional/east{
-	pixel_x = 38
-	},
 /obj/effect/turf_decal/tile/red/half/contrasted{
 	dir = 4
 	},
+/obj/machinery/light_switch/directional/east,
 /turf/open/floor/iron/white/side{
 	dir = 8
 	},
@@ -59138,6 +59081,9 @@
 	dir = 4
 	},
 /obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/smart/simple/dark/visible{
+	dir = 10
+	},
 /turf/open/floor/iron,
 /area/station/maintenance/disposal/incinerator)
 "oTv" = (
@@ -59342,6 +59288,7 @@
 	},
 /obj/structure/bed/medical/emergency,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/machinery/firealarm/directional/north,
 /turf/open/floor/iron/dark,
 /area/station/security/medical)
 "oWA" = (
@@ -60365,8 +60312,7 @@
 "pkb" = (
 /obj/machinery/button/door/directional/north{
 	id = "chemisttop";
-	name = "Pharmacy Shutters";
-	pixel_y = 40
+	name = "Pharmacy Shutters"
 	},
 /obj/machinery/chem_mass_spec,
 /obj/effect/turf_decal/siding/yellow{
@@ -60676,13 +60622,6 @@
 	frequency = 1449;
 	id_tag = "virology_airlock_interior";
 	name = "Virology Interior Airlock"
-	},
-/obj/machinery/door_buttons/access_button{
-	idDoor = "virology_airlock_interior";
-	idSelf = "virology_airlock_control";
-	name = "Virology Access Button";
-	pixel_y = 22;
-	req_access = list("virology")
 	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -60999,8 +60938,7 @@
 /obj/effect/turf_decal/tile/yellow/opposingcorners,
 /obj/machinery/button/door/directional/north{
 	id = "chemisttop";
-	name = "Pharmacy Shutters";
-	pixel_y = 40
+	name = "Pharmacy Shutters"
 	},
 /turf/open/floor/iron/dark,
 /area/station/medical/pharmacy)
@@ -61022,7 +60960,6 @@
 /area/station/service/theater)
 "ptq" = (
 /obj/machinery/porta_turret/ai,
-/obj/structure/sign/warning/electric_shock/directional/south,
 /obj/structure/cable,
 /turf/open/floor/circuit/green,
 /area/station/ai_monitored/turret_protected/ai_upload)
@@ -61446,6 +61383,11 @@
 /obj/structure/cable,
 /turf/open/floor/iron/smooth,
 /area/station/maintenance/department/science/xenobiology)
+"pzg" = (
+/obj/structure/lattice,
+/obj/structure/sign/warning/docking/directional/north,
+/turf/open/space/basic,
+/area/space/nearstation)
 "pzh" = (
 /obj/structure/table/reinforced,
 /obj/machinery/door/window/brigdoor/right/directional/west{
@@ -62223,12 +62165,14 @@
 /turf/open/floor/iron/kitchen,
 /area/station/commons/dorms/laundry)
 "pHl" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/green/visible/layer2,
 /obj/machinery/atmospherics/pipe/smart/simple/dark/visible{
 	dir = 4
 	},
 /obj/machinery/atmospherics/components/binary/dp_vent_pump/high_volume/incinerator_atmos{
 	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/green/visible/layer2{
+	dir = 8
 	},
 /turf/open/floor/engine,
 /area/station/maintenance/disposal/incinerator)
@@ -62365,6 +62309,11 @@
 /obj/effect/turf_decal/tile/neutral/full,
 /turf/open/floor/iron/large,
 /area/station/science/lab)
+"pJu" = (
+/obj/structure/cable,
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
+/area/station/security/warden)
 "pJM" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -62503,6 +62452,7 @@
 /obj/effect/turf_decal/box/red,
 /obj/machinery/portable_atmospherics/canister,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/machinery/button/door/incinerator_vent_ordmix/directional/north,
 /turf/open/floor/iron/dark,
 /area/station/science/ordnance)
 "pLe" = (
@@ -64000,6 +63950,10 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/machinery/atmospherics/pipe/smart/simple/green/visible{
+	dir = 4
+	},
+/obj/machinery/meter,
 /turf/open/floor/iron,
 /area/station/maintenance/disposal/incinerator)
 "qbP" = (
@@ -64431,6 +64385,7 @@
 /obj/effect/turf_decal/tile/green{
 	dir = 8
 	},
+/obj/machinery/door_buttons/access_button/directional/west,
 /turf/open/floor/iron/white,
 /area/station/medical/virology)
 "qig" = (
@@ -65680,13 +65635,13 @@
 /obj/machinery/newscaster/directional/west,
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/light/small/directional/east,
-/obj/machinery/button/door/directional/south{
+/obj/item/food/sandwich/cheese/grilled,
+/obj/machinery/button/door/directional/east{
 	id = "Toilet_Med";
 	name = "Lock Control";
 	normaldoorcontrol = 1;
 	specialfunctions = 4
 	},
-/obj/item/food/sandwich/cheese/grilled,
 /turf/open/floor/iron/cafeteria,
 /area/station/medical/break_room)
 "qzT" = (
@@ -65851,6 +65806,13 @@
 	},
 /obj/item/restraints/handcuffs,
 /obj/item/assembly/flash/handheld,
+/obj/machinery/button/door/table{
+	pixel_y = 9;
+	pixel_x = -6;
+	id = "armouryaccess";
+	name = "Armoury Access";
+	req_access = list("armory")
+	},
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/security/armory)
 "qBF" = (
@@ -66051,7 +66013,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/structure/sign/warning/biohazard/directional/north,
+/obj/machinery/door_buttons/access_button/directional/north,
 /turf/open/floor/iron,
 /area/station/medical/virology)
 "qDZ" = (
@@ -66559,8 +66521,10 @@
 /area/station/ai_monitored/aisat/exterior)
 "qKk" = (
 /obj/structure/table/wood,
-/obj/item/radio/intercom,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/item/radio/intercom{
+	pixel_y = 32
+	},
 /turf/open/floor/iron/dark,
 /area/station/security/courtroom)
 "qKs" = (
@@ -66694,6 +66658,10 @@
 /obj/effect/turf_decal/tile/neutral/anticorner/contrasted{
 	dir = 1
 	},
+/obj/machinery/airlock_controller/incinerator_ordmix{
+	dir = 4;
+	pixel_x = -12
+	},
 /turf/open/floor/iron/dark,
 /area/station/science/ordnance)
 "qLu" = (
@@ -66743,10 +66711,6 @@
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron,
 /area/station/hallway/primary/central/aft)
-"qLJ" = (
-/obj/structure/sign/nanotrasen,
-/turf/closed/wall/r_wall,
-/area/station/security/checkpoint/engineering)
 "qLO" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/suit_storage_unit/engine,
@@ -67717,10 +67681,10 @@
 "raL" = (
 /obj/structure/cable,
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/layer_manifold/green/visible{
-	dir = 4
-	},
 /obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/machinery/atmospherics/pipe/smart/simple/green/visible{
+	dir = 6
+	},
 /turf/open/floor/iron/dark,
 /area/station/maintenance/disposal/incinerator)
 "raQ" = (
@@ -67734,6 +67698,9 @@
 /obj/effect/mapping_helpers/requests_console/assistance,
 /obj/effect/turf_decal/bot_white,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/machinery/camera/directional/north{
+	c_tag = "Security - Head of Security's Office"
+	},
 /turf/open/floor/iron/dark,
 /area/station/command/heads_quarters/hos)
 "rbb" = (
@@ -68026,8 +67993,8 @@
 /obj/structure/bed/medical{
 	dir = 4
 	},
-/obj/structure/window/reinforced/spawner/directional/east,
 /obj/effect/turf_decal/tile/blue/fourcorners,
+/obj/structure/window/half/directional/east,
 /turf/open/floor/iron,
 /area/station/medical/treatment_center)
 "rfG" = (
@@ -68333,6 +68300,13 @@
 /obj/effect/landmark/start/hangover,
 /turf/open/floor/iron/white,
 /area/station/medical/medbay)
+"riV" = (
+/obj/effect/spawner/structure/window/reinforced/plasma,
+/obj/machinery/atmospherics/pipe/smart/simple/green/visible{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/station/engineering/atmos/hfr_room)
 "rjd" = (
 /obj/structure/table/wood,
 /obj/item/flashlight/lamp/green,
@@ -68584,11 +68558,13 @@
 /turf/open/floor/iron/grimy,
 /area/station/security/detectives_office)
 "rlE" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/green/visible/layer2,
 /obj/machinery/atmospherics/pipe/smart/simple/dark/visible{
 	dir = 4
 	},
 /obj/machinery/air_sensor/incinerator_tank,
+/obj/machinery/atmospherics/pipe/smart/simple/green/visible/layer2{
+	dir = 6
+	},
 /turf/open/floor/engine/vacuum,
 /area/station/maintenance/disposal/incinerator)
 "rlG" = (
@@ -68710,9 +68686,6 @@
 "rmk" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 10
-	},
-/obj/structure/sign/nanotrasen{
-	pixel_y = -32
 	},
 /turf/open/floor/iron,
 /area/station/science/auxlab/firing_range)
@@ -69442,17 +69415,16 @@
 /turf/open/floor/iron/dark,
 /area/station/service/kitchen)
 "rxN" = (
-/obj/machinery/turretid/directional/south{
-	icon_state = "control_stun";
-	name = "AI Chamber turret control"
-	},
 /obj/machinery/door/window/brigdoor/left/directional/west{
 	name = "Primary AI Core Access";
 	req_access = list("ai_upload")
 	},
 /obj/structure/cable,
-/obj/machinery/power/apc/auto_name/directional/north,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/machinery/power/apc/auto_name/directional/south,
+/obj/machinery/turretid/directional/north{
+	name = "AI Chamber turret control"
+	},
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/turret_protected/ai)
 "rxT" = (
@@ -69759,8 +69731,7 @@
 /obj/machinery/button/door/directional/north{
 	id = "engdoor";
 	name = "Engineering Cell Control";
-	normaldoorcontrol = 1;
-	pixel_y = 37
+	normaldoorcontrol = 1
 	},
 /obj/effect/turf_decal/bot,
 /obj/effect/turf_decal/tile/red/anticorner/contrasted{
@@ -69925,10 +69896,10 @@
 /obj/machinery/mineral/stacking_machine{
 	input_dir = 2
 	},
-/obj/structure/window/reinforced/spawner/directional/east,
-/obj/structure/window/reinforced/spawner/directional/north,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/bot,
+/obj/structure/window/half/directional/north,
+/obj/structure/window/half/directional/east,
 /turf/open/floor/iron,
 /area/station/maintenance/disposal)
 "rEe" = (
@@ -70064,10 +70035,6 @@
 "rFV" = (
 /obj/effect/turf_decal/bot,
 /obj/structure/disposalpipe/trunk,
-/obj/machinery/camera/directional/north{
-	c_tag = "Security - Office Fore";
-	dir = 9
-	},
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /obj/machinery/light/directional/north,
 /obj/machinery/disposal/bin/tagger,
@@ -70126,6 +70093,11 @@
 	dir = 8
 	},
 /turf/open/floor/wood,
+/area/station/service/abandoned_gambling_den)
+"rGW" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/sign/calendar/directional/north,
+/turf/open/floor/plating,
 /area/station/service/abandoned_gambling_den)
 "rGZ" = (
 /obj/structure/cable,
@@ -70268,7 +70240,6 @@
 /turf/open/floor/iron,
 /area/station/service/hydroponics)
 "rII" = (
-/obj/structure/window/reinforced/spawner/directional/east,
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
@@ -70285,6 +70256,7 @@
 /obj/effect/turf_decal/tile/brown/half/contrasted{
 	dir = 1
 	},
+/obj/structure/window/half/directional/east,
 /turf/open/floor/iron,
 /area/station/cargo/sorting)
 "rIM" = (
@@ -70807,11 +70779,6 @@
 /turf/open/floor/iron,
 /area/station/engineering/storage/tech)
 "rOS" = (
-/obj/machinery/button/door/directional/south{
-	id = "armouryaccess";
-	name = "Armoury Access";
-	req_access = list("armory")
-	},
 /obj/effect/turf_decal/trimline/dark_red/filled/line{
 	dir = 10
 	},
@@ -71688,7 +71655,8 @@
 "rYE" = (
 /obj/structure/table/reinforced,
 /obj/structure/window/reinforced/spawner/directional/east,
-/obj/machinery/button/door{
+/obj/machinery/button/door/incinerator_vent_atmos_aux/table{
+	pixel_y = 6;
 	id = "xeno4";
 	name = "Containment Control";
 	req_access = list("xenobiology")
@@ -71772,7 +71740,9 @@
 "rZE" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/security/glass{
-	name = "Prison Wing"
+	name = "Prison Wing";
+	dir = 4;
+	manual_align = 1
 	},
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 8
@@ -72048,6 +72018,18 @@
 	req_access = list("ai_upload")
 	},
 /obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/machinery/button/door/directional/north{
+	id = "aicorewindow";
+	name = "AI Core Shutters";
+	req_access = list("ai_upload")
+	},
+/obj/machinery/button/door/directional/north{
+	pixel_y = 24;
+	id = "aicoredoor";
+	name = "AI Chamber Access Control";
+	req_access = list("ai_upload")
+	},
+/obj/machinery/flasher/directional/south,
 /obj/machinery/light/small/directional/south,
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/turret_protected/ai)
@@ -72081,6 +72063,7 @@
 	dir = 4
 	},
 /obj/structure/sign/nanotrasen,
+/obj/structure/sign/warning/biohazard/directional/north,
 /turf/open/floor/iron,
 /area/station/medical/virology)
 "sdB" = (
@@ -72600,14 +72583,6 @@
 /obj/machinery/light_switch/directional/north{
 	pixel_x = -8
 	},
-/obj/machinery/button/door{
-	id = "rdordnance";
-	name = "Ordnance Containment Control";
-	pixel_x = 8;
-	pixel_y = 26;
-	req_access = list("science")
-	},
-/obj/structure/filingcabinet/chestdrawer,
 /obj/effect/turf_decal/trimline/purple/filled/line{
 	dir = 1
 	},
@@ -72616,6 +72591,7 @@
 	name = "science camera";
 	network = list("ss13","rd")
 	},
+/obj/structure/filingcabinet/chestdrawer,
 /turf/open/floor/iron/white,
 /area/station/science/ordnance/office)
 "skC" = (
@@ -73123,27 +73099,6 @@
 /turf/open/floor/iron,
 /area/station/commons/vacant_room/commissary)
 "ssr" = (
-/obj/machinery/button/door{
-	id = "brigwindows";
-	name = "Cell Window Control";
-	pixel_x = -32;
-	pixel_y = -26;
-	req_access = list("security")
-	},
-/obj/machinery/button/door{
-	id = "brigfront";
-	name = "Brig Access Control";
-	pixel_x = -26;
-	pixel_y = -36;
-	req_access = list("security")
-	},
-/obj/machinery/button/door{
-	id = "brigprison";
-	name = "Prison Lockdown";
-	pixel_x = -38;
-	pixel_y = -36;
-	req_access = list("brig")
-	},
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -73353,12 +73308,13 @@
 /area/station/engineering/atmos)
 "svc" = (
 /obj/structure/table/reinforced,
-/obj/machinery/button/door{
+/obj/structure/window/reinforced/spawner/directional/east,
+/obj/machinery/button/door/incinerator_vent_atmos_aux/table{
+	pixel_y = 6;
 	id = "xeno7";
 	name = "Containment Control";
 	req_access = list("xenobiology")
 	},
-/obj/structure/window/reinforced/spawner/directional/east,
 /turf/open/floor/iron,
 /area/station/science/xenobiology)
 "svd" = (
@@ -73455,6 +73411,35 @@
 "swn" = (
 /obj/effect/turf_decal/tile/red/half/contrasted{
 	dir = 1
+	},
+/obj/machinery/button/ignition/incinerator/ordmix/table{
+	id = "justicespark";
+	name = "ignition switch";
+	req_access = list("armory");
+	pixel_y = 5;
+	pixel_x = 4
+	},
+/obj/structure/table/reinforced,
+/obj/machinery/button/ignition/incinerator/ordmix/table{
+	id = "justiceflash";
+	name = "flasher button";
+	req_access = list("armory");
+	pixel_y = 5;
+	pixel_x = -8
+	},
+/obj/machinery/button/door/incinerator_vent_atmos_aux/table{
+	pixel_y = 13;
+	pixel_x = 4;
+	id = "justicechamber";
+	name = "Justice Chamber Control";
+	req_access = list("armory")
+	},
+/obj/machinery/button/door/incinerator_vent_atmos_aux/table{
+	pixel_y = 13;
+	pixel_x = -8;
+	id = "justiceblast";
+	name = "Justice Shutters Control";
+	req_access = list("armory")
 	},
 /turf/open/floor/iron/dark,
 /area/station/security/execution/education)
@@ -74182,10 +74167,6 @@
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron,
 /area/station/hallway/primary/starboard)
-"sGz" = (
-/obj/structure/sign/nanotrasen,
-/turf/closed/wall,
-/area/station/command/heads_quarters/hop)
 "sGB" = (
 /obj/machinery/airalarm/directional/east,
 /obj/machinery/disposal/bin,
@@ -74825,6 +74806,11 @@
 	dir = 8
 	},
 /area/station/service/chapel)
+"sOK" = (
+/obj/structure/window/reinforced/spawner/directional/south,
+/obj/structure/sign/warning/electric_shock/directional/north,
+/turf/open/space,
+/area/space/nearstation)
 "sOM" = (
 /obj/machinery/navbeacon{
 	codes_txt = "patrol;next_patrol=hall4";
@@ -74916,6 +74902,10 @@
 /area/station/commons/fitness/recreation)
 "sQb" = (
 /obj/effect/turf_decal/stripes/line,
+/obj/machinery/meter,
+/obj/machinery/atmospherics/pipe/smart/simple/dark/visible{
+	dir = 4
+	},
 /turf/open/floor/iron,
 /area/station/maintenance/disposal/incinerator)
 "sQi" = (
@@ -75189,12 +75179,6 @@
 /area/station/engineering/supermatter/room)
 "sTq" = (
 /obj/structure/cable,
-/obj/machinery/button/flasher{
-	id = "Cell 2";
-	name = "Prisoner Flash";
-	pixel_x = 25;
-	pixel_y = 7
-	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/button/door/directional/east{
@@ -75205,6 +75189,10 @@
 	},
 /obj/effect/turf_decal/tile/red{
 	dir = 8
+	},
+/obj/machinery/button/flasher/directional/east{
+	id = "Cell 2";
+	name = "Prisoner Flash"
 	},
 /turf/open/floor/iron,
 /area/station/security/execution/transfer)
@@ -75696,6 +75684,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
+/obj/structure/window/half/directional/south,
 /turf/open/floor/plating,
 /area/station/maintenance/disposal)
 "sZv" = (
@@ -76195,6 +76184,7 @@
 /obj/machinery/atmospherics/components/tank/air{
 	dir = 9
 	},
+/obj/machinery/button/ignition/incinerator/ordmix/directional/north,
 /turf/open/floor/iron/dark,
 /area/station/science/ordnance)
 "tgN" = (
@@ -76607,12 +76597,13 @@
 /area/station/service/library/abandoned)
 "tnN" = (
 /obj/structure/table/reinforced,
-/obj/machinery/button/door{
+/obj/structure/window/reinforced/spawner/directional/east,
+/obj/machinery/button/door/incinerator_vent_atmos_aux/table{
+	pixel_y = 6;
 	id = "xeno5";
 	name = "Containment Control";
 	req_access = list("xenobiology")
 	},
-/obj/structure/window/reinforced/spawner/directional/east,
 /turf/open/floor/iron,
 /area/station/science/xenobiology)
 "tnR" = (
@@ -77190,6 +77181,10 @@
 	},
 /turf/open/floor/iron,
 /area/station/maintenance/department/security)
+"tuw" = (
+/obj/effect/spawner/structure/window,
+/turf/open/floor/plating,
+/area/station/maintenance/disposal)
 "tuy" = (
 /obj/machinery/duct,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -77500,10 +77495,8 @@
 /obj/machinery/atmospherics/components/binary/pump/on{
 	dir = 8
 	},
-/obj/machinery/airlock_sensor/incinerator_ordmix{
-	pixel_y = 24
-	},
 /obj/machinery/atmospherics/pipe/layer_manifold/scrubbers/hidden,
+/obj/machinery/airlock_sensor/incinerator_ordmix,
 /turf/open/floor/engine,
 /area/station/science/ordnance/burnchamber)
 "tzT" = (
@@ -78635,6 +78628,7 @@
 /obj/machinery/door/firedoor/border_only{
 	dir = 8
 	},
+/obj/structure/sign/poster/random/directional/north,
 /turf/open/floor/wood,
 /area/station/service/theater)
 "tNP" = (
@@ -79005,6 +78999,7 @@
 /obj/effect/turf_decal/tile/red/opposingcorners{
 	dir = 1
 	},
+/obj/item/radio/intercom/directional/south,
 /turf/open/floor/iron/cafeteria,
 /area/station/service/barber)
 "tRu" = (
@@ -79890,11 +79885,10 @@
 /obj/machinery/disposal/delivery_chute{
 	dir = 4
 	},
-/obj/structure/window/reinforced/spawner/directional/south,
-/obj/structure/window/reinforced/spawner/directional/west,
-/obj/structure/window/reinforced/spawner/directional/north,
 /obj/effect/turf_decal/delivery,
 /obj/machinery/door/window/right/directional/east,
+/obj/structure/window/half/directional/south,
+/obj/structure/window/half/directional/north,
 /turf/open/floor/iron,
 /area/station/maintenance/disposal)
 "ucT" = (
@@ -79976,6 +79970,9 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/stripes/line{
 	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/green/visible{
+	dir = 4
 	},
 /turf/open/floor/iron,
 /area/station/maintenance/disposal/incinerator)
@@ -80071,7 +80068,8 @@
 "ueC" = (
 /obj/structure/table/reinforced,
 /obj/structure/window/reinforced/spawner/directional/east,
-/obj/machinery/button/door{
+/obj/machinery/button/door/incinerator_vent_atmos_aux/table{
+	pixel_y = 6;
 	id = "xeno2";
 	name = "Containment Control";
 	req_access = list("xenobiology")
@@ -80903,7 +80901,7 @@
 /area/station/security/checkpoint/arrivals)
 "uqX" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/sign/poster/random/directional/north,
+/obj/machinery/status_display/ai/directional/north,
 /turf/open/floor/wood,
 /area/station/service/theater)
 "uqZ" = (
@@ -82284,7 +82282,6 @@
 "uIK" = (
 /obj/effect/landmark/navigate_destination/dockesc,
 /obj/effect/turf_decal/delivery,
-/obj/structure/sign/warning/vacuum/directional/south,
 /turf/open/floor/iron,
 /area/station/hallway/secondary/exit/departure_lounge)
 "uIM" = (
@@ -82700,6 +82697,7 @@
 "uNh" = (
 /obj/item/kirbyplants/random,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/structure/sign/plaques/kiddie,
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/turret_protected/aisat_interior)
 "uNq" = (
@@ -82707,6 +82705,9 @@
 	dir = 9
 	},
 /obj/structure/sign/warning/electric_shock/directional/north,
+/obj/machinery/atmospherics/pipe/smart/simple/green/visible{
+	dir = 4
+	},
 /turf/open/floor/iron,
 /area/station/engineering/atmos/hfr_room)
 "uNy" = (
@@ -84632,12 +84633,8 @@
 /area/station/engineering/main)
 "vod" = (
 /obj/item/kirbyplants/random,
-/obj/machinery/button/door/directional/south{
-	id = "Interro_shutters";
-	name = "Shutters Control";
-	req_access = list("security")
-	},
 /obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/machinery/airalarm/directional/south,
 /turf/open/floor/iron/dark,
 /area/station/security/interrogation)
 "voe" = (
@@ -84736,9 +84733,14 @@
 "vpC" = (
 /obj/item/storage/medkit/regular,
 /obj/structure/table,
-/obj/machinery/airalarm/directional/north,
 /obj/effect/turf_decal/tile/neutral/anticorner/contrasted{
 	dir = 8
+	},
+/obj/machinery/airalarm/directional/north,
+/obj/machinery/button/door/directional/north{
+	id = "cmoshutter";
+	name = "CMO Office Shutters";
+	req_access = list("cmo")
 	},
 /turf/open/floor/iron,
 /area/station/command/heads_quarters/cmo)
@@ -84785,17 +84787,6 @@
 "vqx" = (
 /obj/machinery/door/airlock/research/glass/incinerator/ordmix_interior{
 	name = "Burn Chamber Interior Airlock"
-	},
-/obj/machinery/button/ignition/incinerator/ordmix{
-	pixel_x = -6;
-	pixel_y = -24
-	},
-/obj/machinery/button/door/incinerator_vent_ordmix{
-	pixel_x = 8;
-	pixel_y = -24
-	},
-/obj/machinery/airlock_controller/incinerator_ordmix{
-	pixel_y = 32
 	},
 /obj/effect/mapping_helpers/airlock/locked,
 /obj/effect/turf_decal/stripes/line{
@@ -85078,7 +85069,6 @@
 /turf/open/floor/iron/dark,
 /area/station/science/circuits)
 "vub" = (
-/obj/machinery/light_switch/directional/west,
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
@@ -85504,6 +85494,7 @@
 /obj/effect/turf_decal/tile/brown/anticorner/contrasted{
 	dir = 1
 	},
+/obj/structure/sign/nanotrasen,
 /turf/open/floor/iron,
 /area/station/cargo/lobby)
 "vyO" = (
@@ -85519,6 +85510,11 @@
 /obj/structure/table/reinforced,
 /obj/item/storage/belt/utility,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/machinery/button/door/directional/east{
+	id = "evashutters";
+	name = "E.V.A. Shutters";
+	req_access = list("command")
+	},
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/command/storage/eva)
 "vyX" = (
@@ -85567,7 +85563,9 @@
 "vzD" = (
 /obj/structure/table/wood,
 /obj/structure/cable,
-/obj/item/radio/intercom,
+/obj/item/radio/intercom{
+	pixel_y = 32
+	},
 /turf/open/floor/iron/dark,
 /area/station/command/corporate_showroom)
 "vzK" = (
@@ -85805,10 +85803,6 @@
 	icon_state = "foam_plating"
 	},
 /area/station/maintenance/department/science/xenobiology)
-"vBX" = (
-/obj/structure/sign/nanotrasen,
-/turf/closed/wall,
-/area/station/engineering/storage/tech)
 "vBY" = (
 /obj/effect/turf_decal/tile/yellow/half/contrasted{
 	dir = 4
@@ -86061,7 +86055,6 @@
 /obj/structure/cable,
 /obj/machinery/camera/directional/east{
 	c_tag = "Dormitories - Hall";
-	dir = 6;
 	name = "dormitories camera"
 	},
 /obj/effect/turf_decal/tile/neutral/half/contrasted{
@@ -86783,9 +86776,12 @@
 /turf/open/floor/iron,
 /area/station/science/robotics/lab)
 "vPZ" = (
-/obj/machinery/atmospherics/pipe/smart/simple/dark/visible,
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
+	},
+/obj/machinery/airlock_controller/incinerator_atmos{
+	dir = 4;
+	pixel_x = -12
 	},
 /turf/open/floor/iron,
 /area/station/maintenance/disposal/incinerator)
@@ -86999,6 +86995,7 @@
 /obj/effect/turf_decal/bot,
 /obj/structure/closet/emcloset,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/structure/sign/nanotrasen,
 /turf/open/floor/iron/dark,
 /area/station/hallway/primary/port)
 "vTC" = (
@@ -88877,13 +88874,13 @@
 /area/station/engineering/atmos/storage)
 "wqQ" = (
 /obj/item/radio/intercom/directional/east,
-/obj/structure/window/reinforced/spawner/directional/south,
 /obj/effect/turf_decal/trimline/blue/end{
 	dir = 8
 	},
 /obj/effect/turf_decal/siding/blue,
 /obj/machinery/shower/directional/west,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/structure/window/half/directional/south,
 /turf/open/floor/iron/textured,
 /area/station/medical/cryo)
 "wqT" = (
@@ -89551,6 +89548,15 @@
 /mob/living/basic/lizard/eats_the_roaches,
 /turf/open/floor/iron/checker,
 /area/station/service/janitor)
+"wzz" = (
+/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/effect/turf_decal/caution/stand_clear,
+/obj/structure/sign/warning/vacuum/directional/north,
+/turf/open/floor/iron,
+/area/station/cargo/storage)
 "wzD" = (
 /obj/machinery/portable_atmospherics/pump,
 /obj/effect/turf_decal/bot,
@@ -90321,6 +90327,7 @@
 /turf/open/floor/iron/white,
 /area/station/medical/pharmacy)
 "wIO" = (
+/obj/machinery/atmospherics/pipe/smart/simple/dark/visible,
 /turf/open/floor/engine,
 /area/station/maintenance/disposal/incinerator)
 "wJa" = (
@@ -90746,14 +90753,13 @@
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/command/nuke_storage)
 "wPW" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/green/visible/layer2,
-/obj/machinery/atmospherics/pipe/smart/simple/dark/visible{
-	dir = 10
-	},
-/obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/smart/simple/green/visible{
+	dir = 4
+	},
+/obj/machinery/meter,
 /turf/open/floor/iron,
 /area/station/maintenance/disposal/incinerator)
 "wQo" = (
@@ -90958,11 +90964,13 @@
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/lobby)
 "wTc" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/green/visible/layer2,
-/obj/machinery/atmospherics/pipe/smart/simple/dark/visible{
-	dir = 4
-	},
 /obj/machinery/airlock_sensor/incinerator_atmos,
+/obj/machinery/atmospherics/pipe/smart/simple/dark/visible{
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/green/visible/layer2{
+	dir = 8
+	},
 /turf/open/floor/engine,
 /area/station/maintenance/disposal/incinerator)
 "wTg" = (
@@ -92182,11 +92190,9 @@
 /turf/open/floor/iron/white,
 /area/station/medical/medbay)
 "xka" = (
-/obj/item/radio/intercom/directional/north,
 /obj/machinery/button/door/directional/north{
 	id = "barber_door_lock";
 	normaldoorcontrol = 1;
-	pixel_y = 40;
 	specialfunctions = 4
 	},
 /obj/machinery/camera/directional/north{
@@ -92894,7 +92900,6 @@
 /turf/open/floor/iron/dark,
 /area/station/security/evidence)
 "xtf" = (
-/obj/machinery/airalarm/directional/east,
 /obj/machinery/light/cold/directional/east,
 /obj/effect/turf_decal/tile/red/anticorner/contrasted{
 	dir = 4
@@ -92955,6 +92960,12 @@
 /obj/effect/turf_decal/tile/neutral/anticorner/contrasted{
 	dir = 4
 	},
+/obj/machinery/button/door/incinerator_vent_atmos_aux/table{
+	pixel_y = 6;
+	id = "xenosecure";
+	name = "Containment Control";
+	req_access = list("xenobiology")
+	},
 /turf/open/floor/iron,
 /area/station/science/xenobiology)
 "xtB" = (
@@ -93011,6 +93022,9 @@
 /obj/item/cigarette/cigar{
 	pixel_x = -2;
 	pixel_y = 2
+	},
+/obj/machinery/keycard_auth{
+	pixel_y = 11
 	},
 /turf/open/floor/iron/grimy,
 /area/station/command/heads_quarters/hos)
@@ -93437,10 +93451,17 @@
 /area/station/service/theater)
 "xzH" = (
 /obj/structure/table/reinforced,
-/obj/item/paper_bin,
 /obj/item/pen,
 /obj/effect/turf_decal/tile/red/anticorner/contrasted{
 	dir = 8
+	},
+/obj/item/clipboard{
+	pixel_x = 6;
+	pixel_y = 7
+	},
+/obj/item/paper_bin,
+/obj/item/toy/figure/secofficer{
+	pixel_y = 7
 	},
 /turf/open/floor/iron,
 /area/station/security/holding_cell)
@@ -93588,7 +93609,9 @@
 /area/station/hallway/secondary/command)
 "xAN" = (
 /obj/structure/table/wood,
-/obj/item/radio/intercom,
+/obj/item/radio/intercom{
+	pixel_y = 32
+	},
 /obj/effect/turf_decal/tile/neutral/half/contrasted,
 /turf/open/floor/iron,
 /area/station/security/courtroom)
@@ -93789,6 +93812,9 @@
 	dir = 1
 	},
 /obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/smart/simple/green/visible{
+	dir = 4
+	},
 /turf/open/floor/iron,
 /area/station/engineering/atmos/hfr_room)
 "xDY" = (
@@ -93833,9 +93859,6 @@
 /turf/open/floor/iron/dark,
 /area/station/security/courtroom)
 "xEF" = (
-/obj/machinery/computer/pod/old/mass_driver_controller/chapelgun{
-	pixel_x = 24
-	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/camera/directional/east{
 	c_tag = "Chapel - Funeral Room";
@@ -94428,9 +94451,9 @@
 /obj/structure/disposaloutlet{
 	dir = 1
 	},
-/obj/structure/window/reinforced/spawner/directional/east,
 /obj/effect/turf_decal/delivery,
-/obj/structure/window/reinforced/spawner/directional/west,
+/obj/structure/window/half/directional/east,
+/obj/structure/window/half/directional/west,
 /turf/open/floor/iron,
 /area/station/cargo/sorting)
 "xLE" = (
@@ -94494,12 +94517,12 @@
 /area/station/hallway/secondary/service)
 "xMi" = (
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/dark/visible{
-	dir = 5
-	},
 /obj/machinery/camera/directional/north{
 	c_tag = "Atmospherics - Incinerator Control";
 	name = "atmospherics camera"
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/dark/visible{
+	dir = 4
 	},
 /turf/open/floor/iron,
 /area/station/maintenance/disposal/incinerator)
@@ -94633,10 +94656,6 @@
 	},
 /turf/open/floor/iron,
 /area/station/commons/fitness/recreation)
-"xOt" = (
-/obj/structure/sign/warning/electric_shock,
-/turf/closed/wall/r_wall,
-/area/station/command/heads_quarters/hop)
 "xOu" = (
 /obj/effect/spawner/random/structure/tank_holder,
 /turf/open/floor/plating,
@@ -96214,6 +96233,11 @@
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron/dark,
 /area/station/service/chapel)
+"ylS" = (
+/obj/structure/cable,
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
+/area/station/security/holding_cell)
 "ylT" = (
 /obj/machinery/newscaster/directional/west,
 /obj/effect/decal/cleanable/dirt,
@@ -104094,7 +104118,7 @@ sdK
 qdV
 qGs
 cdt
-idU
+oBW
 kXC
 jtr
 odk
@@ -104341,7 +104365,7 @@ lgs
 bYe
 tfl
 bYe
-kkh
+jCy
 bPC
 hmU
 hmU
@@ -104351,7 +104375,7 @@ hmU
 cfu
 ptq
 cdt
-pYJ
+sOK
 kXC
 xRE
 hfl
@@ -105107,7 +105131,7 @@ deX
 deX
 hkC
 kXJ
-bPH
+bPC
 uNh
 bYe
 tfl
@@ -105122,7 +105146,7 @@ hmU
 tEd
 cJh
 cdt
-idU
+oBW
 kXC
 uqd
 aaN
@@ -106907,7 +106931,7 @@ chU
 iIm
 pzp
 bPC
-uNh
+gOF
 asa
 uQY
 asa
@@ -108963,7 +108987,7 @@ qYo
 aad
 vVc
 aad
-bRP
+aJD
 eOb
 qdF
 gnO
@@ -114917,9 +114941,9 @@ iyO
 nCi
 vPU
 fqm
-iDs
-oSN
-iDs
+aaa
+qYo
+aaa
 aaa
 uHd
 aaa
@@ -116978,7 +117002,7 @@ mAt
 cRJ
 mAt
 mAt
-pBY
+rGW
 mVi
 fUf
 hSE
@@ -117138,7 +117162,7 @@ vVc
 edx
 wTc
 wIO
-edx
+kgL
 ltx
 aIp
 edx
@@ -119706,7 +119730,7 @@ ixO
 vlA
 vlA
 vlA
-gAL
+mtx
 iXp
 wSR
 wSR
@@ -119813,7 +119837,7 @@ pNA
 tmc
 fza
 lgW
-dJY
+jtC
 fYR
 aad
 aaa
@@ -120734,7 +120758,7 @@ vlA
 vlA
 vlA
 vlA
-epV
+riV
 vkL
 dYj
 dYj
@@ -121297,7 +121321,7 @@ oGb
 qYo
 oGb
 lGF
-qOL
+kTS
 iBR
 iBR
 wxd
@@ -122327,7 +122351,7 @@ eSk
 wif
 pEY
 vvp
-lDV
+tqo
 tUg
 gmP
 qeP
@@ -123866,8 +123890,8 @@ rov
 bjl
 lNk
 nSJ
-bDX
-qLJ
+rov
+wGA
 wGA
 wGA
 rAH
@@ -125154,7 +125178,7 @@ dGS
 dGS
 dGS
 dGS
-vBX
+dGS
 dsy
 nps
 nps
@@ -125218,7 +125242,7 @@ mdm
 jYs
 rxK
 hGW
-hEt
+kzc
 pFd
 qQM
 pqg
@@ -131586,7 +131610,7 @@ hWA
 iaL
 pRS
 iaL
-xOt
+pRS
 iaL
 pRS
 pRS
@@ -131849,7 +131873,7 @@ oEu
 lZx
 lZx
 dQf
-sGz
+lZx
 pRS
 mcv
 qLS
@@ -132097,7 +132121,7 @@ mGw
 pRS
 ahm
 lNA
-ozz
+iDZ
 lNA
 ozz
 lNA
@@ -135672,7 +135696,7 @@ qAV
 ttF
 qAV
 qAV
-okb
+qAV
 rKN
 pXg
 jkf
@@ -137574,7 +137598,7 @@ fvo
 fvo
 nEa
 jSQ
-aBn
+nEa
 fvo
 nEa
 nEa
@@ -138603,8 +138627,8 @@ thB
 ivz
 jTa
 eWi
-hLt
-qYo
+nxb
+pzg
 aaa
 aaa
 aaa
@@ -142320,8 +142344,8 @@ vno
 aad
 kic
 vcz
-kic
-kic
+tuw
+tuw
 xBu
 mvv
 fkS
@@ -142332,8 +142356,8 @@ aad
 tDx
 xEO
 bti
-hhK
-bti
+jrp
+wzz
 sJi
 tDx
 aad
@@ -146235,7 +146259,7 @@ hOz
 gmz
 mTA
 mTA
-tNZ
+ylS
 nIb
 dth
 hmi
@@ -146964,7 +146988,7 @@ vXr
 vXr
 qIH
 qIH
-qIH
+dCD
 nJY
 qIH
 qIH
@@ -148289,7 +148313,7 @@ gIB
 cPF
 vEV
 efg
-lra
+pJu
 ozt
 eAV
 mDF
@@ -151096,7 +151120,7 @@ cLX
 aNq
 oYp
 aNq
-ida
+nNV
 psx
 kOA
 aaa


### PR DESCRIPTION
things not done:
- not all the doors dir set (only ones that don't auto-align correctly) 
- no table item offsetting done
- virology entrance may need a remap (no south facing airlock access buttons kinda sucks) 
- library needs to be remapped entirely (i can't bring myself to do it i like the current design too much) 

things broken/missing noticed in mapping (and as such i kinda left untouched):

- no table mount intercoms
- some posters (the non-random ones. despite using the correct directional helper, looks fine in editor but not in game
- direction signs (the ones that go `-> sec`) are broken
- no directional wallmounts for nanotrasen signs (they offset themselves, not shown in editor)
- no directional helpers for supply shuttle status display (self offset, not shown in editor
- digital clocks seem to have broken offsets as well
- no directional helpers for airlock access presets (ord, atmos incin)
- barricades are a bit jank in general, primarily those made from the rng mapping helper
- some sign dirs are reversed north/south. i think? maybe same issues with posters mentioned above
- turret controls seem to have messed up icon states, semi invisible. also the south dir one looks off (though maybe not supposed to exist)
- apcs very difficult to map because of reverse dir in editor

other notes:
- loss of detailing felt very heavily. for every 1 sign moved, i deleted probably 6-8. 
- ability to put two mounts on opposites sides of a wall, however, is also really felt. love it for condensing space
- probably should delete south/east/west poster/sign helpers entirely since they don't work
