### PR TITLE
Delta shuttles (cargo-escape-whiteship)

### DIFF
--- a/_maps/shuttles/cargo_delta.dmm
+++ b/_maps/shuttles/cargo_delta.dmm
@@ -58,7 +58,8 @@
 	},
 /obj/machinery/door/poddoor{
 	id = "cargounload";
-	name = "Supply Dock Unloading Door"
+	name = "Supply Dock Unloading Door";
+	dir = 4
 	},
 /turf/open/floor/plating,
 /area/shuttle/supply)
@@ -75,7 +76,8 @@
 /area/shuttle/supply)
 "n" = (
 /obj/machinery/door/airlock/shuttle{
-	name = "Supply Shuttle Airlock"
+	name = "Supply Shuttle Airlock";
+	dir = 4
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/docking_port/mobile/supply{
@@ -100,7 +102,8 @@
 /area/shuttle/supply)
 "r" = (
 /obj/machinery/door/airlock/shuttle{
-	name = "Supply Shuttle Airlock"
+	name = "Supply Shuttle Airlock";
+	dir = 4
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/mapping_helpers/airlock/access/all/supply/general,
@@ -109,7 +112,8 @@
 "s" = (
 /obj/machinery/door/poddoor{
 	id = "cargoload";
-	name = "Supply Dock Loading Door"
+	name = "Supply Dock Loading Door";
+	dir = 4
 	},
 /obj/machinery/conveyor{
 	dir = 4;

--- a/_maps/shuttles/emergency_delta.dmm
+++ b/_maps/shuttles/emergency_delta.dmm
@@ -30,11 +30,6 @@
 "af" = (
 /turf/closed/wall/mineral/titanium,
 /area/shuttle/escape)
-"ag" = (
-/obj/structure/window/reinforced/shuttle,
-/obj/structure/grille,
-/turf/open/floor/plating,
-/area/shuttle/escape)
 "ah" = (
 /obj/item/clothing/suit/hazardvest{
 	desc = "A high-visibility lifejacket complete with whistle and slot for oxygen tanks.";
@@ -122,7 +117,9 @@
 /turf/open/floor/iron,
 /area/shuttle/escape)
 "aj" = (
-/obj/item/defibrillator/loaded,
+/obj/item/defibrillator/loaded{
+	pixel_y = 16
+	},
 /obj/structure/table/reinforced,
 /obj/effect/turf_decal/tile/blue/opposingcorners{
 	dir = 1
@@ -148,18 +145,30 @@
 /obj/item/scalpel{
 	pixel_y = 12
 	},
-/obj/item/circular_saw,
+/obj/item/circular_saw{
+	pixel_y = 10
+	},
 /obj/item/retractor{
-	pixel_x = 4
+	pixel_x = 4;
+	pixel_y = 9
 	},
 /obj/item/hemostat{
-	pixel_x = -4
+	pixel_x = -4;
+	pixel_y = 5
 	},
-/obj/item/clothing/gloves/latex,
-/obj/item/clothing/mask/surgical,
+/obj/item/clothing/gloves/latex{
+	pixel_y = 8
+	},
+/obj/item/clothing/mask/surgical{
+	pixel_y = 13
+	},
 /obj/structure/table/reinforced,
-/obj/item/surgicaldrill,
-/obj/item/cautery,
+/obj/item/surgicaldrill{
+	pixel_y = 14
+	},
+/obj/item/cautery{
+	pixel_y = 22
+	},
 /obj/item/radio/intercom/directional/east,
 /obj/effect/turf_decal/tile/blue/opposingcorners{
 	dir = 1
@@ -168,18 +177,20 @@
 /area/shuttle/escape)
 "ar" = (
 /obj/item/reagent_containers/cup/bottle/epinephrine{
-	pixel_x = 6
+	pixel_x = 6;
+	pixel_y = 10
 	},
 /obj/item/reagent_containers/cup/bottle/multiver{
-	pixel_x = -3
+	pixel_x = -3;
+	pixel_y = 16
 	},
 /obj/item/reagent_containers/cup/bottle/epinephrine{
 	pixel_x = -3;
-	pixel_y = 8
+	pixel_y = 25
 	},
 /obj/item/reagent_containers/cup/bottle/multiver{
 	pixel_x = 6;
-	pixel_y = 8
+	pixel_y = 22
 	},
 /obj/item/reagent_containers/syringe/epinephrine{
 	pixel_x = 3;
@@ -203,9 +214,7 @@
 /obj/effect/turf_decal/tile/blue/opposingcorners{
 	dir = 1
 	},
-/obj/machinery/camera/autoname{
-	dir = 8
-	},
+/obj/machinery/camera/autoname/directional/west,
 /turf/open/floor/iron/white,
 /area/shuttle/escape)
 "as" = (
@@ -218,10 +227,10 @@
 /turf/open/floor/iron/white,
 /area/shuttle/escape)
 "au" = (
-/obj/structure/sink/directional/west,
 /obj/effect/turf_decal/tile/blue/opposingcorners{
 	dir = 1
 	},
+/obj/structure/sink/directional/east,
 /turf/open/floor/iron/white,
 /area/shuttle/escape)
 "av" = (
@@ -300,12 +309,10 @@
 /turf/open/floor/grass,
 /area/shuttle/escape)
 "aJ" = (
-/obj/machinery/shower/directional/west{
-	name = "emergency shower"
-	},
 /obj/effect/turf_decal/tile/blue/half/contrasted{
 	dir = 4
 	},
+/obj/machinery/shower/directional/east,
 /turf/open/floor/iron/white,
 /area/shuttle/escape)
 "aL" = (
@@ -321,7 +328,9 @@
 "aN" = (
 /obj/structure/bed/medical/emergency,
 /obj/machinery/iv_drip,
-/obj/structure/extinguisher_cabinet/directional/east,
+/obj/structure/extinguisher_cabinet/directional/east{
+	pixel_y = 10
+	},
 /obj/machinery/light/small/directional/east,
 /obj/effect/turf_decal/tile/blue/anticorner/contrasted,
 /turf/open/floor/iron/white,
@@ -334,10 +343,6 @@
 	dir = 8
 	},
 /turf/open/floor/iron/white,
-/area/shuttle/escape)
-"aP" = (
-/obj/structure/sign/departments/medbay/alt,
-/turf/closed/wall/mineral/titanium,
 /area/shuttle/escape)
 "aQ" = (
 /obj/machinery/stasis,
@@ -391,6 +396,7 @@
 /obj/structure/extinguisher_cabinet/directional/west,
 /obj/machinery/shieldgen,
 /obj/effect/turf_decal/bot,
+/obj/machinery/light/small/directional/north,
 /turf/open/floor/iron,
 /area/shuttle/escape)
 "aZ" = (
@@ -407,7 +413,7 @@
 	pixel_y = -5
 	},
 /obj/effect/turf_decal/bot,
-/obj/machinery/light/small/directional/north,
+/obj/structure/sign/departments/medbay/alt/directional/north,
 /turf/open/floor/iron,
 /area/shuttle/escape)
 "ba" = (
@@ -518,10 +524,17 @@
 /area/shuttle/escape)
 "bq" = (
 /obj/structure/table,
-/obj/item/clipboard,
-/obj/item/folder/yellow,
+/obj/item/clipboard{
+	pixel_y = 12
+	},
+/obj/item/folder/yellow{
+	pixel_y = 12
+	},
 /obj/item/pen,
-/obj/item/hand_labeler_refill,
+/obj/item/hand_labeler_refill{
+	pixel_x = 4;
+	pixel_y = 5
+	},
 /obj/effect/turf_decal/bot,
 /turf/open/floor/iron,
 /area/shuttle/escape)
@@ -532,10 +545,14 @@
 /area/shuttle/escape)
 "bs" = (
 /obj/structure/table,
-/obj/machinery/cell_charger,
-/obj/item/stock_parts/power_store/cell/high,
+/obj/machinery/cell_charger{
+	pixel_y = 10
+	},
+/obj/item/stock_parts/power_store/cell/high{
+	pixel_y = 11
+	},
 /obj/effect/turf_decal/bot,
-/obj/machinery/camera/autoname,
+/obj/machinery/camera/autoname/directional/east,
 /turf/open/floor/iron,
 /area/shuttle/escape)
 "bt" = (
@@ -572,13 +589,19 @@
 /area/shuttle/escape/brig)
 "by" = (
 /obj/structure/table/reinforced,
-/obj/machinery/recharger,
+/obj/machinery/recharger{
+	pixel_y = 12
+	},
 /turf/open/floor/mineral/plastitanium/red,
 /area/shuttle/escape/brig)
 "bB" = (
 /obj/structure/table,
-/obj/item/clipboard,
-/obj/item/toy/figure/ninja,
+/obj/item/clipboard{
+	pixel_y = 10
+	},
+/obj/item/toy/figure/ninja{
+	pixel_y = 8
+	},
 /obj/effect/turf_decal/bot,
 /turf/open/floor/iron,
 /area/shuttle/escape)
@@ -642,14 +665,22 @@
 /area/shuttle/escape/brig)
 "bO" = (
 /obj/structure/table/reinforced,
-/obj/item/storage/lockbox/loyalty,
+/obj/item/storage/lockbox/loyalty{
+	pixel_y = 12
+	},
 /turf/open/floor/mineral/plastitanium/red,
 /area/shuttle/escape/brig)
 "bP" = (
 /obj/structure/table/reinforced,
-/obj/machinery/recharger,
+/obj/machinery/recharger{
+	pixel_y = 15
+	},
 /obj/effect/turf_decal/tile/red{
 	dir = 8
+	},
+/obj/machinery/button/flasher/table{
+	pixel_y = 2;
+	id = "shuttleflash"
 	},
 /turf/open/floor/iron,
 /area/shuttle/escape)
@@ -669,9 +700,7 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 4
 	},
-/obj/machinery/camera/autoname{
-	dir = 8
-	},
+/obj/machinery/camera/autoname/directional/west,
 /turf/open/floor/iron,
 /area/shuttle/escape)
 "bT" = (
@@ -688,7 +717,9 @@
 /area/shuttle/escape/brig)
 "bV" = (
 /obj/structure/table/reinforced,
-/obj/item/storage/box/zipties,
+/obj/item/storage/box/zipties{
+	pixel_y = 10
+	},
 /obj/item/radio/intercom/directional/south,
 /turf/open/floor/mineral/plastitanium/red,
 /area/shuttle/escape/brig)
@@ -818,7 +849,9 @@
 /area/shuttle/escape)
 "en" = (
 /obj/structure/table/reinforced,
-/obj/item/storage/toolbox/mechanical,
+/obj/item/storage/toolbox/mechanical{
+	pixel_y = 10
+	},
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron/dark,
 /area/shuttle/escape)
@@ -840,9 +873,7 @@
 	},
 /obj/effect/turf_decal/bot,
 /obj/structure/extinguisher_cabinet/directional/east,
-/obj/machinery/camera/autoname{
-	dir = 4
-	},
+/obj/machinery/camera/autoname/directional/east,
 /turf/open/floor/iron,
 /area/shuttle/escape)
 "jU" = (
@@ -884,7 +915,7 @@
 /area/shuttle/escape)
 "nJ" = (
 /obj/effect/turf_decal/tile/neutral/half/contrasted,
-/obj/machinery/camera/autoname,
+/obj/machinery/camera/autoname/directional/south,
 /turf/open/floor/iron,
 /area/shuttle/escape)
 "nL" = (
@@ -905,16 +936,16 @@
 /turf/open/floor/iron,
 /area/shuttle/escape)
 "pd" = (
-/obj/machinery/camera/autoname{
-	dir = 9
-	},
+/obj/machinery/camera/autoname/directional/north,
 /turf/open/floor/mineral/plastitanium/red,
 /area/shuttle/escape/brig)
 "pR" = (
-/obj/item/storage/medkit/fire,
+/obj/item/storage/medkit/fire{
+	pixel_y = 13
+	},
 /obj/item/storage/medkit/regular{
 	pixel_x = 2;
-	pixel_y = 3
+	pixel_y = 20
 	},
 /obj/structure/table/reinforced,
 /obj/effect/turf_decal/tile/blue/half/contrasted{
@@ -924,14 +955,20 @@
 /area/shuttle/escape)
 "sI" = (
 /obj/structure/table/reinforced,
-/obj/item/storage/fancy/donut_box,
+/obj/item/storage/fancy/donut_box{
+	pixel_y = 15
+	},
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron/dark,
 /area/shuttle/escape)
 "wU" = (
 /obj/structure/table/reinforced,
-/obj/item/paper_bin,
-/obj/item/pen,
+/obj/item/paper_bin{
+	pixel_y = 11
+	},
+/obj/item/pen{
+	pixel_y = 11
+	},
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron/dark,
 /area/shuttle/escape)
@@ -945,11 +982,6 @@
 /area/shuttle/escape)
 "zf" = (
 /obj/item/kirbyplants/organic/plant21,
-/obj/machinery/button/flasher{
-	id = "shuttleflash";
-	pixel_x = -26;
-	pixel_y = 24
-	},
 /obj/effect/turf_decal/tile/red{
 	dir = 1
 	},
@@ -961,7 +993,9 @@
 	pixel_y = 3
 	},
 /obj/machinery/light/directional/north,
-/obj/item/radio/intercom/directional/north,
+/obj/item/radio/intercom/directional/north{
+	pixel_y = 30
+	},
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron/dark,
 /area/shuttle/escape)
@@ -991,8 +1025,12 @@
 /area/shuttle/escape)
 "Iu" = (
 /obj/structure/table/reinforced,
-/obj/item/paper_bin,
-/obj/item/pen,
+/obj/item/paper_bin{
+	pixel_y = 9
+	},
+/obj/item/pen{
+	pixel_y = 10
+	},
 /obj/effect/turf_decal/tile/red{
 	dir = 8
 	},
@@ -1008,8 +1046,12 @@
 /area/shuttle/escape)
 "Jl" = (
 /obj/structure/table/reinforced,
-/obj/item/folder/blue,
-/obj/item/pen,
+/obj/item/folder/blue{
+	pixel_y = 8
+	},
+/obj/item/pen{
+	pixel_y = 6
+	},
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron/dark,
 /area/shuttle/escape)
@@ -1028,17 +1070,28 @@
 /obj/machinery/light/directional/south,
 /turf/open/floor/iron,
 /area/shuttle/escape)
+"NY" = (
+/obj/machinery/power/shuttle_engine/propulsion,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/turf/open/floor/plating/airless,
+/area/shuttle/escape)
 "PO" = (
 /obj/structure/table/reinforced,
-/obj/item/storage/medkit/regular,
+/obj/item/storage/medkit/regular{
+	pixel_y = 6
+	},
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron/dark,
 /area/shuttle/escape)
 "QD" = (
-/obj/item/storage/medkit/toxin,
+/obj/item/storage/medkit/toxin{
+	pixel_y = 10
+	},
 /obj/item/storage/medkit/o2{
 	pixel_x = 3;
-	pixel_y = 3
+	pixel_y = 13
 	},
 /obj/structure/table/reinforced,
 /obj/effect/turf_decal/tile/blue/anticorner/contrasted{
@@ -1057,8 +1110,12 @@
 /area/shuttle/escape)
 "Rz" = (
 /obj/structure/table/reinforced,
-/obj/machinery/cell_charger,
-/obj/item/stock_parts/power_store/cell/high,
+/obj/machinery/cell_charger{
+	pixel_y = 10
+	},
+/obj/item/stock_parts/power_store/cell/high{
+	pixel_y = 12
+	},
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron/dark,
 /area/shuttle/escape)
@@ -1072,6 +1129,17 @@
 	},
 /turf/open/floor/iron,
 /area/shuttle/escape)
+"VN" = (
+/obj/item/kirbyplants/organic/plant21{
+	pixel_x = -3;
+	pixel_y = -6
+	},
+/obj/effect/turf_decal/tile/neutral/half/contrasted{
+	dir = 4
+	},
+/obj/structure/sign/departments/cargo/directional/east,
+/turf/open/floor/iron,
+/area/shuttle/escape)
 "WG" = (
 /obj/item/kirbyplants/organic/plant21{
 	pixel_x = -3;
@@ -1081,17 +1149,33 @@
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron/dark,
 /area/shuttle/escape)
+"Xg" = (
+/obj/structure/chair/comfy/shuttle{
+	dir = 8
+	},
+/obj/effect/turf_decal/bot,
+/obj/structure/sign/departments/medbay/alt/directional/east,
+/turf/open/floor/iron,
+/area/shuttle/escape)
 "Xt" = (
 /obj/structure/table/reinforced,
-/obj/machinery/recharger,
+/obj/machinery/recharger{
+	pixel_y = 10
+	},
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron/dark,
 /area/shuttle/escape)
 "Zb" = (
 /obj/structure/table/reinforced,
-/obj/item/folder/red,
-/obj/item/restraints/handcuffs,
-/obj/item/assembly/flash/handheld,
+/obj/item/folder/red{
+	pixel_y = 4
+	},
+/obj/item/restraints/handcuffs{
+	pixel_y = 7
+	},
+/obj/item/assembly/flash/handheld{
+	pixel_y = 16
+	},
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron/dark,
 /area/shuttle/escape)
@@ -1128,7 +1212,7 @@ aa
 aa
 "}
 (2,1,1) = {"
-ab
+NY
 ad
 af
 ah
@@ -1447,14 +1531,14 @@ aw
 aE
 aE
 aw
-aw
+Xg
 cB
 aw
 aw
 aw
 aE
 aE
-dY
+VN
 ah
 af
 aT
@@ -1474,11 +1558,11 @@ ad
 af
 af
 af
-ag
+hB
 aF
 aF
-ag
-aP
+hB
+af
 af
 af
 af
@@ -1603,7 +1687,7 @@ pR
 aJ
 aN
 aQ
-aP
+af
 aZ
 HJ
 bi

--- a/_maps/shuttles/whiteship_delta.dmm
+++ b/_maps/shuttles/whiteship_delta.dmm
@@ -61,13 +61,12 @@
 	pixel_y = 16
 	},
 /obj/structure/sink/directional/west,
-/obj/structure/mirror/directional/east,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
+/obj/structure/mirror/directional/north,
 /turf/open/floor/iron/freezer,
 /area/shuttle/abandoned/crew)
 "al" = (
-/obj/machinery/light/small/built/directional/north,
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/bed{
 	dir = 4
@@ -78,25 +77,26 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on,
 /obj/machinery/airalarm/directional/east,
 /obj/effect/mapping_helpers/airalarm/all_access,
+/obj/machinery/light/small/built/directional/west,
 /turf/open/floor/wood,
 /area/shuttle/abandoned/crew)
 "am" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/bed,
 /obj/item/bedsheet/centcom,
-/obj/machinery/light/small/directional/north,
 /obj/machinery/atmospherics/components/unary/vent_pump/on,
 /obj/machinery/airalarm/directional/east,
 /obj/effect/mapping_helpers/airalarm/all_access,
+/obj/machinery/light/small/built/directional/west,
 /turf/open/floor/wood,
 /area/shuttle/abandoned/crew)
 "an" = (
 /obj/structure/closet/emcloset/anchored,
 /obj/effect/decal/cleanable/dirt,
+/obj/structure/sign/warning/vacuum/external/directional/south,
 /turf/open/floor/plating,
 /area/shuttle/abandoned/crew)
 "ao" = (
-/obj/structure/sign/warning/vacuum/external/directional/east,
 /obj/machinery/light/small/built/directional/east,
 /turf/open/floor/plating,
 /area/shuttle/abandoned/crew)
@@ -223,10 +223,6 @@
 /obj/item/weldingtool/largetank,
 /turf/open/floor/plating,
 /area/shuttle/abandoned/engine)
-"aC" = (
-/obj/structure/sign/departments/restroom,
-/turf/closed/wall/mineral/titanium/nodiagonal,
-/area/shuttle/abandoned/crew)
 "aD" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/door/airlock{
@@ -430,6 +426,7 @@
 	dir = 1
 	},
 /obj/structure/cable,
+/obj/structure/sign/warning/vacuum/external/directional/north,
 /turf/open/floor/iron/dark,
 /area/shuttle/abandoned/crew)
 "ba" = (
@@ -514,10 +511,6 @@
 /obj/structure/spider/stickyweb,
 /turf/open/floor/plating,
 /area/shuttle/abandoned/engine)
-"bm" = (
-/obj/structure/sign/departments/engineering,
-/turf/closed/wall/mineral/titanium/nodiagonal,
-/area/shuttle/abandoned/engine)
 "bn" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -526,6 +519,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden,
 /obj/structure/cable,
 /obj/effect/turf_decal/tile/blue/half/contrasted,
+/obj/structure/sign/departments/engineering/directional/west,
 /turf/open/floor/iron,
 /area/shuttle/abandoned/crew)
 "bo" = (
@@ -564,10 +558,15 @@
 /obj/structure/table,
 /obj/item/stack/sheet/glass/fifty{
 	pixel_x = -2;
-	pixel_y = 2
+	pixel_y = 10
 	},
-/obj/item/stack/rods/fifty,
-/obj/item/wrench,
+/obj/item/stack/rods/fifty{
+	pixel_y = 11
+	},
+/obj/item/wrench{
+	pixel_y = 6;
+	pixel_x = 4
+	},
 /obj/structure/spider/stickyweb,
 /turf/open/floor/iron/dark,
 /area/shuttle/abandoned/crew)
@@ -614,7 +613,9 @@
 "bw" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/table,
-/obj/machinery/microwave,
+/obj/machinery/microwave{
+	pixel_y = 10
+	},
 /obj/effect/turf_decal/tile/bar/opposingcorners,
 /turf/open/floor/iron,
 /area/shuttle/abandoned/bar)
@@ -646,15 +647,15 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/table,
 /obj/item/storage/toolbox/mechanical{
-	pixel_y = 4
+	pixel_y = 18
 	},
 /obj/item/flashlight{
 	pixel_x = 3;
-	pixel_y = 3
+	pixel_y = 14
 	},
 /obj/item/clothing/head/utility/welding{
 	pixel_x = -2;
-	pixel_y = 1
+	pixel_y = 10
 	},
 /obj/machinery/firealarm/directional/east,
 /turf/open/floor/plating,
@@ -783,15 +784,17 @@
 /obj/structure/table,
 /obj/item/folder/blue{
 	pixel_x = 6;
-	pixel_y = 5
+	pixel_y = 16
 	},
 /obj/item/pen{
-	pixel_x = 5;
+	pixel_x = 10;
 	pixel_y = 3
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/recharger,
+/obj/machinery/recharger{
+	pixel_y = 6
+	},
 /obj/structure/spider/stickyweb,
 /obj/effect/turf_decal/tile/blue/half/contrasted{
 	dir = 4
@@ -835,11 +838,13 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/cobweb,
+/obj/effect/decal/cleanable/cobweb{
+	pixel_y = 18
+	},
 /obj/machinery/firealarm/directional/west,
 /obj/item/stack/spacecash/c200{
-	pixel_x = 7;
-	pixel_y = 4
+	pixel_x = 2;
+	pixel_y = 15
 	},
 /obj/item/pen{
 	pixel_x = -4
@@ -895,10 +900,6 @@
 /obj/effect/turf_decal/tile/blue,
 /turf/open/floor/iron,
 /area/shuttle/abandoned/crew)
-"cc" = (
-/obj/structure/sign/warning/electric_shock,
-/turf/closed/wall/mineral/titanium/nodiagonal,
-/area/shuttle/abandoned/engine)
 "cd" = (
 /obj/machinery/door/airlock/engineering{
 	name = "Engineering"
@@ -916,7 +917,9 @@
 /obj/item/camera,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/light/small/directional/west,
+/obj/machinery/light/small/directional/west{
+	pixel_y = 4
+	},
 /obj/machinery/power/apc/auto_name/directional/west,
 /obj/structure/cable,
 /obj/effect/turf_decal/tile/blue/half/contrasted{
@@ -972,6 +975,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/power/smes/ship,
 /obj/structure/cable,
+/obj/structure/sign/warning/electric_shock/directional/north,
 /turf/open/floor/plating,
 /area/shuttle/abandoned/engine)
 "cl" = (
@@ -1167,7 +1171,9 @@
 /obj/item/screwdriver{
 	pixel_y = 15
 	},
-/obj/machinery/cell_charger,
+/obj/machinery/cell_charger{
+	pixel_y = 6
+	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
 /area/shuttle/abandoned/cargo)
@@ -1216,27 +1222,27 @@
 /area/shuttle/abandoned/engine)
 "cP" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/light/small/built/directional/west,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden,
 /obj/structure/cable,
 /obj/effect/turf_decal/tile/blue/half/contrasted{
 	dir = 1
 	},
+/obj/structure/sign/departments/engineering/directional/west,
 /turf/open/floor/iron,
 /area/shuttle/abandoned/medbay)
 "cQ" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/rack,
-/obj/item/defibrillator,
+/obj/item/defibrillator{
+	pixel_y = 10
+	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on,
 /obj/effect/turf_decal/tile/blue/half/contrasted{
 	dir = 1
 	},
+/obj/structure/sign/poster/official/nanotrasen_logo/directional/north,
+/obj/machinery/light/small/built/directional/east,
 /turf/open/floor/iron,
-/area/shuttle/abandoned/medbay)
-"cR" = (
-/obj/structure/sign/departments/medbay/alt,
-/turf/closed/wall/mineral/titanium/nodiagonal,
 /area/shuttle/abandoned/medbay)
 "cS" = (
 /obj/machinery/door/airlock/medical/glass{
@@ -1269,12 +1275,9 @@
 /obj/machinery/airalarm/directional/north,
 /obj/effect/mapping_helpers/airalarm/all_access,
 /obj/machinery/atmospherics/components/unary/vent_pump/on,
+/obj/structure/sign/departments/cargo/directional/east,
 /turf/open/floor/iron/dark,
 /area/shuttle/abandoned/medbay)
-"cW" = (
-/obj/structure/sign/departments/cargo,
-/turf/closed/wall/mineral/titanium,
-/area/shuttle/abandoned/cargo)
 "cX" = (
 /obj/machinery/light/small/built/directional/west,
 /obj/effect/decal/cleanable/dirt,
@@ -1346,14 +1349,22 @@
 /area/shuttle/abandoned/medbay)
 "di" = (
 /obj/structure/table,
-/obj/item/clothing/gloves/latex,
-/obj/item/clothing/mask/surgical,
-/obj/item/clothing/suit/apron/surgical,
+/obj/item/clothing/gloves/latex{
+	pixel_y = 8
+	},
+/obj/item/clothing/mask/surgical{
+	pixel_y = 10
+	},
+/obj/item/clothing/suit/apron/surgical{
+	pixel_y = 14
+	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/white,
 /area/shuttle/abandoned/medbay)
 "dj" = (
-/obj/machinery/light/small/built/directional/north,
+/obj/machinery/light/small/built/directional/north{
+	pixel_x = 10
+	},
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/spider/stickyweb,
 /obj/machinery/firealarm/directional/north,
@@ -1385,11 +1396,16 @@
 /area/shuttle/abandoned/medbay)
 "dm" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/light/small/directional/north,
+/obj/machinery/light/small/directional/north{
+	pixel_x = -11
+	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden{
 	dir = 4
 	},
 /obj/structure/cable,
+/obj/structure/sign/departments/medbay/alt/directional/north{
+	pixel_x = 4
+	},
 /turf/open/floor/iron/white/side{
 	dir = 5
 	},
@@ -1585,10 +1601,12 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/table,
 /obj/item/reagent_containers/cup/bottle/epinephrine{
-	pixel_x = 6
+	pixel_x = 6;
+	pixel_y = 12
 	},
 /obj/item/reagent_containers/cup/bottle/multiver{
-	pixel_x = -3
+	pixel_x = -3;
+	pixel_y = 10
 	},
 /obj/item/reagent_containers/syringe,
 /obj/effect/decal/cleanable/dirt,
@@ -1638,10 +1656,10 @@
 /area/shuttle/abandoned/medbay)
 "dS" = (
 /obj/structure/closet/emcloset/anchored,
+/obj/structure/sign/warning/vacuum/external/directional/north,
 /turf/open/floor/plating,
 /area/shuttle/abandoned/medbay)
 "dT" = (
-/obj/structure/sign/warning/vacuum/external/directional/east,
 /obj/machinery/light/small/built/directional/east,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
@@ -1761,10 +1779,12 @@
 /obj/machinery/firealarm/directional/east,
 /obj/structure/table,
 /obj/machinery/cell_charger,
-/obj/item/stack/cable_coil,
+/obj/item/stack/cable_coil{
+	pixel_y = 9
+	},
 /obj/item/stock_parts/power_store/cell/high,
 /obj/item/multitool{
-	pixel_y = -13
+	pixel_y = 16
 	},
 /turf/open/floor/plating,
 /area/shuttle/abandoned/engine)
@@ -1789,7 +1809,9 @@
 /obj/effect/turf_decal/bot_white,
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/table,
-/obj/item/stack/sheet/iron/fifty,
+/obj/item/stack/sheet/iron/fifty{
+	pixel_y = 12
+	},
 /obj/item/storage/toolbox/electrical{
 	pixel_x = -3;
 	pixel_y = 8
@@ -1798,7 +1820,9 @@
 	pixel_x = 3;
 	pixel_y = -1
 	},
-/obj/effect/decal/cleanable/cobweb,
+/obj/effect/decal/cleanable/cobweb{
+	pixel_y = 16
+	},
 /turf/open/floor/iron/dark,
 /area/shuttle/abandoned/medbay)
 "zL" = (
@@ -1813,6 +1837,18 @@
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron/dark,
 /area/shuttle/abandoned/cargo)
+"BU" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden{
+	dir = 1
+	},
+/obj/structure/cable,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/structure/sign/departments/restroom/directional/north,
+/turf/open/floor/iron,
+/area/shuttle/abandoned/crew)
 "DZ" = (
 /obj/effect/turf_decal/delivery/white,
 /obj/effect/decal/cleanable/dirt,
@@ -1851,8 +1887,8 @@
 	pixel_x = -5
 	},
 /obj/item/reagent_containers/cup/glass/bottle/beer{
-	pixel_x = 7;
-	pixel_y = 4
+	pixel_x = -4;
+	pixel_y = 10
 	},
 /obj/effect/turf_decal/tile/bar/opposingcorners,
 /turf/open/floor/iron,
@@ -1992,7 +2028,7 @@ ai
 by
 bP
 bV
-cc
+ai
 ck
 cs
 cB
@@ -2045,7 +2081,7 @@ aa
 ai
 ai
 de
-bm
+ai
 bB
 bB
 bW
@@ -2053,7 +2089,7 @@ ce
 cm
 bB
 bB
-bm
+ai
 de
 ai
 ai
@@ -2081,8 +2117,8 @@ iM
 (8,1,1) = {"
 ac
 aj
-aC
-aQ
+ac
+BU
 bo
 bD
 bS
@@ -2090,7 +2126,7 @@ bY
 cg
 co
 cu
-bD
+bB
 cQ
 dg
 dE
@@ -2186,7 +2222,7 @@ ac
 bI
 ac
 cF
-cR
+vm
 dm
 dP
 dR
@@ -2281,7 +2317,7 @@ aa
 aa
 cx
 cy
-cW
+cx
 dr
 cy
 bv


### PR DESCRIPTION
## About The Pull Request
Updates the maps for delta's shuttles to accompany #324.
This includes deltastation's cargo, escape, and whiteship for general gameplay functionality.

Items left untouched are things like sinks and showers, which are currently being fixed by #346.
![image](https://github.com/user-attachments/assets/3ff1932b-a6c4-43eb-9c6e-73d2c8a4bf47)
![image](https://github.com/user-attachments/assets/83fa14a6-a2e2-4705-9e9e-d1cdf00ebbd8)
![image](https://github.com/user-attachments/assets/6b889d61-0bab-465e-9b1f-e96159caabde)

Whiteship in particular is a mess, and I'm not 100% sure on the ramifications of what will turn where, but for this 5 seconds in the interest to getting a single map stable and presentable, I'd consider this a good use of time right now.