### PR TITLE
Camera mobs (AI eye and Blob eye) don't have shadows

### DIFF
--- a/code/datums/components/drop_shadow.dm
+++ b/code/datums/components/drop_shadow.dm
@@ -25,7 +25,6 @@
 		layer = BELOW_MOB_LAYER,
 		appearance_flags = KEEP_APART | RESET_TRANSFORM | RESET_COLOR
 	)
-	shadow.mouse_opacity = MOUSE_OPACITY_TRANSPARENT
 	shadow.pixel_x = shadow_offset_x - movable_parent.pixel_x
 	update_shadow_position()
 

--- a/code/datums/components/drop_shadow.dm
+++ b/code/datums/components/drop_shadow.dm
@@ -25,6 +25,7 @@
 		layer = BELOW_MOB_LAYER,
 		appearance_flags = KEEP_APART | RESET_TRANSFORM | RESET_COLOR
 	)
+	shadow.mouse_opacity = MOUSE_OPACITY_TRANSPARENT
 	shadow.pixel_x = shadow_offset_x - movable_parent.pixel_x
 	update_shadow_position()
 

--- a/code/modules/mob/camera/camera.dm
+++ b/code/modules/mob/camera/camera.dm
@@ -1,5 +1,6 @@
 // Camera mob, used by AI camera and blob.
 /mob/camera
+	SET_BASE_VISUAL_PIXEL(0, 0) // These are selecting floor tiles
 	name = "camera mob"
 	density = FALSE
 	move_force = INFINITY

--- a/code/modules/mob/camera/camera.dm
+++ b/code/modules/mob/camera/camera.dm
@@ -8,6 +8,7 @@
 	mouse_opacity = MOUSE_OPACITY_TRANSPARENT
 	invisibility = INVISIBILITY_ABSTRACT // No one can see us
 	sight = SEE_SELF
+	shadow_type = SHADOW_NONE
 	/// Toggles if the camera can move on shuttles
 	var/move_on_shuttle = FALSE
 	/// Toggles if the camera can use emotes


### PR DESCRIPTION
Fixes https://github.com/tgstation/tgstation/issues/85765
(Do cross repo links like this even work?)
(Lemon: if someone with perms on the repo in question merges it yes? I think?)

This removes the shadow from the AI and blob cursor mobs (the AI one is only visible to observers anyway IIRC).
Also removes the offset from them; they're "cursors" which are selecting floor tiles.

I was also interested in investigating "not letting you click on the shadow as a hitbox" but that doesn't seem to be a supported behaviour in BYOND. 
It's not intentional for this to make mobs easier to click but... I guess it will.

Is that bad? I guess personally, while I didn't put it into the game with this intention, not really?
I have never thought pixel hunting was interesting skill expression and we're going to have swing combat eventually so maybe we just call it a feature 🙃 