### PR TITLE
Fixes APC Construction

### DIFF
--- a/code/modules/power/apc/apc_tool_act.dm
+++ b/code/modules/power/apc/apc_tool_act.dm
@@ -60,7 +60,7 @@
 		balloon_alert(user, "cell already installed!")
 		return ITEM_INTERACT_BLOCKING
 	if(machine_stat & MAINT)
-		balloon_alert(user, "no connector for a cell!")
+		balloon_alert(user, "no connector for a cell!") //We are stuck here
 		return ITEM_INTERACT_BLOCKING
 	if(!user.transferItemToLoc(new_cell, src))
 		return ITEM_INTERACT_BLOCKING
@@ -160,6 +160,7 @@
 	locked = FALSE
 	balloon_alert(user, "board installed")
 	qdel(installing_board)
+	set_machine_stat(machine_stat & ~MAINT)
 	return ITEM_INTERACT_SUCCESS
 
 /// Called when we interact with the APC with an electroadaptive pseudocircuit, used by cyborgs to install a board or weak cell

--- a/code/modules/power/apc/apc_tool_act.dm
+++ b/code/modules/power/apc/apc_tool_act.dm
@@ -160,7 +160,6 @@
 	locked = FALSE
 	balloon_alert(user, "board installed")
 	qdel(installing_board)
-	set_machine_stat(machine_stat & ~MAINT)
 	return ITEM_INTERACT_SUCCESS
 
 /// Called when we interact with the APC with an electroadaptive pseudocircuit, used by cyborgs to install a board or weak cell
@@ -305,7 +304,7 @@
 	. = TRUE
 
 	//You can only touch the electronics if the panel and tray are open, and the terminal is yoten
-	if(!opened || !panel_open || terminal)
+	if((!opened || !panel_open || terminal) && !(machine_stat & MAINT))
 		if(obj_flags & EMAGGED)
 			balloon_alert(user, "interface is broken!")
 			return


### PR DESCRIPTION
## About The Pull Request

Adds a check to the APC construction process to verify if we're in the MAINT machine_status bitflag, so that you can successfully fasten the APC board when building.

![image](https://github.com/user-attachments/assets/6b214e49-aff9-472c-8780-ac30c855c820)

I hate to say it but it was potato's fault
easy fix