### PR TITLE
Fixes a couple runtimes that happened in unit tests

### DIFF
--- a/code/datums/components/hide_weather_planes.dm
+++ b/code/datums/components/hide_weather_planes.dm
@@ -76,6 +76,8 @@
 /datum/component/hide_weather_planes/proc/z_changed(datum/source, new_z)
 	SIGNAL_HANDLER
 	active_weather = list()
+	if(!SSmapping.initialized)
+		return
 	var/list/connected_levels = SSmapping.get_connected_levels(new_z)
 	for(var/datum/weather/active as anything in SSweather.processing)
 		if(length(connected_levels & active.impacted_z_levels))

--- a/code/game/machinery/doors/firedoor.dm
+++ b/code/game/machinery/doors/firedoor.dm
@@ -656,12 +656,25 @@
 
 /obj/machinery/door/firedoor/update_overlays()
 	. = ..()
-	if(!use_split_sprites)
-		return
 
-	var/working_icon_state = "[get_base_state()]_bottom"
-	. += mutable_appearance(icon, working_icon_state, ABOVE_MOB_LAYER, appearance_flags = KEEP_APART)
-	. += emissive_blocker(icon, working_icon_state, src, ABOVE_MOB_LAYER)
+	if(use_split_sprites)
+		var/working_icon_state = "[get_base_state()]_bottom"
+		. += mutable_appearance(icon, working_icon_state, ABOVE_MOB_LAYER, appearance_flags = KEEP_APART)
+		. += emissive_blocker(icon, working_icon_state, src, ABOVE_MOB_LAYER)
+
+	if(welded)
+		. += mutable_appearance(icon, density ? "welded_bottom" : "welded_top")
+
+	if(alarm_type && powered() && !ignore_alarms)
+		var/mutable_appearance/hazards
+		hazards = mutable_appearance(icon, "[(obj_flags & EMAGGED) ? "firelock_alarm_type_emag" : alarm_type]")
+		hazards.pixel_x = light_xoffset
+		hazards.pixel_y = light_yoffset
+		. += hazards
+		hazards = emissive_appearance(icon, "[(obj_flags & EMAGGED) ? "firelock_alarm_type_emag" : alarm_type]", src, alpha = src.alpha)
+		hazards.pixel_x = light_xoffset
+		hazards.pixel_y = light_yoffset
+		. += hazards
 
 /obj/machinery/door/firedoor/animation_length(animation)
 	switch(animation)
@@ -682,21 +695,6 @@
 			return 0.2 SECONDS
 		if(DOOR_CLOSING_FINISHED)
 			return 1.1 SECONDS
-
-/obj/machinery/door/firedoor/update_overlays()
-	. = ..()
-	if(welded)
-		. += welded
-	if(alarm_type && powered() && !ignore_alarms)
-		var/mutable_appearance/hazards
-		hazards = mutable_appearance(icon, "[(obj_flags & EMAGGED) ? "firelock_alarm_type_emag" : alarm_type]")
-		hazards.pixel_x = light_xoffset
-		hazards.pixel_y = light_yoffset
-		. += hazards
-		hazards = emissive_appearance(icon, "[(obj_flags & EMAGGED) ? "firelock_alarm_type_emag" : alarm_type]", src, alpha = src.alpha)
-		hazards.pixel_x = light_xoffset
-		hazards.pixel_y = light_yoffset
-		. += hazards
 
 /**
  * Corrects the current state of the door, based on its activity.


### PR DESCRIPTION
Firedoors had 2 update_overlays proc definitions and were also adding a number to the overlay list >:(